### PR TITLE
Val ref

### DIFF
--- a/samples/array-fns.syntran
+++ b/samples/array-fns.syntran
@@ -1,4 +1,7 @@
 
+let chain = true;
+chain = false;
+
 fn mul_mat_vec(mat: [f32; :,:], vec: [f32; :]): [f32; :]
 {
 	// Matrix-vector multiplication.  Return mat * vec
@@ -69,9 +72,13 @@ println(mul_mat_vec(rotx, vec));
 
 // Apply 180 degree x rotation
 
-//println(mul_mat_vec(mul_mat(rotx, rotx), vec));
-let rotxx = mul_mat(rotx, rotx);
-println(mul_mat_vec(rotxx, vec));
+if chain
+	println(mul_mat_vec(mul_mat(rotx, rotx), vec));
+else
+{
+	let rotxx = mul_mat(rotx, rotx);
+	println(mul_mat_vec(rotxx, vec));
+}
 
 // [1.0, -2.0, -3.0]
 //********************
@@ -80,20 +87,31 @@ println(mul_mat_vec(rotxx, vec));
 // to applying a 180 degree z rotation
 println("calling 1");
 
-//// TODO: this is broken.  It should work as a chain of fn calls (without temp
+// TODO: this is broken.  It should work as a chain of fn calls (without temp
 //// var rotxx) but there's a syntran bug, maybe re deep copy of value_t
 ////
-//println(mul_mat_vec(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty), vec));
-let rotxxy = mul_mat(rotxx, roty);
-println(mul_mat_vec(mul_mat(rotxxy, roty), vec));
+if chain
+	println(mul_mat_vec(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty), vec));
+else
+{
+	let rotxx = mul_mat(rotx, rotx);
+	let rotxxy = mul_mat(rotxx, roty);
+	println(mul_mat_vec(mul_mat(rotxxy, roty), vec));
+}
 
 println("done 1");
 // [-1.0, -2.0, 3.0]
 
 println("calling 2");
 
-//println(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty));
-println(mul_mat(rotxxy, roty));
+if chain
+	println(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty));
+else
+{
+	let rotxx = mul_mat(rotx, rotx);
+	let rotxxy = mul_mat(rotxx, roty);
+	println(mul_mat(rotxxy, roty));
+}
 
 println("done 2");
 // [

--- a/samples/array-fns.syntran
+++ b/samples/array-fns.syntran
@@ -1,6 +1,6 @@
 
 let chain = true;
-chain = false;
+//chain = false;
 
 fn mul_mat_vec(mat: [f32; :,:], vec: [f32; :]): [f32; :]
 {

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -47,8 +47,8 @@ recursive subroutine syntax_eval(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	!type(value_t), intent(inout) :: res
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
+	!type(value_t), intent(out) :: res
 
 	!********
 
@@ -161,7 +161,7 @@ subroutine eval_binary_expr(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -254,7 +254,7 @@ subroutine eval_name_expr(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -334,13 +334,16 @@ subroutine eval_name_expr(node, state, res)
 			!print *, 'len_  = ', node%val%array%len_
 			!print *, 'cap   = ', node%val%array%cap
 
-			allocate(res%array)
+			if (.not. allocated(res%array)) allocate(res%array)
 			res%type = array_type
 			res%array%kind = expl_array
 			res%array%type = node%val%array%type
 			res%array%rank = rank_res
 
+			!if (.not. allocated(res%array%size)) allocate(res%array%size( rank_res ))
+			if (allocated(res%array%size)) deallocate(res%array%size)
 			allocate(res%array%size( rank_res ))
+
 			idim_res = 1
 			do idim_ = 1, size(lsubs)
 				select case (node%lsubscripts(idim_)%sub_kind)
@@ -423,7 +426,7 @@ subroutine eval_fn_call(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -767,10 +770,10 @@ subroutine eval_fn_call(node, state, res)
 			! deeply-nested fn calls can crash without the tmp value.  idk why i
 			! can't just eval directly into the state var like commented above
 			! :(.  probably state var type is getting cleared by passing it to
-			! an intent(out) arg? or, nested fn calls basically create a stack
-			! in which we store each nested arg in different copies of tmp.  if
-			! you try to store them all in the same state var at multiple stack
-			! levels it breaks?
+			! an intent(out) arg? more likely, nested fn calls basically create
+			! a stack in which we store each nested arg in different copies of
+			! tmp.  if you try to store them all in the same state var at
+			! multiple stack levels it breaks?
 			call syntax_eval(node%args(i), state, tmp)
 			state%vars%vals( node%params(i) ) = tmp
 
@@ -810,7 +813,7 @@ subroutine eval_for_statement(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -990,7 +993,7 @@ subroutine eval_assignment_expr(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1160,7 +1163,7 @@ subroutine eval_translation_unit(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1210,7 +1213,7 @@ subroutine eval_array_expr(node, state, res)
 
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1332,7 +1335,7 @@ subroutine eval_array_expr(node, state, res)
 		allocate(array%size( array%rank ))
 		array%size = array%len_
 
-		allocate(res%array)
+		if (.not. allocated(res%array)) allocate(res%array)
 		res%type  = array_type
 		res%array = array
 
@@ -1416,7 +1419,7 @@ subroutine eval_array_expr(node, state, res)
 			call internal_error()
 		end select
 
-		allocate(res%array)
+		if (.not. allocated(res%array)) allocate(res%array)
 		res%type  = array_type
 		res%array = array
 
@@ -1506,7 +1509,7 @@ subroutine eval_array_expr(node, state, res)
 		end if
 
 		!print *, 'copying array'
-		allocate(res%array)
+		if (.not. allocated(res%array)) allocate(res%array)
 		res%type  = array_type
 		res%array = array
 		!print *, 'done'
@@ -1534,7 +1537,7 @@ subroutine eval_array_expr(node, state, res)
 		array%size = array%len_
 
 		!print *, 'copying array'
-		allocate(res%array)
+		if (.not. allocated(res%array)) allocate(res%array)
 		res%type  = array_type
 		res%array = array
 		!print *, 'done'
@@ -1553,7 +1556,7 @@ subroutine eval_while_statement(node, state, res)
 	type(syntax_node_t), intent(in) :: node
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1575,7 +1578,7 @@ subroutine eval_if_statement(node, state, res)
 	type(syntax_node_t), intent(in) :: node
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1603,7 +1606,7 @@ subroutine eval_return_statement(node, state, res)
 	type(syntax_node_t), intent(in) :: node
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1629,7 +1632,7 @@ subroutine eval_block_statement(node, state, res)
 	type(syntax_node_t), intent(in) :: node
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1682,7 +1685,7 @@ subroutine eval_unary_expr(node, state, res)
 	type(syntax_node_t), intent(in) :: node
 	type(state_t), intent(inout) :: state
 
-	type(value_t), intent(out) :: res
+	type(value_t), intent(inout) :: res
 
 	!********
 
@@ -1738,16 +1741,24 @@ subroutine allocate_array(array, cap)
 
 	array%cap = cap
 
+	! this could potentially be optimized by only re-allocating if over previous
+	! cap (or change of type?)
+
 	select case (array%type)
 	case (i32_type)
+		if (allocated(array%i32)) deallocate(array%i32)
 		allocate(array%i32( cap ))
 	case (i64_type)
+		if (allocated(array%i64)) deallocate(array%i64)
 		allocate(array%i64( cap ))
 	case (f32_type)
+		if (allocated(array%f32)) deallocate(array%f32)
 		allocate(array%f32( cap ))
 	case (bool_type)
+		if (allocated(array%bool)) deallocate(array%bool)
 		allocate(array%bool( cap ))
 	case (str_type)
+		if (allocated(array%str)) deallocate(array%str)
 		allocate(array%str( cap ))
 	case default
 		write(*,*) err_int_prefix//'cannot allocate array of type `' &

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -101,30 +101,7 @@ recursive subroutine syntax_eval(node, state, res)
 
 		!print *, 'assigning identifier ', quote(node%identifier%text)
 
-		! TODO: deep copy?
 		state%vars%vals(node%id_index) = res
-
-		if (res%type == array_type) then
-			!print *, "array let expr"
-
-			!if (allocated(res%array)) deallocate(res%array)
-			!allocate(res%array)
-			!if (.not. allocated(res%array)) allocate(res%array)
-			if (.not. allocated(state%vars%vals(node%id_index)%array)) &
-				allocate(state%vars%vals(node%id_index)%array)
-
-			state%vars%vals(node%id_index)%type  = array_type
-			state%vars%vals(node%id_index)%array = res%array 
-
-			!! TODO: this might be unnecessary
-			state%vars%vals(node%id_index)%array%rank = res%array%rank 
-			!!print *, "allocated(size j) = ", allocated(state%vars%vals(node%id_index)%array%size)
-			state%vars%vals(node%id_index)%array%size = res%array%size 
-			!print *, "rank = ", res%array%rank, state%vars%vals(node%id_index)%array%rank
-
-		!else
-		!	print *, 'scalar name_expr'
-		end if
 
 	case (fn_call_expr)
 		call eval_fn_call(node, state, res)
@@ -382,31 +359,31 @@ subroutine eval_name_expr(node, state, res)
 		!	kind_name(state%vars%vals(node%id_index)%type), &
 		!	          state%vars%vals(node%id_index)%type
 
-		! Deep copy of whole array instead of aliasing pointers
-		!
-		! I suspect that value_t now has a deep copy problem like syntax_node_t
-		! does, and this may be why samples/array-fns.syntran doesn't work.  May
-		! need to convert return-by-value to subroutine out-arg as reference (or
-		! override the copy operator, but that hasn't worked out so well for
-		! syntax_node_t)
-		if (res%type == array_type) then
-			!print *, 'array name_expr'
+		!! Deep copy of whole array instead of aliasing pointers
+		!!
+		!! I suspect that value_t now has a deep copy problem like syntax_node_t
+		!! does, and this may be why samples/array-fns.syntran doesn't work.  May
+		!! need to convert return-by-value to subroutine out-arg as reference (or
+		!! override the copy operator, but that hasn't worked out so well for
+		!! syntax_node_t)
+		!if (res%type == array_type) then
+		!	!print *, 'array name_expr'
 
-			if (allocated(res%array)) deallocate(res%array)
+		!	if (allocated(res%array)) deallocate(res%array)
 
-			allocate(res%array)
-			res%type = array_type
-			res%array = state%vars%vals(node%id_index)%array
+		!	allocate(res%array)
+		!	res%type = array_type
+		!	res%array = state%vars%vals(node%id_index)%array
 
-			!! TODO: this might be unnecessary
-			res%array%rank = state%vars%vals(node%id_index)%array%rank
-			!!print *, "allocated(size j) = ", allocated(state%vars%vals(node%id_index)%array%size)
-			res%array%size = state%vars%vals(node%id_index)%array%size
-			!print *, "rank = ", res%array%rank, state%vars%vals(node%id_index)%array%rank
+		!	!! TODO: this might be unnecessary
+		!	res%array%rank = state%vars%vals(node%id_index)%array%rank
+		!	!!print *, "allocated(size j) = ", allocated(state%vars%vals(node%id_index)%array%size)
+		!	res%array%size = state%vars%vals(node%id_index)%array%size
+		!	!print *, "rank = ", res%array%rank, state%vars%vals(node%id_index)%array%rank
 
-		!else
-		!	print *, 'scalar name_expr'
-		end if
+		!!else
+		!!	print *, 'scalar name_expr'
+		!end if
 
 	end if
 
@@ -1651,14 +1628,12 @@ subroutine eval_block_statement(node, state, res)
 		!print *, ''
 
 		! In case of no-op if statements and while loops
-		!
-		! TODO: deep copy?
 		if (tmp%type /= unknown_type) then
 			res = tmp
 
-			if (tmp%type == array_type) then
-				res%array = tmp%array
-			end if
+			!if (tmp%type == array_type) then
+			!	res%array = tmp%array
+			!end if
 		end if
 
 		! HolyC feature: implicitly print name expression members.  I may

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -48,7 +48,7 @@ recursive function syntax_eval(node, state) result(res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
 	type(value_t) :: res
 
@@ -79,28 +79,28 @@ recursive function syntax_eval(node, state) result(res)
 		res = node%val  ! this handles ints, bools, etc.
 
 	case (array_expr)
-		res = eval_array_expr(node, state)
+		call eval_array_expr(node, state, res)
 
 	case (for_statement)
-		res = eval_for_statement(node, state)
+		call eval_for_statement(node, state, res)
 
 	case (while_statement)
-		res = eval_while_statement(node, state)
+		call eval_while_statement(node, state, res)
 
 	case (if_statement)
-		res = eval_if_statement(node, state)
+		call eval_if_statement(node, state, res)
 
 	case (return_statement)
-		res = eval_return_statement(node, state)
+		call eval_return_statement(node, state, res)
 
 	case (translation_unit)
-		res = eval_translation_unit(node, state)
+		call eval_translation_unit(node, state, res)
 
 	case (block_statement)
-		res = eval_block_statement(node, state)
+		call eval_block_statement(node, state, res)
 
 	case (assignment_expr)
-		res = eval_assignment_expr(node, state)
+		call eval_assignment_expr(node, state, res)
 
 	case (let_expr)
 
@@ -108,19 +108,21 @@ recursive function syntax_eval(node, state) result(res)
 		res = syntax_eval(node%right, state)
 
 		!print *, 'assigning identifier ', quote(node%identifier%text)
+
+		! TODO: deep copy?
 		state%vars%vals(node%id_index) = res
 
 	case (fn_call_expr)
-		res = eval_fn_call(node, state)
+		call eval_fn_call(node, state, res)
 
 	case (name_expr)
-		res = eval_name_expr(node, state)
+		call eval_name_expr(node, state, res)
 
 	case (unary_expr)
-		res = eval_unary_expr(node, state)
+		call eval_unary_expr(node, state, res)
 
 	case (binary_expr)
-		res = eval_binary_expr(node, state)
+		call eval_binary_expr(node, state, res)
 
 	case default
 		write(*,*) err_eval_node(kind_name(node%kind))
@@ -132,13 +134,13 @@ end function syntax_eval
 
 !===============================================================================
 
-function eval_binary_expr(node, state) result(res)
+subroutine eval_binary_expr(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -221,17 +223,17 @@ function eval_binary_expr(node, state) result(res)
 
 	end select
 
-end function eval_binary_expr
+end subroutine eval_binary_expr
 
 !===============================================================================
 
-function eval_name_expr(node, state) result(res)
+subroutine eval_name_expr(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -380,17 +382,17 @@ function eval_name_expr(node, state) result(res)
 
 	end if
 
-end function eval_name_expr
+end subroutine eval_name_expr
 
 !===============================================================================
 
-function eval_fn_call(node, state) result(res)
+subroutine eval_fn_call(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -750,17 +752,17 @@ function eval_fn_call(node, state) result(res)
 	state%ifn = state%ifn - 1  ! pop
 	state%returned%len_ = state%returned%len_ - 1
 
-end function eval_fn_call
+end subroutine eval_fn_call
 
 !===============================================================================
 
-function eval_for_statement(node, state) result(res)
+subroutine eval_for_statement(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -930,17 +932,17 @@ function eval_for_statement(node, state) result(res)
 	end do
 	call state%vars%pop_scope()
 
-end function eval_for_statement
+end subroutine eval_for_statement
 
 !===============================================================================
 
-function eval_assignment_expr(node, state) result(res)
+subroutine eval_assignment_expr(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1100,17 +1102,17 @@ function eval_assignment_expr(node, state) result(res)
 		end if
 	end if
 
-end function eval_assignment_expr
+end subroutine eval_assignment_expr
 
 !===============================================================================
 
-function eval_translation_unit(node, state) result(res)
+subroutine eval_translation_unit(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1150,17 +1152,17 @@ function eval_translation_unit(node, state) result(res)
 
 	!call state%vars%pop_scope()
 
-end function eval_translation_unit
+end subroutine eval_translation_unit
 
 !===============================================================================
 
-function eval_array_expr(node, state) result(res)
+subroutine eval_array_expr(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1490,16 +1492,16 @@ function eval_array_expr(node, state) result(res)
 		call internal_error()
 	end if
 
-end function eval_array_expr
+end subroutine eval_array_expr
 
 !===============================================================================
 
-function eval_while_statement(node, state) result(res)
+subroutine eval_while_statement(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1512,16 +1514,16 @@ function eval_while_statement(node, state) result(res)
 		if (state%returned%v( state%ifn )) exit
 	end do
 
-end function eval_while_statement
+end subroutine eval_while_statement
 
 !===============================================================================
 
-function eval_if_statement(node, state) result(res)
+subroutine eval_if_statement(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1540,16 +1542,16 @@ function eval_if_statement(node, state) result(res)
 
 	end if
 
-end function eval_if_statement
+end subroutine eval_if_statement
 
 !===============================================================================
 
-function eval_return_statement(node, state) result(res)
+subroutine eval_return_statement(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1566,16 +1568,16 @@ function eval_return_statement(node, state) result(res)
 
 	!print *, "ending eval_return_statement"
 
-end function eval_return_statement
+end subroutine eval_return_statement
 
 !===============================================================================
 
-function eval_block_statement(node, state) result(res)
+subroutine eval_block_statement(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1611,16 +1613,16 @@ function eval_block_statement(node, state) result(res)
 
 	call state%vars%pop_scope()
 
-end function eval_block_statement
+end subroutine eval_block_statement
 
 !===============================================================================
 
-function eval_unary_expr(node, state) result(res)
+subroutine eval_unary_expr(node, state, res)
 
 	type(syntax_node_t), intent(in) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
-	type(value_t) :: res
+	type(value_t), intent(out) :: res
 
 	!********
 
@@ -1646,7 +1648,7 @@ function eval_unary_expr(node, state) result(res)
 		call internal_error()
 	end select
 
-end function eval_unary_expr
+end subroutine eval_unary_expr
 
 !===============================================================================
 
@@ -1795,7 +1797,7 @@ subroutine get_subscript_range(node, state, lsubs, usubs, rank_res)
 	! *after* being sliced
 
 	type(syntax_node_t), intent(in) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
 	integer(kind = 8), allocatable, intent(out) :: lsubs(:), usubs(:)
 	integer, intent(out) :: rank_res
@@ -1913,7 +1915,7 @@ function subscript_eval(node, state) result(index_)
 	! subscript index_
 
 	type(syntax_node_t) :: node
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
 	integer(kind = 8) :: index_
 
@@ -1987,7 +1989,7 @@ subroutine array_at(val, kind_, i, lbound_, step, ubound_, len_, array, &
 
 	type(syntax_node_t), allocatable :: elems(:)
 
-	type(state_t) :: state
+	type(state_t), intent(inout) :: state
 
 	!*********
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -513,7 +513,6 @@ module function parse_fn_declaration(parser) result(decl)
 	!
 
 	fn%type = void_type
-	!fn%type = i32_type
 	rank = 0
 	if (parser%current_kind() == colon_token) then
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -197,7 +197,8 @@ module function parse_fn_call(parser) result(fn_call)
 
 	! Intrinsic fns don't have a syntax node: they are implemented
 	! in Fortran, not syntran
-	if (associated(fn%node)) then
+	!if (associated(fn%node)) then
+	if (allocated(fn%node)) then
 		!print *, 'assigning fn node'
 
 		! If I understand my own code, this is inlining:  every fn

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -496,9 +496,10 @@ module function parse_fn_declaration(parser) result(decl)
 			allocate(val%array)
 			val%array%type = fn%params(i)%array_type
 			val%array%rank = fn%params(i)%rank
-			!!print *, "rank = ", val%array%rank
+			!print *, "rank = ", val%array%rank
 		end if
-!
+
+		!print *, "insert var type ", kind_name(val%type)
 		call parser%vars%insert(fn%params(i)%name, val, parser%num_vars)
 
 	end do
@@ -511,6 +512,7 @@ module function parse_fn_declaration(parser) result(decl)
 	!
 
 	fn%type = void_type
+	!fn%type = i32_type
 	rank = 0
 	if (parser%current_kind() == colon_token) then
 

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -94,8 +94,7 @@ function syntran_interpret(str_, quiet, startup_file) result(res_str)
 		end if
 
 		! TODO: chdir option?
-
-		res = syntax_eval(compilation, state)
+		call syntax_eval(compilation, state, res)
 		res_str = res%to_str()
 		write(*,*) '    '//res_str
 
@@ -187,7 +186,7 @@ function syntran_interpret(str_, quiet, startup_file) result(res_str)
 		! Don't try to evaluate with errors
 		if (compilation%diagnostics%len_ > 0) cycle
 
-		res  = syntax_eval(compilation, state)
+		call syntax_eval(compilation, state, res )
 
 		! Consider MATLAB-style "ans = " log?
 		!
@@ -223,7 +222,7 @@ integer function syntran_eval_i32(str_) result(eval_i32)
 		return
 	end if
 
-	val = syntax_eval(tree, state)
+	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	eval_i32 = val%sca%i32
@@ -254,7 +253,7 @@ integer(kind = 8) function syntran_eval_i64(str_) result(val_)
 		return
 	end if
 
-	val = syntax_eval(tree, state)
+	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	val_ = val%sca%i64
@@ -288,7 +287,7 @@ real(kind = 4) function syntran_eval_f32(str_, quiet) result(eval_f32)
 		return
 	end if
 
-	val = syntax_eval(tree, state)
+	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	eval_f32 = val%sca%f32
@@ -386,7 +385,7 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 
 	end if
 
-	val = syntax_eval(tree, state)
+	call syntax_eval(tree, state, val)
 	res = val%to_str()
 	!print *, 'res = ', res
 

--- a/src/tests/test-src/linear-algebra/test-06.syntran
+++ b/src/tests/test-src/linear-algebra/test-06.syntran
@@ -2,7 +2,10 @@
 fn mul_mat_vec(mat: [f32; :,:], vec: [f32; :]): [f32; :]
 {
 	// Matrix-vector multiplication.  Return mat * vec
-	let ans =  [0.0; size(mat,0)];
+	//println("starting mul_mat_vec()");
+	//let ans =  [0.0; size(mat,0)];
+	let n = size(mat,0);
+	let ans =  [0.0; n];
 	for     j in [0: size(mat,1)]
 		for i in [0: size(mat,0)]
 			ans[i] = ans[i] + mat[i,j] * vec[j];
@@ -12,10 +15,17 @@ fn mul_mat_vec(mat: [f32; :,:], vec: [f32; :]): [f32; :]
 fn mul_mat(a: [f32; :,:], b: [f32; :,:]): [f32; :,:]
 {
 	// Matrix-matrix multiplication.  Return a * b
-	let c = [0.0; size(a,0), size(b,1)];
-	for         k in [0: size(b,1)]
-		for     j in [0: size(a,1)]
-			for i in [0: size(a,0)]
+	//println("starting mul_mat()");
+	let l = size(a,0);
+	//println("l = ", l);
+	let m = size(a,1);
+	//println("m = ", m);
+	let n = size(b,1);
+	//println("n = ", n);
+	let c = [0.0; l, n];
+	for         k in [0: n]
+		for     j in [0: m]
+			for i in [0: l]
 				c[i,k] = c[i,k] + a[i,j] * b[j,k];
 	return c;
 }
@@ -53,8 +63,22 @@ let roty =
 		3, 3
 	];
 
+//println(rotx);
+//println(roty);
+
 // Apply 180 degree x rotation then 180 degree y rotation, which is equivalent
 // to applying a 180 degree z rotation
-return mul_mat_vec(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty), vec);
+//println("calling");
+
+//let rotx1 = rotx;
+//return mul_mat_vec(mul_mat(mul_mat(mul_mat(rotx, rotx1), roty), roty), vec);
+
+//// TODO: nested fn calls should work
+//return mul_mat_vec(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty), vec);
+
+let rotxx  = mul_mat(rotx, rotx);
+let rotxxy = mul_mat(rotxx, roty);
+return mul_mat_vec(mul_mat(rotxxy, roty), vec);
+
 // [-1.0, -2.0, 3.0]
 

--- a/src/tests/test-src/linear-algebra/test-07.syntran
+++ b/src/tests/test-src/linear-algebra/test-07.syntran
@@ -1,0 +1,71 @@
+
+fn mul_mat_vec(mat: [f32; :,:], vec: [f32; :]): [f32; :]
+{
+	// Matrix-vector multiplication.  Return mat * vec
+	//println("starting mul_mat_vec()");
+	//let ans =  [0.0; size(mat,0)];
+	let n = size(mat,0);
+	let ans =  [0.0; n];
+	for     j in [0: size(mat,1)]
+		for i in [0: size(mat,0)]
+			ans[i] = ans[i] + mat[i,j] * vec[j];
+	return ans;
+}
+
+fn mul_mat(a: [f32; :,:], b: [f32; :,:]): [f32; :,:]
+{
+	// Matrix-matrix multiplication.  Return a * b
+	//println("starting mul_mat()");
+	let l = size(a,0);
+	//println("l = ", l);
+	let m = size(a,1);
+	//println("m = ", m);
+	let n = size(b,1);
+	//println("n = ", n);
+	let c = [0.0; l, n];
+	for         k in [0: n]
+		for     j in [0: m]
+			for i in [0: l]
+				c[i,k] = c[i,k] + a[i,j] * b[j,k];
+	return c;
+}
+
+// 3D vector with x = 1.0, y = 2.0, z = 3.0
+let vec = [1.0, 2.0, 3.0];
+
+// 3x3 identity matrix.  Sizes go after the semicolon
+let eye3 =
+	[
+		1.0, 0.0, 0.0,
+		0.0, 1.0, 0.0,
+		0.0, 0.0, 1.0 ;
+		3, 3
+	];
+
+eye3;
+
+// 90 degree x rotation.  Note that arrays are stored in row-major order, so
+// this appears transposed
+let rotx =
+	[
+		1.0,  0.0,  0.0,
+		0.0,  0.0,  1.0,
+		0.0, -1.0,  0.0 ;
+		3, 3
+	];
+
+// 90 degree y rotation
+let roty =
+	[
+		0.0,  0.0, -1.0,
+		0.0,  1.0,  0.0,
+		1.0,  0.0,  0.0 ;
+		3, 3
+	];
+
+//println(rotx);
+//println(roty);
+
+return mul_mat_vec(mul_mat(mul_mat(mul_mat(rotx, rotx), roty), roty), vec);
+// [-1.0, -2.0, 3.0]
+

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -2243,6 +2243,7 @@ subroutine unit_test_linalg_fns(npass, nfail)
 			interpret_file(path//'test-04.syntran', quiet) == 'true', &
 			interpret_file(path//'test-05.syntran', quiet) == '[1.000000E+00, -3.000000E+00, 2.000000E+00]', &
 			interpret_file(path//'test-06.syntran', quiet) == '[-1.000000E+00, -2.000000E+00, 3.000000E+00]', &
+			interpret_file(path//'test-07.syntran', quiet) == '[-1.000000E+00, -2.000000E+00, 3.000000E+00]', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/types.f90
+++ b/src/types.f90
@@ -271,12 +271,7 @@ contains
 
 recursive subroutine fn_copy(dst, src)
 
-	! Deep copy.  This overwrites dst with src.  If dst had keys that weren't in
-	! source, they will be gone!
-	!
-	! This should be avoided for efficient compilation, but the interactive
-	! interpreter uses it to backup and restore the variable dict for
-	! partially-evaluated continuation lines
+	! Deep copy.  This overwrites dst with src
 
 	class(fn_t), intent(inout) :: dst
 	class(fn_t), intent(in)    :: src


### PR DESCRIPTION
the intel compilers ifx (and ifort) are an order of magnitude slower than gfortran and i'm not 100% sure why

this at least improves the situation, but it still doesn't bring the compilers to parity

by evaluating the syntax tree with a passed-by-reference `value_t` type output argument, evaluation avoids copying an assigned `value_t` return value.  imo subroutines with out args are less readable than functions which return a value, but a sacrifice of readability is worth it for performance improvement

here is a benchmark from the advent of code solution [src/tests/long/aoc/2023/1](src/tests/long/aoc/2023/1):

- with functions and return values, ifx takes almost 10 minutes to evaluate 
- with subroutines and out args, ifx takes about 4.5 to 5 minutes

~~unfortunately, subroutines and out args are also buggier.  scripts like `samples/array-fns.syntran` and `src/tests/test-src/linear-algebra/test-06.syntran` (not the worked-around versions) will crash on deeply-nested function calls.  i'm still not sure why, somehow a value which should be an array is ending up as `void_type` and no allocated array.~~

Update 2024-09-03:  the nested function call bug was fixed here:  https://github.com/JeffIrwin/syntran/commit/324ad414f4557766ff012b631e80e83b400c8140 
