### PR TITLE
1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.
 ./syntran -h
 ```
 
-The binary asset `syntran-linux.zip` works on most distros:  alma, arch, debian, fedora, kali, rocky, and ubuntu.  The environment variable `LD_LIBRARY_PATH` should be set, or else `libgfortran*.so` may not be found.
+The binary asset `syntran-linux.zip` works on most distros:  alma, arch, debian, fedora, kali, rocky, and ubuntu.
 
 <!--
 // The rocky binary is the official binary now.  It used to be ubuntu, but the

--- a/fpm.toml
+++ b/fpm.toml
@@ -66,7 +66,11 @@ auto-examples    = true
 module-naming    = false
 
 [install]
-library = false
+library = true
+# To get module usage working with nvim gfortran linting, run
+# `fpm install --prefix ./build` with library set to true here to place the .mod
+# files somewhere that nvim/gfortran can find them, as opposed to the default
+# location build/gfortran_{random-hex-shit}/*.mod
 
 [[executable]]
 name = "syntran"

--- a/src/app.f90
+++ b/src/app.f90
@@ -5,6 +5,9 @@
 module ifport
 	! Unfortunately this is the only way i can get fpm to not complain about
 	! ifport with gfortran
+	!
+	! TODO: try using "external-modules" in fpm.toml, I think this is what it's
+	! for
 end module ifport
 #endif
 

--- a/src/bool.f90
+++ b/src/bool.f90
@@ -84,15 +84,17 @@ subroutine is_eq_value_t(left, right, res, op_text)
 	case        (magic * i64_type + i32_type)
 		res%sca%bool = left%sca%i64 == right%sca%i32
 
-	! TODO: mixed f32 <compare_op> f64 operators
+	! Mixed f32 to f64 `==` and `!=` operators? Probably not, see comments in
+	! is_binary_op_allowed()
 
 	case        (magic * f32_type + f32_type)
 		res%sca%bool = left%sca%f32 == right%sca%f32
 
 	case        (magic * f32_type + i32_type)
 		res%sca%bool = left%sca%f32 == right%sca%i32
-		! TODO: is this even possible or should I ban comparing ints and
-		! floats?  Similarly for other comparisons
+		! Is this even possible or should I ban comparing ints and floats?
+		! Similarly for other comparisons.  Currently this is banned in
+		! is_binary_op_allowed()
 		!
 		! GNU says Warning: Equality comparison for REAL(4) at (1)
 		! [-Wcompare-reals]

--- a/src/compiler.F90
+++ b/src/compiler.F90
@@ -32,11 +32,6 @@ module syntran__compiler_m
 #else
 #error Neither __GFORTRAN__ nor __INTEL__ are defined.  Please use a supported compiler and compile with pre-processing `-cpp` (gfortran) or `-fpp` (intel)
 
-	! TODO: 
-	!
-	! Re-test the Windows issue.  It's possible that some of these memory
-	! corruption bugs have helped there too after getting gfortran 13+ fixed
-
 	character(len = *), parameter :: fort_compiler = "unknown"
 	integer, parameter :: fort_vers(*) = []
 

--- a/src/core.f90
+++ b/src/core.f90
@@ -25,9 +25,9 @@ module syntran__core_m
 	character(len = *), parameter :: lang_name = "syntran"
 
 	integer, parameter ::   &
-		syntran_major =  0, &
+		syntran_major =  1, &
 		syntran_minor =  0, &
-		syntran_patch =  63
+		syntran_patch =  0
 
 	! TODO:
 	!  - fn type checking bug:

--- a/src/core.f90
+++ b/src/core.f90
@@ -43,15 +43,6 @@ module syntran__core_m
 	!  - document recommendation of `ulimit -s unlimited`
 	!    * aoc 2018 day 17 crashed without this. helps with large (~hundreds)
 	!      recursion depth
-	!  - roadmap to version 1.0.0:
-	!    * update docs to not mention libgfortran or libquadmath.  these are
-	!      statically linked now in linux ci/cd builds
-	!    * more tests?
-	!      + aoc 2018/8 is a good recursion example and runs fast (1.5 s)
-	!      + i said i would do a code freeze, but i think adding tests is
-	!        allowed
-	!    * have a trial alpha/beta release 0.1.0 for a bit before 1.0
-	!      + targetting 1.0 release circa April 15, 2025
 	!  - built-in syntran update:
 	!    * add checksum verification
 	!    * currently ./syup.sh can do it

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,6 +30,53 @@ module syntran__core_m
 		syntran_patch =  63
 
 	! TODO:
+	!  - fn type checking bug:
+	!
+	!      // TODO:  something about myfn() being defined below and maybe abs()
+	!      // being overloaded makes this fail the type checker:
+	!      println(abs(myfn(7)));
+	!      fn myfn(a: i32): i32
+	!      {
+	!      	return a + 1;
+	!      }
+	!
+	!  - document recommendation of `ulimit -s unlimited`
+	!    * aoc 2018 day 17 crashed without this. helps with large (~hundreds)
+	!      recursion depth
+	!  - roadmap to version 1.0.0:
+	!    * update docs to not mention libgfortran or libquadmath.  these are
+	!      statically linked now in linux ci/cd builds
+	!    * more tests?
+	!      + aoc 2018/8 is a good recursion example and runs fast (1.5 s)
+	!      + i said i would do a code freeze, but i think adding tests is
+	!        allowed
+	!    * have a trial alpha/beta release 0.1.0 for a bit before 1.0
+	!      + targetting 1.0 release circa April 15, 2025
+	!  - built-in syntran update:
+	!    * add checksum verification
+	!    * currently ./syup.sh can do it
+	!    * make this built-in to syntran binary, maybe invoke like
+	!      `syntran --update`.  think carefully. don't want to break this by
+	!      changing the name of the script or arg
+	!    * this would only work on linux, since windows can't overwrite a
+	!      running exe
+	!    * apparently it's possible on windows too.  til:  https://stackoverflow.com/a/459860/4347028
+	!  - post 1.0:
+	!    * need to think about namespaces, at least for std fns so i can add
+	!      intrinsic fns without breaking anyone's code who happened to already
+	!      define a fn with the same name
+	!      + example: define a `println` fn.  it won't parse
+	!      + note that you *are* allowed to define a `sum` fn because the
+	!        intrinsic sum fn is overloaded.  all of the actual intrinsic sums
+	!        are named like `0sum_i32` or `0sum_f64`
+	!        > could this be abused to add new secret fns starting with "0"
+	!          without breaking compat? seems like a bad idea
+	!        > it also seems bad that users can shadow define `sum` or any other
+	!          overloaded intrinsic
+	!  - enable plugging in to nvim linting.  doesn't seem hard from the way
+	!    that gfortran nvim linting works.  just need to add a cmd arg like
+	!    `--syntax-only` and print errors in 1 line per error, with filename,
+	!    line, and column indices
 	!  - test rocky 10 circa May 2025, that's when they're planning to release
 	!    it
 	!  - appimage?  some kind of binary packaging improvement
@@ -39,8 +86,6 @@ module syntran__core_m
 	!      statically bundled into one file
 	!    * is appimage the standard tool for this?  how does fpm do it?
 	!  - add recursive fibonacci sample to syntran-explorer
-	!  - roadmap to version 1.0.0:
-	!    * maybe have a trial alpha/beta release 0.1.0 for a bit before 1.0?
 	!  - REPL styling
 	!    * any other ideas from julia?  got their green prompt
 	!    * could later extend with hint levels (off, semicolon-only, or fully on)

--- a/src/types.f90
+++ b/src/types.f90
@@ -1683,7 +1683,9 @@ logical function is_binary_op_allowed(left, op, right, left_arr, right_arr) &
 				return
 			end if
 
-			! TODO: allow and then implement comparisons on mixed float types
+			! Allow and then implement comparisons on mixed float types? Might
+			! be a bad idea like float to int equality, noted below
+
 			if (left == array_type .and. right == array_type) then
 				allowed = &
 					(is_int_type(left_arr) .and. is_int_type(right_arr)) .or. &

--- a/syup.sh
+++ b/syup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This script updates syntran on Linux by downloading the latest github release
+# binary
+
+#****************
+
+set -eu
+
+# Make a temp dir for download and then cleanup afterwards
+
+dir_=$(mktemp -d)
+pushd "$dir_"
+
+curl -LO "https://github.com/JeffIrwin/syntran/releases/latest/download/syntran-linux.zip"
+
+unzip syntran-linux.zip
+rm syntran-linux.zip
+
+chmod +x ./syntran
+
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.
+
+#./syntran -h
+#./syntran --version
+
+# TODO: check for existing syntran installation and use that as dest dir.
+# Otherwise, require dest arg?
+bin_dest="$HOME/.local/bin/"
+
+mv * "$bin_dest"
+
+syntran --version
+
+popd
+rm -rf "$dir_"
+


### PR DESCRIPTION
This PR bumps the version from 0.0.63 to 1.0.0

Otherwise, there are no significant changes other than documentation and comments

In the month since 0.0.63, I've completed another year's worth of Advent of Code problems in syntran with no serious issues found.  Although, I did find two minor issues:
- non-regression bug from the recursion implementation:  https://github.com/JeffIrwin/syntran/blob/b0c44687dfcb0944103027b85c88bedf8dc8f305/src/core.f90#L35-L41
- `ulimit` is required for some crazy-recursive aoc problems 

Neither issue warrants a delay IMO and they can be fixed post 1.0.0 