### PR TITLE
Pass by reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -270,6 +270,11 @@
 				"run":
 				"
 					docker --version \n
+
+					# TODO: this always builds main branch. Pass branch as arg \n
+					# into docker. Same problem with Dockerfile.ubuntu.  Only \n
+					# alpine Dockerfile copies src folder instead of cloning, so
+					# it does not have this issue \n
 					docker build . --file Dockerfile.rocky -t sy \n
 
 					## Test run \n

--- a/samples/dict_i64_fn.syntran
+++ b/samples/dict_i64_fn.syntran
@@ -1,0 +1,250 @@
+
+
+// TODO: keep this in-sync with aoc-syntran version until they're stable
+
+
+// A larger max hash val is ok with global vars, but copying in/out is very slow
+// for passing by value, so 256 is better in this implementation
+
+let HASH_MAX_DICT = 256;
+//HASH_MAX_DICT = 1024 * 8;
+
+//==============================================================================
+
+fn hash_str_dict(s: str): i32
+{
+	// This is the hash fn that determines which bucket a key goes into
+
+	//// djb2 hash fn
+	//let hash_ = 5381;
+	////let hash_ = 5381'i64;
+	//for j in [0: len(s)]
+	//{
+	//	hash_ = ((hash_ << 5) + hash_) + i32(s[j]);
+	//	//hash_ = hash_ * 33 + i32(s[j]);
+	//	hash_ %= HASH_MAX_DICT; // not part of djb2, but it crashes without this :(
+	//}
+	////hash_ %= HASH_MAX_DICT;
+	////return i32(hash_);
+	//return hash_;
+
+	// This is the hash fn from aoc 2023 day 15
+	let hash_ = 0;
+	for j in [0: len(s)]
+	{
+		hash_ += i32(s[j]);
+		hash_ *= 17;
+		hash_ %= HASH_MAX_DICT;
+	}
+	//println("hash_ = ", hash_);
+	return hash_;
+}
+
+struct dict_i64_bucket
+{
+	cap: i32,
+	len: i32,
+	keys: [str; :],
+	vals: [i64; :],
+}
+
+struct dict_i64
+{
+	len: i32,
+	buckets: [dict_i64_bucket; :],
+}
+
+fn init_dict_i64(): dict_i64
+{
+	// TODO: arg?
+	//let len_glbl = 256;
+	let len_glbl64 = HASH_MAX_DICT;
+
+	let empty_bucket_glbl64 = dict_i64_bucket
+	{
+		cap = 0,
+		len = 0,
+		keys = [""   ; 0],
+		vals = [0'i64; 0],
+	};
+
+	let DICT_I64 = dict_i64
+	{
+		len = len_glbl64,
+		buckets = [empty_bucket_glbl64; len_glbl64],
+	};
+
+	return DICT_I64;
+}
+
+fn print_lens_dict_i64(DICT_I64: &dict_i64)
+{
+	for i in [0: DICT_I64.len]
+	{
+		let len_ = DICT_I64.buckets[i].len;
+		if len_ != 0
+		{
+			println("bucket[", i, "] len = ", len_);
+			//println("bucket[", i, "] cap = ", DICT_I64.buckets[i].cap);
+		}
+	}
+	return;
+}
+
+fn get_dict_i64(DICT_I64: &dict_i64, key: str): i64
+{
+	let ib = hash_str_dict(key); // bucket index
+	let len_ = DICT_I64.buckets[ib].len;
+	for i in [0: len_]
+	{
+		if DICT_I64.buckets[ib].keys[i] == key
+		{
+			return DICT_I64.buckets[ib].vals[i];
+		}
+	}
+	// TODO: should we panic?
+	return -1'i64;
+	//return 0;
+}
+
+fn keys_dict_i64(DICT_I64: &dict_i64): [str; :]
+{
+	// Return a flat array of all the keys in the dict
+	let n = 0;
+	for i in [0: DICT_I64.len]
+		n += DICT_I64.buckets[i].len;
+	let keys = [""; n];
+	let k = 0;
+	for i in [0: DICT_I64.len]
+	for j in [0: DICT_I64.buckets[i].len]
+	{
+		keys[k] = DICT_I64.buckets[i].keys[j];
+		k += 1;
+	}
+	return keys;
+}
+
+fn vals_dict_i64(DICT_I64: &dict_i64): [i64; :]
+{
+	// Return a flat array of all the vals in the dict
+	let n = 0;
+	for i in [0: DICT_I64.len]
+		n += DICT_I64.buckets[i].len;
+	let vals = [0'i64; n];
+	let k = 0;
+	for i in [0: DICT_I64.len]
+	for j in [0: DICT_I64.buckets[i].len]
+	{
+		vals[k] = DICT_I64.buckets[i].vals[j];
+		k += 1;
+	}
+	return vals;
+}
+
+//fn set_dict_i64(DICT_I64: &dict_i64, key: str, val: i64): dict_i64
+fn set_dict_i64(DICT_I64: &dict_i64, key: str, val: i64)
+{
+	// TODO: we really need dict arg as reference (not value) for efficiency
+	//
+	// Modifies a dict DICT_I64 as a global var for now
+
+	let ib = hash_str_dict(key); // bucket index
+	println("ib = ", ib);
+
+	let len_ = DICT_I64.buckets[ib].len;
+	println("len_ = ", len_);
+	for i in [0: len_]
+	{
+		if DICT_I64.buckets[ib].keys[i] == key
+		{
+			// Reset existing value
+			DICT_I64.buckets[ib].vals[i] = val;
+			return;
+		}
+	}
+
+	let cap_ = DICT_I64.buckets[ib].cap;
+	if len_ >= cap_
+	{
+		// Grow arrays
+		if cap_ == 0
+			cap_ = 1;
+		else
+			cap_ *= 2;
+
+		println("new cap_ = ", cap_);
+		DICT_I64.buckets[ib].cap = cap_;
+		println("done setting cap");
+		let keys = DICT_I64.buckets[ib].keys;
+		let vals = DICT_I64.buckets[ib].vals;
+
+		DICT_I64.buckets[ib].keys = [""; cap_];
+
+		DICT_I64.buckets[ib].vals = [0'i64 ; cap_];
+
+		//DICT_I64.buckets[ib].keys[0: len_] = keys; // struct array slices not implemented :(
+		//DICT_I64.buckets[ib].vals[0: len_] = vals;
+		for i in [0: len_]
+		{
+			DICT_I64.buckets[ib].keys[i] = keys[i];
+			DICT_I64.buckets[ib].vals[i] = vals[i];
+		}
+	}
+	println("setting ", key, ", ", val);
+
+	// Append new key value pair
+	DICT_I64.buckets[ib].keys[len_] = key;
+	DICT_I64.buckets[ib].vals[len_] = val;
+	DICT_I64.buckets[ib].len += 1;
+
+	return;
+}
+
+//==============================================================================
+
+fn main(): i32
+{
+	// Unit tests
+
+	println("starting dict.syntran");
+
+	let DICT_I64 = init_dict_i64();
+	println("len   = ", DICT_I64.len);
+	println("len 0 = ", DICT_I64.buckets[0].len);
+	println("cap 0 = ", DICT_I64.buckets[0].cap);
+
+	//DICT_I64.buckets[0].cap = 7;
+	//println("cap 0 = ", DICT_I64.buckets[0].cap);
+	//DICT_I64.buckets[0].cap = 4;
+	//print_lens_dict_i64(&DICT_I64);
+	//exit(0);
+
+	println("hash 'HASH' = ", hash_str_dict("HASH")); // 52
+	println("hash 'rn=1' = ", hash_str_dict("rn=1")); // 30
+	println("hash 'rn'   = ", hash_str_dict("rn"));   // 0
+	println("hash 'cm'   = ", hash_str_dict("cm"));   // 0 (hash clash, good for testing)
+
+	set_dict_i64(&DICT_I64, "rn", 1'i64);
+	set_dict_i64(&DICT_I64, "qp", 3'i64);
+	set_dict_i64(&DICT_I64, "cm", 2'i64);
+	set_dict_i64(&DICT_I64, "pc", 4'i64);
+	set_dict_i64(&DICT_I64, "ot", 9'i64);
+	set_dict_i64(&DICT_I64, "ab", 5'i64);
+
+	println("get 'rn' = ", get_dict_i64(&DICT_I64, "rn"));
+	println("get 'qp' = ", get_dict_i64(&DICT_I64, "qp"));
+	println("get 'cm' = ", get_dict_i64(&DICT_I64, "cm"));
+	println("get 'pc' = ", get_dict_i64(&DICT_I64, "pc"));
+	println("get 'ot' = ", get_dict_i64(&DICT_I64, "ot"));
+	println("get 'ab' = ", get_dict_i64(&DICT_I64, "ab"));
+
+	print_lens_dict_i64(&DICT_I64);
+
+	println("keys = ", keys_dict_i64(&DICT_I64));
+	println("vals = ", vals_dict_i64(&DICT_I64));
+
+	println("ending dict.syntran");
+	return 0;
+}
+return main();
+

--- a/samples/dict_i64_fn.syntran
+++ b/samples/dict_i64_fn.syntran
@@ -139,13 +139,8 @@ fn vals_dict_i64(dict: &dict_i64): [i64; :]
 	return vals;
 }
 
-//fn set_dict_i64(dict: &dict_i64, key: str, val: i64): dict_i64
 fn set_dict_i64(dict: &dict_i64, key: str, val: i64)
 {
-	// TODO: we really need dict arg as reference (not value) for efficiency
-	//
-	// Modifies a dict dict as a global var for now
-
 	let ib = hash_str_dict(key); // bucket index
 	//println("ib = ", ib);
 

--- a/src/consts.f90
+++ b/src/consts.f90
@@ -24,7 +24,7 @@ module syntran__consts_m
 			bit_not_token         = 112, &
 			bit_xor_token         = 111, &
 			bit_or_token          = 110, &
-			bit_and_token         = 109, &
+			amp_token             = 109, &
 			ggreater_token        = 108, &
 			lless_token           = 107, &
 			continue_statement    = 106, &
@@ -393,7 +393,7 @@ function kind_name(kind)
 			"continue statement   ", & ! 106
 			"lless_token          ", & ! 107
 			"ggreater_token       ", & ! 108
-			"bit_and_token        ", & ! 109
+			"amp_token            ", & ! 109
 			"bit_or_token         ", & ! 110
 			"bit_xor_token        ", & ! 111
 			"bit_not_token        ", & ! 112

--- a/src/core.f90
+++ b/src/core.f90
@@ -257,7 +257,8 @@ contains
 
 function syntax_parse(str, vars, fns, src_file, allow_continue) result(tree)
 
-	! TODO: take state struct instead of separate vars and fns members?
+	! TODO: take state struct instead of separate vars and fns members.  Then
+	! init_ref_sub() could be called at the end of this fn
 
 	! TODO: take structs arg (like existing fns arg)
 

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,6 +30,16 @@ module syntran__core_m
 		syntran_patch =  57
 
 	! TODO:
+	!  - pass by reference?  big boost to perf for array fns.  should be
+	!    possible by swapping around some id_index values in vars%vals array.
+	!    harder part is ensuring that only lvalues are passed by ref (not
+	!    rvalues), e.g. `my_fn(x)` is allowed but `my_fn(x+1)` is not if arg is
+	!    passed by ref
+	!    * this would be helpful for lots of AOC problems. it would allow
+	!      efficient implementation of data structures like hash map
+	!      dictionaries.  this can be done already, but it requires either
+	!      copying in/out the whole dict for every modification (slow), or
+	!      modification of a singleton dict global variable
 	!  - raw string literals
 	!    * easier to include quotes without doubling
 	!    * follow rust style:
@@ -148,11 +158,6 @@ module syntran__core_m
 	!    * 8 isn't installed.  maybe i can install it in workflow?
 	!    * tried "setup-fortran" marketplace action but it can't install 8
 	!      either
-	!  - pass by reference?  big boost to perf for array fns.  should be
-	!    possible by swapping around some id_index values in vars%vals array.
-	!    harder part is ensuring that only lvalues are passed by ref (not
-	!    rvalues), e.g. `my_fn(x)` is allowed but `my_fn(x+1)` is not if arg is
-	!    passed by ref
 	!  - #(pragma)once  directive. #let var=val directive?
 	!    * for #once include guards, insert filename path as key into a ternary
 	!      tree w/ bool value true.  then when something is included, check if

--- a/src/core.f90
+++ b/src/core.f90
@@ -43,16 +43,10 @@ module syntran__core_m
 	!    * how can interactive interpretter still be used as a desktop
 	!      calculator tho? maybe have a "mode" flag which is set differently for
 	!      interactive runs (if there isn't already one)
-	!  - pass by reference?  big boost to perf for array fns.  should be
-	!    possible by swapping around some id_index values in vars%vals array.
-	!    harder part is ensuring that only lvalues are passed by ref (not
-	!    rvalues), e.g. `my_fn(x)` is allowed but `my_fn(x+1)` is not if arg is
-	!    passed by ref
-	!    * this would be helpful for lots of AOC problems. it would allow
-	!      efficient implementation of data structures like hash map
-	!      dictionaries.  this can be done already, but it requires either
-	!      copying in/out the whole dict for every modification (slow), or
-	!      modification of a singleton dict global variable
+	!  - pass by reference for subscripted array name expressions and dot
+	!    expressions
+	!    * done for regular variable name expressions
+	!    * needs documentation
 	!  - raw string literals
 	!    * easier to include quotes without doubling
 	!    * follow rust style:

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,6 +30,19 @@ module syntran__core_m
 		syntran_patch =  57
 
 	! TODO:
+	!  - ban expression statements?
+	!    * these were needed before i had the return statement
+	!    * they were also used for HolyC-style implicit prints, which should
+	!      also probably be removed
+	!    * now it causes issues if i accidentally do a line like this:
+	!          x == y;
+	!      instead of:
+	!          x = y;
+	!      the first implicit bool expr line is currently allowed but never what
+	!      i meant!
+	!    * how can interactive interpretter still be used as a desktop
+	!      calculator tho? maybe have a "mode" flag which is set differently for
+	!      interactive runs (if there isn't already one)
 	!  - pass by reference?  big boost to perf for array fns.  should be
 	!    possible by swapping around some id_index values in vars%vals array.
 	!    harder part is ensuring that only lvalues are passed by ref (not

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -675,6 +675,36 @@ end function err_bad_arg_ref
 
 !===============================================================================
 
+function err_non_name_ref(context, span) result(err)
+
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	err = err_prefix &
+		//'`&` reference to unexpected expression kind.  references can only ' &
+		//'be made to variable name expressions' &
+		//underline(context, span)//" non-name `&` ref"//color_reset
+
+end function err_non_name_ref
+
+!===============================================================================
+
+function err_sub_ref(context, span) result(err)
+
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	err = err_prefix &
+		//'`&` reference to unexpected subscripted expression.  references can only ' &
+		//'be made to name expressions without subscripts' &
+		//underline(context, span)//" subscripted `&` ref"//color_reset
+
+end function err_sub_ref
+
+!===============================================================================
+
 function err_bad_arg_rank(context, span, fn, iarg, param, expect, actual) &
 		result(err)
 

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -637,6 +637,44 @@ end function err_bad_arg_type
 
 !===============================================================================
 
+function err_bad_arg_val(context, span, fn, iarg, param) &
+		result(err)
+
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+	integer, intent(in):: iarg
+
+	character(len = *), intent(in) :: fn, param
+
+	err = err_prefix &
+		//'function `'//fn//'` parameter '//str(iarg)//' `'//param &
+		//'` requires a `&` reference but was given a value argument' &
+		//underline(context, span)//" missing `&` ref"//color_reset
+
+end function err_bad_arg_val
+
+!===============================================================================
+
+function err_bad_arg_ref(context, span, fn, iarg, param) &
+		result(err)
+
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+	integer, intent(in):: iarg
+
+	character(len = *), intent(in) :: fn, param
+
+	err = err_prefix &
+		//'function `'//fn//'` parameter '//str(iarg)//' `'//param &
+		//'` requires a value but was given a `&` reference argument' &
+		//underline(context, span)//" bad `&` ref"//color_reset
+
+end function err_bad_arg_ref
+
+!===============================================================================
+
 function err_bad_arg_rank(context, span, fn, iarg, param, expect, actual) &
 		result(err)
 

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -37,9 +37,9 @@ module syntran__eval_m
 		! nightmare if you grep for "break" and don't find "broke"
 		logical :: returned, breaked, continued
 
-		! This table is used to make substitutions for passing by reference.
-		! For values which are not references, it is mostly an identity mapping
-		! [1, 2, 3, ... ]
+		! This table is used to make substitutions in the vars array for passing
+		! by reference. For values which are not references, it is otherwise an
+		! identity mapping [1, 2, 3, ... ]
 		integer, allocatable :: ref_sub(:)
 
 	end type state_t

--- a/src/lex.f90
+++ b/src/lex.f90
@@ -856,7 +856,7 @@ function lex(lexer) result(token)
 				lexer%pos = lexer%pos + 1
 				token = new_token(bit_and_equals_token, lexer%pos, "&=")
 			else
-				token = new_token(bit_and_token, lexer%pos, lexer%current())
+				token = new_token(amp_token, lexer%pos, lexer%current())
 			end if
 
 		case default

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -376,8 +376,9 @@ module function parse_fn_declaration(parser) result(decl)
 		!print *, 'matching colon'
 		colon = parser%match(colon_token)
 
-		! TODO: should this be part of parse_type()?  I think not, as refs can
-		! appear in fn decls but not struct decls
+		! Should this be part of parse_type()?  I think not, as refs can appear
+		! in fn decls but not struct decls.  Fn calls do not even call
+		! parse_type, they call parse_expr instead
 		if (parser%current_kind() == amp_token) then
 			amp = parser%match(amp_token)
 			call is_ref%push(.true.)

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -228,15 +228,10 @@ recursive module function parse_fn_call(parser) result(fn_call)
 		param_is_ref = .false.
 		if (allocated(fn%node)) param_is_ref = fn%node%is_ref(i)
 
-		!if (fn%is_ref(i) .neqv. is_ref%v(i)) then
-		!if (fn%node%is_ref(i) .neqv. is_ref%v(i)) then
 		if (param_is_ref .neqv. is_ref%v(i)) then
 
-			! TODO: pass by ref tests
-
-			span = new_span(pos_args%v(i), pos_args%v(i+1) - pos_args%v(i) - 1)
-
 			! The "param" is in the decl, the "arg" is in the call
+			span = new_span(pos_args%v(i), pos_args%v(i+1) - pos_args%v(i) - 1)
 			if (param_is_ref) then
 				call parser%diagnostics%push(err_bad_arg_val( &
 					parser%context(), &

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -215,6 +215,8 @@ recursive module function parse_fn_call(parser) result(fn_call)
 			! TODO: diag
 			print *, "Error: bad reference in fn call"
 			print *, ""
+			stop
+
 		end if
 
 		if (types_match(param_val, args%v(i)%val) /= TYPE_MATCH) then

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -95,6 +95,7 @@ function syntran_interpret(str_, quiet, startup_file) result(res_str)
 		end if
 
 		! TODO: chdir option?
+		call init_ref_sub(state)
 		call syntax_eval(compilation, state, res)
 		res_str = res%to_str()
 		write(*,*) '    '//res_str
@@ -187,6 +188,7 @@ function syntran_interpret(str_, quiet, startup_file) result(res_str)
 		! Don't try to evaluate with errors
 		if (compilation%diagnostics%len_ > 0) cycle
 
+		call init_ref_sub(state)
 		call syntax_eval(compilation, state, res )
 
 		! Consider MATLAB-style "ans = " log?
@@ -223,6 +225,7 @@ integer function syntran_eval_i32(str_) result(eval_i32)
 		return
 	end if
 
+	call init_ref_sub(state)
 	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
@@ -254,6 +257,7 @@ integer(kind = 8) function syntran_eval_i64(str_) result(val_)
 		return
 	end if
 
+	call init_ref_sub(state)
 	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
@@ -288,6 +292,7 @@ real(kind = 4) function syntran_eval_f32(str_, quiet) result(eval_f32)
 		return
 	end if
 
+	call init_ref_sub(state)
 	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
@@ -323,6 +328,7 @@ real(kind = 8) function syntran_eval_f64(str_, quiet) result(eval_f64)
 		return
 	end if
 
+	call init_ref_sub(state)
 	call syntax_eval(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
@@ -330,6 +336,24 @@ real(kind = 8) function syntran_eval_f64(str_, quiet) result(eval_f64)
 	!print *, 'eval_f64 = ', eval_f64
 
 end function syntran_eval_f64
+
+!===============================================================================
+
+subroutine init_ref_sub(state)
+
+	! TODO: move to eval.f90
+
+	type(state_t), intent(inout) :: state
+
+	!********
+
+	integer :: i
+
+	!print *, "size vars = ", size(state%vars%vals)
+	state%ref_sub = [(i, i = 1, size(state%vars%vals))]
+	!print *, "ref_sub = ", state%ref_sub
+
+end subroutine init_ref_sub
 
 !===============================================================================
 
@@ -374,8 +398,6 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 
 	character(len = 1024) :: buffer
 	character(len = :), allocatable :: src_filel, dir, cwd
-
-	integer :: i
 
 	logical :: chdirl
 
@@ -429,14 +451,8 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 
 	end if
 
-	print *, "size vars = ", size(state%vars%vals)
-
-	! TODO: set ref_sub in every other place that calls syntax_eval(), add helper
-	! fn
-	state%ref_sub = [(i, i = 1, size(state%vars%vals))]
-	print *, "ref_sub = ", state%ref_sub
-
 	!print *, "evaling "
+	call init_ref_sub(state)
 	call syntax_eval(tree, state, val)
 	!print *, "done"
 	res = val%to_str()

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -375,6 +375,8 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 	character(len = 1024) :: buffer
 	character(len = :), allocatable :: src_filel, dir, cwd
 
+	integer :: i
+
 	logical :: chdirl
 
 	type(state_t) :: state
@@ -426,6 +428,13 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 		call chdir(dir)
 
 	end if
+
+	print *, "size vars = ", size(state%vars%vals)
+
+	! TODO: set ref_sub in every other place that calls syntax_eval(), add helper
+	! fn
+	state%ref_sub = [(i, i = 1, size(state%vars%vals))]
+	print *, "ref_sub = ", state%ref_sub
 
 	!print *, "evaling "
 	call syntax_eval(tree, state, val)

--- a/src/tests/test-src/ref/test-01.syntran
+++ b/src/tests/test-src/ref/test-01.syntran
@@ -1,0 +1,17 @@
+
+fn add_one(var_ref: &i32)
+{
+	var_ref += 1;
+	return;
+}
+
+fn main(): i32
+{
+	let x = 0;
+	x = 42;
+	add_one(&x);
+	return x;
+}
+
+return main();
+

--- a/src/tests/test-src/ref/test-02.syntran
+++ b/src/tests/test-src/ref/test-02.syntran
@@ -1,0 +1,23 @@
+
+fn swap_i32_(a: &i32, b: &i32)
+{
+	let tmp = a;
+	a = b;
+	b = tmp;
+	return;
+}
+
+fn main(): bool
+{
+	let x = 42;
+	let y = 1337;
+	//println("x, y = ", [x, y]);
+	swap_i32_(&x, &y);
+	//println("x, y = ", [x, y]);
+	return
+		x == 1337 and
+		y == 42;
+}
+
+return main();
+

--- a/src/tests/test-src/ref/test-03.syntran
+++ b/src/tests/test-src/ref/test-03.syntran
@@ -1,0 +1,65 @@
+
+fn swap_i64_(a: &i64, b: &i64)
+{
+	let tmp = a;
+	a = b;
+	b = tmp;
+	return;
+}
+
+fn swap_f64_(a: &f64, b: &f64)
+{
+	let tmp = a;
+	a = b;
+	b = tmp;
+	return;
+}
+
+fn swap_str_(a: &str, b: &str)
+{
+	let tmp = a;
+	a = b;
+	b = tmp;
+	return;
+}
+
+fn swap_bool_(a: &bool, b: &bool)
+{
+	let tmp = a;
+	a = b;
+	b = tmp;
+	return;
+}
+
+fn main(): bool
+{
+	let ix =   42'i64;
+	let iy = 1337'i64;
+	swap_i64_(&ix, &iy);
+
+	let fx = 3.1416;
+	let fy = 2.71828;
+	swap_f64_(&fx, &fy);
+
+	let sx = "hi";
+	let sy = "world";
+	swap_str_(&sx, &sy);
+
+	let bx = true;
+	let by = false;
+	swap_bool_(&bx, &by);
+
+	return
+		ix == 1337 and
+		iy ==   42 and
+		abs(fx - 2.71828) < 1.e-9 and
+		abs(fy - 3.1416 ) < 1.e-9 and
+		sx == "world" and
+		sy == "hi" and
+		bx == false and
+		by == true
+	;
+}
+
+return main();
+

--- a/src/tests/test-src/ref/test-04.syntran
+++ b/src/tests/test-src/ref/test-04.syntran
@@ -1,0 +1,51 @@
+
+fn add_one(var_ref: &i32)
+{
+	var_ref += 1;
+	return;
+}
+
+fn assert_eq(a: i32, b: i32): i32
+{
+	if a == b
+		return 0;
+	return 1;
+}
+
+fn main(): i32
+{
+	let status = 0;
+
+	let x = 0;
+	x = 42;
+
+	add_one(&x);
+	status += assert_eq(x, 43);
+	add_one(&x);
+	status += assert_eq(x, 44);
+	add_one(&x);
+	status += assert_eq(x, 45);
+
+	let y = 1337;
+	add_one(&y);
+	status += assert_eq(y, 1338);
+	add_one(&y);
+	status += assert_eq(y, 1339);
+
+	add_one(&x);
+	status += assert_eq(x, 46);
+
+	let z = 69;
+	add_one(&z);
+	status += assert_eq(z, 70);
+
+	add_one(&x);
+	status += assert_eq(x, 47);
+	add_one(&x);
+	status += assert_eq(x, 48);
+
+	return status;
+}
+
+return main();
+

--- a/src/tests/test-src/ref/test-05.syntran
+++ b/src/tests/test-src/ref/test-05.syntran
@@ -1,0 +1,58 @@
+
+fn sub_one(my_var: &i32)
+{
+	my_var -= 1;
+	return;
+}
+
+fn noop(var_ref: &i32)
+{
+	var_ref += 1;
+	sub_one(&var_ref);
+	return;
+}
+
+fn assert_eq(a: i32, b: i32): i32
+{
+	if a == b
+		return 0;
+	return 1;
+}
+
+fn main(): i32
+{
+	let status = 0;
+
+	let x = 0;
+	x = 42;
+
+	noop(&x);
+	status += assert_eq(x, 42);
+	noop(&x);
+	status += assert_eq(x, 42);
+	noop(&x);
+	status += assert_eq(x, 42);
+
+	let y = 1337;
+	noop(&y);
+	status += assert_eq(y, 1337);
+	noop(&y);
+	status += assert_eq(y, 1337);
+
+	noop(&x);
+	status += assert_eq(x, 42);
+
+	let z = 69;
+	noop(&z);
+	status += assert_eq(z, 69);
+
+	noop(&x);
+	status += assert_eq(x, 42);
+	noop(&x);
+	status += assert_eq(x, 42);
+
+	return status;
+}
+
+return main();
+

--- a/src/tests/test-src/ref/test-06.syntran
+++ b/src/tests/test-src/ref/test-06.syntran
@@ -1,0 +1,58 @@
+
+fn add_two(my_var: &i32)
+{
+	my_var += 2;
+	return;
+}
+
+fn add_three(var_ref: &i32)
+{
+	var_ref += 1;
+	add_two(&var_ref);
+	return;
+}
+
+fn assert_eq(a: i32, b: i32): i32
+{
+	if a == b
+		return 0;
+	return 1;
+}
+
+fn main(): i32
+{
+	let status = 0;
+
+	let x = 0;
+	x = 42;
+
+	add_three(&x);
+	status += assert_eq(x, 45);
+	add_three(&x);
+	status += assert_eq(x, 48);
+	add_three(&x);
+	status += assert_eq(x, 51);
+
+	let y = 1337;
+	add_three(&y);
+	status += assert_eq(y, 1340);
+	add_three(&y);
+	status += assert_eq(y, 1343);
+
+	add_three(&x);
+	status += assert_eq(x, 54);
+
+	let z = 69;
+	add_three(&z);
+	status += assert_eq(z, 72);
+
+	add_three(&x);
+	status += assert_eq(x, 57);
+	add_three(&x);
+	status += assert_eq(x, 60);
+
+	return status;
+}
+
+return main();
+

--- a/src/tests/test-src/ref/test-07.syntran
+++ b/src/tests/test-src/ref/test-07.syntran
@@ -223,30 +223,12 @@ fn main(): i64
 	set_dict_i64(&dict, "ot", 9'i64);
 	set_dict_i64(&dict, "ab", 5'i64);
 
-	let rn = get_dict_i64(&dict, "rn");
-	let qp = get_dict_i64(&dict, "qp");
-	let cm = get_dict_i64(&dict, "cm");
-	let pc = get_dict_i64(&dict, "pc");
-	let ot = get_dict_i64(&dict, "ot");
-	let ab = get_dict_i64(&dict, "ab");
-
-	println("get 'rn' = ", rn);
-	println("get 'qp' = ", qp);
-	println("get 'cm' = ", cm);
-	println("get 'pc' = ", pc);
-	println("get 'ot' = ", ot);
-	println("get 'ab' = ", ab);
-
-	//print_lens_dict_i64(&dict);
-	//println("keys = ", keys_dict_i64(&dict));
-	//println("vals = ", vals_dict_i64(&dict));
-
-	status += assert_eq64(rn, 1'i64);
-	status += assert_eq64(qp, 3'i64);
-	status += assert_eq64(cm, 2'i64);
-	status += assert_eq64(pc, 4'i64);
-	status += assert_eq64(ot, 9'i64);
-	status += assert_eq64(ab, 5'i64);
+	status += assert_eq64(get_dict_i64(&dict, "rn"), 1'i64);
+	status += assert_eq64(get_dict_i64(&dict, "qp"), 3'i64);
+	status += assert_eq64(get_dict_i64(&dict, "cm"), 2'i64);
+	status += assert_eq64(get_dict_i64(&dict, "pc"), 4'i64);
+	status += assert_eq64(get_dict_i64(&dict, "ot"), 9'i64);
+	status += assert_eq64(get_dict_i64(&dict, "ab"), 5'i64);
 
 	//println("ending dict.syntran");
 	return status;

--- a/src/tests/test-src/ref/test-07.syntran
+++ b/src/tests/test-src/ref/test-07.syntran
@@ -139,13 +139,8 @@ fn vals_dict_i64(dict: &dict_i64): [i64; :]
 	return vals;
 }
 
-//fn set_dict_i64(dict: &dict_i64, key: str, val: i64): dict_i64
 fn set_dict_i64(dict: &dict_i64, key: str, val: i64)
 {
-	// TODO: we really need dict arg as reference (not value) for efficiency
-	//
-	// Modifies a dict dict as a global var for now
-
 	let ib = hash_str_dict(key); // bucket index
 	//println("ib = ", ib);
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4292,6 +4292,12 @@ subroutine unit_test_ref(npass, nfail)
 	tests = &
 		[   &
 			interpret_file(path//'test-01.syntran', quiet) == '43', &
+			interpret_file(path//'test-02.syntran', quiet) == 'true', &
+			interpret_file(path//'test-03.syntran', quiet) == 'true', &
+			interpret_file(path//'test-04.syntran', quiet) == '0', &
+			interpret_file(path//'test-05.syntran', quiet) == '0', &
+			interpret_file(path//'test-06.syntran', quiet) == '0', &
+			interpret_file(path//'test-07.syntran', quiet) == '0', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4271,6 +4271,39 @@ end subroutine unit_test_bitwise_2
 
 !===============================================================================
 
+subroutine unit_test_ref(npass, nfail)
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'pass-by-reference'
+
+	! Path to syntran test files from root of repo
+	character(len = *), parameter :: path = 'src/tests/test-src/ref/'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			interpret_file(path//'test-01.syntran', quiet) == '43', &
+			.false.  & ! so I don't have to bother w/ trailing commas
+		]
+
+	! Trim dummy false element
+	tests = tests(1: size(tests) - 1)
+
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_ref
+
+!===============================================================================
+
 subroutine unit_test_array_bool(npass, nfail)
 
 	! More advanced tests on longer scripts
@@ -4502,6 +4535,7 @@ subroutine unit_tests(iostat)
 	call unit_test_bitwise    (npass, nfail)
 	call unit_test_bit_ass    (npass, nfail)
 	call unit_test_bitwise_2  (npass, nfail)
+	call unit_test_ref        (npass, nfail)
 
 	! TODO: add tests that mock interpreting one line at a time (as opposed to
 	! whole files)

--- a/src/types.f90
+++ b/src/types.f90
@@ -156,6 +156,7 @@ module syntran__types_m
 		integer :: id_index
 
 		integer, allocatable :: params(:)
+		logical, allocatable :: is_ref(:)  ! is param passed by reference?
 
 		type(value_t) :: val
 
@@ -761,6 +762,12 @@ recursive subroutine syntax_node_copy(dst, src)
 		dst%params = src%params
 	else if (allocated(dst%params)) then
 		deallocate(dst%params)
+	end if
+
+	if (allocated(src%is_ref)) then
+		dst%is_ref = src%is_ref
+	else if (allocated(dst%is_ref)) then
+		deallocate(dst%is_ref)
 	end if
 
 	if (allocated(src%condition)) then
@@ -1547,7 +1554,7 @@ logical function is_binary_op_allowed(left, op, right, left_arr, right_arr) &
 			end if
 
 		case ( &
-				bit_xor_token, bit_or_token, bit_and_token, &
+				bit_xor_token, bit_or_token, amp_token, &
 				bit_xor_equals_token, bit_or_equals_token, bit_and_equals_token)
 
 			! Other bitwise binary operators (besides shift) only work on ints
@@ -1752,7 +1759,7 @@ integer function get_binary_op_prec(kind) result(prec)
 		case (lless_token, ggreater_token) ! `<<`, `>>`
 			prec = 8
 
-		case (bit_and_token) ! `&`
+		case (amp_token) ! `&`
 			prec = 7
 
 		case (bit_xor_token) ! `^`


### PR DESCRIPTION
This PR implements a pass-by-reference feature for function arguments.  References are denoted with an ampersand before the type in function declarations and before the respective variables name in function calls

There is a hash map dict sample (and test) showing its usage

References are only allowed for basic names for now, not subscripted names or dot expressions

Here is a simple but useful example from [src/tests/test-src/ref/test-02.syntran](src/tests/test-src/ref/test-02.syntran) :

```rust
fn swap_i32_(a: &i32, b: &i32)
{
	let tmp = a;
	a = b;
	b = tmp;
	return;
}
fn main(): bool
{
	let x = 42;
	let y = 1337;
	swap_i32_(&x, &y);
	return
		x == 1337 and
		y == 42;
}
return main(); // true
```