### PR TITLE
Dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -581,7 +581,7 @@
 					set -exu \n
 
 					# Test this to run syntran without homebrew gcc lib paths \n
-					brew remove gcc@12 \n
+					brew remove gcc@12 || true \n
 
 					mv /opt/homebrew/bin /opt/homebrew/bin-BACKUP || true \n
 					mv /opt/homebrew/opt /opt/homebrew/opt-BACKUP || true \n

--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -35,6 +35,7 @@ RUN git clone \
 	--depth 1 \
 	##--branch releases/gcc-12.2.0 \
 	#--branch releases/gcc-12 \
+	--branch releases/gcc-15 \
 	$SRC_DIR
 
 WORKDIR /workdir/$SRC_DIR

--- a/README.md
+++ b/README.md
@@ -73,11 +73,20 @@ More or less any terminal on Windows should work, but [Windows Terminal](https:/
 
 <!-- mac works too but i don't want to encourage apple usery -->
 
-### Path
+### Path and environment settings
 
-Feel free to add the directory to your PATH environment variable, or type the full path.
+Feel free to add the directory to your PATH environment variable, or type the
+full path.
 
-Whenever you see something like `./build/Debug/syntran` or `fpm run` in the rest of this documentation, replace that with `/path/to/syntran` or `C:\path\to\syntran.exe` appropriately, depending on your operating system and where you downloaded the binary.
+Whenever you see something like `./build/Debug/syntran` or `fpm run` in the rest
+of this documentation, replace that with `/path/to/syntran` or
+`C:\path\to\syntran.exe` appropriately, depending on your operating system and
+where you downloaded the binary.
+
+I recommend running `ulimit -s unlimited` in `~/.bashrc` or at least in your
+current shell to remove the stack limit.  Otherwise, syntran can crash with
+large recursion depths of recursive function calls (see issue
+https://github.com/JeffIrwin/syntran/issues/28).
 
 ## Build the interpreter from source
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- [![](doc/imgs/logo-syntran-128p.png)](https://github.com/JeffIrwin/syntran/blob/main/samples/logo.syntran) -->
 [![](doc/imgs/logo-syntran-128p.png)](samples/logo.syntran)
 
-⚠️ Syntran is alpha and I don't recommend using it for anything serious.  You will discover bugs, missing features, many pain points in general; and later updates will be incompatible.
+⚠️ Syntran is beta and I don't recommend using it for anything serious.  You may discover bugs, missing features, general pain points; and later updates may be incompatible.
 
 ## [Syntax translator](https://www.practo.com/medicine-info/syntran-100-mg-capsule-18930)
 

--- a/src/compiler.F90
+++ b/src/compiler.F90
@@ -17,9 +17,9 @@ module syntran__compiler_m
 #error syntran is not compatible with gfortran <= 9. upgrade to gfortran 10, 11, or 12
 #endif
 
-#if (__GNUC__ >= 15)
-#error syntran is not compatible with gfortran >= 15. downgrade to gfortran 10 through 14
-! gfortran 15 isn't released yet (as of January 2025).  It might work, but it
+#if (__GNUC__ >= 16)
+#error syntran is not compatible with gfortran >= 16. downgrade to gfortran 10 through 15
+! gfortran 16 isn't released yet (as of November 2025).  It might work, but it
 ! needs to be tested
 #endif
 

--- a/src/core.f90
+++ b/src/core.f90
@@ -40,9 +40,6 @@ module syntran__core_m
 	!      	return a + 1;
 	!      }
 	!
-	!  - document recommendation of `ulimit -s unlimited`
-	!    * aoc 2018 day 17 crashed without this. helps with large (~hundreds)
-	!      recursion depth
 	!  - built-in syntran update:
 	!    * add checksum verification
 	!    * currently ./syup.sh can do it

--- a/src/core.f90
+++ b/src/core.f90
@@ -27,7 +27,7 @@ module syntran__core_m
 	integer, parameter ::   &
 		syntran_major =  1, &
 		syntran_minor =  0, &
-		syntran_patch =  0
+		syntran_patch =  1
 
 	! TODO:
 	!  - many of my Dockerfiles install fpm from the "current" github release,

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,6 +30,9 @@ module syntran__core_m
 		syntran_patch =  1
 
 	! TODO:
+	!  - add ci/cd tests for gfortran 15. maybe phase out 10 or 11 for managable
+	!    compute usage
+	!    * gfortran 15 is now the default for Windows github actions
 	!  - many of my Dockerfiles install fpm from the "current" github release,
 	!    but their "current" release is a stale 3 year old release.  try the
 	!    latest release, or just version pin 0.12.0

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,16 +30,9 @@ module syntran__core_m
 		syntran_patch =  0
 
 	! TODO:
-	!  - fn type checking bug:
-	!
-	!      // TODO:  something about myfn() being defined below and maybe abs()
-	!      // being overloaded makes this fail the type checker:
-	!      println(abs(myfn(7)));
-	!      fn myfn(a: i32): i32
-	!      {
-	!      	return a + 1;
-	!      }
-	!
+	!  - many of my Dockerfiles install fpm from the "current" github release,
+	!    but their "current" release is a stale 3 year old release.  try the
+	!    latest release, or just version pin 0.12.0
 	!  - built-in syntran update:
 	!    * add checksum verification
 	!    * currently ./syup.sh can do it
@@ -73,7 +66,6 @@ module syntran__core_m
 	!      worse than ubuntu.  it would be nice if everything was truly
 	!      statically bundled into one file
 	!    * is appimage the standard tool for this?  how does fpm do it?
-	!  - add recursive fibonacci sample to syntran-explorer
 	!  - REPL styling
 	!    * any other ideas from julia?  got their green prompt
 	!    * could later extend with hint levels (off, semicolon-only, or fully on)

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -29,7 +29,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 
 	integer :: i, io, id_index, pos0, rank
 
-	logical :: has_rank, param_is_ref, arg_is_ref
+	logical :: has_rank, param_is_ref, arg_is_ref, is_ok
 
 	type(fn_t) :: fn
 
@@ -271,10 +271,17 @@ recursive module function parse_fn_call(parser) result(fn_call)
 
 		end if
 
-		if (types_match(param_val, args%v(i)%val) /= TYPE_MATCH) then
+		is_ok = .true.
+		is_ok = is_ok .and. types_match(param_val, args%v(i)%val) == TYPE_MATCH
+		is_ok = is_ok .or. (parser%ipass == 0 .and. args%v(i)%val%type == unknown_type)
+
+		if (.not. is_ok) then
 
 			exp_type = type_name(param_val)
 			act_type = type_name(args%v(i)%val)
+			!print *, "ipass = ", parser%ipass
+			!print *, "exp type = ", exp_type
+			!print *, "act type = ", act_type
 
 			! This used to call a different diagnostic fn depending on whether
 			! it was a top-level type mismatch, array mismatch, or rank

--- a/src/tests/test-src/fns/test-21.syntran
+++ b/src/tests/test-src/fns/test-21.syntran
@@ -1,0 +1,17 @@
+
+// This didn't work before commit 95ebc2e
+//
+// The bug happened with nested fn calls, where the outer fn was a built-in
+// overloaded fn, e.g. `abs`, which can take both ints and floats, and the inner
+// fn is a user-defined fn being called ahead of its definition
+
+let ans = abs(myfn(7));
+let expect = 8;
+
+return ans - expect;
+
+fn myfn(a: i32): i32
+{
+	return a + 1;
+}
+

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -3024,6 +3024,7 @@ subroutine unit_test_fns(npass, nfail)
 			interpret_file(path//'test-18.syntran', quiet) == '0', &
 			interpret_file(path//'test-19.syntran', quiet) == '0', &
 			interpret_file(path//'test-20.syntran', quiet) == '0', &
+			interpret_file(path//'test-21.syntran', quiet) == '0', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/types.f90
+++ b/src/types.f90
@@ -2911,6 +2911,10 @@ integer function types_match(a, b) result(io)
 
 	io = TYPE_MATCH
 
+	! Note that is_binary_op_allowed() specifically allows operations on unknown
+	! types.  Maybe we should allow unknowns here too.  Test cases such as
+	! instantiating a struct with a fn that hasn't been defined above
+
 	if (.not. (a%type == any_type .or. a%type == b%type)) then
 		! Top-level type mismatch (e.g. f32 vs str)
 		io = TYPE_MISMATCH


### PR DESCRIPTION
- The compiler checker allows gfortran 15, since that is now the default on Windows github actions runners.  Note that this version is not extensively tested
- Bug-fix for nested function calls with an overloaded built-in function:

```
// This didn't work before commit 95ebc2e
//
// The bug happened with nested fn calls, where the outer fn was a built-in
// overloaded fn, e.g. `abs`, which can take both ints and floats, and the inner
// fn is a user-defined fn being called ahead of its definition

let ans = abs(myfn(7));
let expect = 8;

return ans - expect;

fn myfn(a: i32): i32
{
	return a + 1;
}
```
