### PR TITLE
add std::args() intrinsic fn for command-line arguments

### DIFF
--- a/Dockerfile.alpine.3.18
+++ b/Dockerfile.alpine.3.18
@@ -5,12 +5,17 @@ WORKDIR /workdir
 
 # Alpine 3.18 has gfortran 12.  3.19 has gfortran 13 which didn't work with
 # syntran until syntran 0.0.61, released 2025 Feb 1
+RUN apk add --no-cache \
+	gfortran \
+	musl-dev \
+	libc6-compat \
+	rlwrap \
+	curl
+# - libc6-compat:  syntran needs glibc compatibility, not alpine's musl libc
+# - rlwrap:  nice to have
 
-RUN apk add gfortran musl-dev
-RUN apk add libc6-compat  # syntran needs glibc compatibility, not alpine's musl libc
-RUN apk add rlwrap        # nice to have
-RUN apk add curl
-
+# Beware, this does not run gen-header.sh like rocky docker. Maybe that's
+# actually a good test that I have the generated source existing locally
 COPY src src
 COPY CMakeLists.txt .
 COPY fpm.toml .
@@ -51,4 +56,21 @@ RUN fpm test test
 ##************
 
 ENTRYPOINT ["rlwrap", "syntran"]
+
+#===========================================================
+# Tests
+#
+# This container is kinda bulky.  Maybe I should move tests to a separate
+# dockerfile (debug build only?) for efficiency
+
+RUN [[ "$(syntran -c '1+2;' | tr -d '[:space:]')" == "3" ]]
+RUN [[ "$(syntran -c 'sum([0:101]);' | tr -d '[:space:]')" == "5050" ]]
+RUN [[ "$(syntran -c 'sum([0:10]**2);' | tr -d '[:space:]')" == "285" ]]
+
+RUN [[ "$(syntran -c 'let a = args(); size(a);' -- foo bar hello world | tr -d '[:space:]')" == "4" ]]
+RUN [[ "$(syntran -c 'let a = args(); size(a);' -- foo bar 'hello world' | tr -d '[:space:]')" == "3" ]]
+
+# `tr` deletes all spaces, while this `sed` only removes *leading* spaces
+RUN [[ "$(syntran -c 'let a = args(); a[0];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "foo" ]]
+RUN [[ "$(syntran -c 'let a = args(); a[2];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "hello world" ]]
 

--- a/Dockerfile.alpine.3.18
+++ b/Dockerfile.alpine.3.18
@@ -67,10 +67,10 @@ RUN [[ "$(syntran -c '1+2;' | tr -d '[:space:]')" == "3" ]]
 RUN [[ "$(syntran -c 'sum([0:101]);' | tr -d '[:space:]')" == "5050" ]]
 RUN [[ "$(syntran -c 'sum([0:10]**2);' | tr -d '[:space:]')" == "285" ]]
 
-RUN [[ "$(syntran -c 'let a = args(); size(a);' -- foo bar hello world | tr -d '[:space:]')" == "4" ]]
-RUN [[ "$(syntran -c 'let a = args(); size(a);' -- foo bar 'hello world' | tr -d '[:space:]')" == "3" ]]
+RUN [[ "$(syntran -c 'let a = std::args(); size(a);' -- foo bar hello world | tr -d '[:space:]')" == "4" ]]
+RUN [[ "$(syntran -c 'let a = std::args(); size(a);' -- foo bar 'hello world' | tr -d '[:space:]')" == "3" ]]
 
 # `tr` deletes all spaces, while this `sed` only removes *leading* spaces
-RUN [[ "$(syntran -c 'let a = args(); a[0];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "foo" ]]
-RUN [[ "$(syntran -c 'let a = args(); a[2];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "hello world" ]]
+RUN [[ "$(syntran -c 'let a = std::args(); a[0];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "foo" ]]
+RUN [[ "$(syntran -c 'let a = std::args(); a[2];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "hello world" ]]
 

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -89,10 +89,10 @@ RUN [[ "$(./bin/syntran -c '1+2;' | tr -d '[:space:]')" == "3" ]]
 RUN [[ "$(./bin/syntran -c 'sum([0:101]);' | tr -d '[:space:]')" == "5050" ]]
 RUN [[ "$(./bin/syntran -c 'sum([0:10]**2);' | tr -d '[:space:]')" == "285" ]]
 
-RUN [[ "$(./bin/syntran -c 'let a = args(); size(a);' -- foo bar hello world | tr -d '[:space:]')" == "4" ]]
-RUN [[ "$(./bin/syntran -c 'let a = args(); size(a);' -- foo bar 'hello world' | tr -d '[:space:]')" == "3" ]]
+RUN [[ "$(./bin/syntran -c 'let a = std::args(); size(a);' -- foo bar hello world | tr -d '[:space:]')" == "4" ]]
+RUN [[ "$(./bin/syntran -c 'let a = std::args(); size(a);' -- foo bar 'hello world' | tr -d '[:space:]')" == "3" ]]
 
 # `tr` deletes all spaces, while this `sed` only removes *leading* spaces
-RUN [[ "$(./bin/syntran -c 'let a = args(); a[0];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "foo" ]]
-RUN [[ "$(./bin/syntran -c 'let a = args(); a[2];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "hello world" ]]
+RUN [[ "$(./bin/syntran -c 'let a = std::args(); a[0];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "foo" ]]
+RUN [[ "$(./bin/syntran -c 'let a = std::args(); a[2];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "hello world" ]]
 

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -79,8 +79,11 @@ RUN cd ./bin && tar czf syntran-linux.tgz *
 #===========================================================
 # Tests
 #
-# This container is kinda bulky.  Maybe I should move tests to a separate
-# dockerfile (debug build only?) for efficiency
+# This container is kinda bulky.  Since this makes the shipped syntran binary,
+# it's good to do a little extra testing here.  However, the alpine dockerfile
+# runs twice as fast (~4 s cached no changes as opposed to 8 s for rocky).  For
+# efficient development/debugging, these binary syntran command tests are in the
+# alpine dockerfile too
 
 RUN [[ "$(./bin/syntran -c '1+2;' | tr -d '[:space:]')" == "3" ]]
 RUN [[ "$(./bin/syntran -c 'sum([0:101]);' | tr -d '[:space:]')" == "5050" ]]

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -3,7 +3,6 @@ FROM rockylinux:9
 
 WORKDIR /workdir
 
-# TODO: update and install all in one line because docker can break otherwise
 RUN dnf update -y && dnf install -y \
 	vim \
 	git \

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -1,50 +1,45 @@
 
-#FROM rockylinux:8  # can't figure out how to get gfortran 11 on rocky 8 :(
 FROM rockylinux:9
 
 WORKDIR /workdir
 
+# TODO: update and install all in one line because docker can break otherwise
 RUN dnf update -y
 RUN dnf install -y vim
 RUN dnf install -y git
-#RUN dnf install -y gcc-gfortran
-#RUN dnf --enablerepo=devel install -y libgfortran-static
-
-# TODO: consider gfort 13 for static libquadmath.  if it adds a dependency on a glibc that doesn't come on base distros though, it's not worth the tradeoff.  need to test
 RUN dnf install -y gcc-toolset-13-gcc-gfortran
 
 ## Static libc.a and libm.a can also be installed, but it does not remove the dependency on libc.so etc. from syntran
 #dnf --enablerepo=crb install glibc-static -y
-
-#RUN dnf install -y curl
 
 RUN find /opt -name "gfortran"
 
 ENV PATH="$PATH:/opt/rh/gcc-toolset-13/root/usr/bin/"
 RUN gfortran --version
 
-# Copying just the src dir would usually be sufficient, but gen-header.sh needs
-# to know the git commit for `--version` output, so we have to install git and
-# clone the whole repo
-
 ADD https://github.com/fortran-lang/fpm/releases/download/current/fpm-linux-x86_64 ./fpm
-#RUN curl -LO https://github.com/fortran-lang/fpm/releases/download/current/fpm-linux-x86_64
-#RUN curl -LO https://github.com/fortran-lang/fpm/releases/download/v0.10.1/fpm-0.10.1-linux-x86_64
-#RUN mv fpm-*linux-x86_64 fpm
 
 RUN chmod +x fpm
 RUN mv fpm /usr/local/bin
 RUN fpm --version
 
-#COPY src ./src
-#COPY fpm.toml .
-#COPY gen-header.sh .
-
 ARG BRANCH="main"
 RUN echo "BRANCH = $BRANCH"
 
-RUN git clone https://github.com/jeffirwin/syntran --branch "$BRANCH"
+#RUN git clone https://github.com/jeffirwin/syntran --branch "$BRANCH"
 WORKDIR /workdir/syntran
+
+# Copying just the src dir would usually be sufficient, but gen-header.sh needs
+# to know the git commit for `--version` output, so we have to install git and
+# clone the whole repo
+ADD src ./src
+ADD .git ./.git
+ADD fpm.toml .
+ADD gen-header.sh .
+
+#COPY src ./src
+#COPY fpm.toml .
+#COPY gen-header.sh .
 
 RUN yes | fpm clean
 
@@ -70,11 +65,31 @@ RUN fpm test test --compiler gfortran --profile "$PROFILE" --link-flag "$LINK_FL
 #RUN fpm test long --compiler gfortran --profile "$PROFILE" --link-flag "$LINK_FLAG"
 RUN fpm install --prefix . --compiler gfortran --profile "$PROFILE" --link-flag "$LINK_FLAG"
 
-## Package other binary dependencies
+## Package other binary dependencies, if any
 #RUN cp /lib64/libquadmath.so.0 ./bin/
 #RUN cp /lib64/libgfortran.so.5 ./bin/
 ##RUN cp /lib64/libc.so.6 ./bin/
 ##RUN cp /lib64/libm.so.6 ./bin/
 
 RUN cd ./bin && tar czf syntran-linux.tgz *
+
+#****************
+# End installer packaging
+
+#===========================================================
+# Tests
+#
+# This container is kinda bulky.  Maybe I should move tests to a separate
+# dockerfile (debug build only?) for efficiency
+
+RUN [[ "$(./bin/syntran -c '1+2;' | tr -d '[:space:]')" == "3" ]]
+RUN [[ "$(./bin/syntran -c 'sum([0:101]);' | tr -d '[:space:]')" == "5050" ]]
+RUN [[ "$(./bin/syntran -c 'sum([0:10]**2);' | tr -d '[:space:]')" == "285" ]]
+
+RUN [[ "$(./bin/syntran -c 'let a = args(); size(a);' -- foo bar hello world | tr -d '[:space:]')" == "4" ]]
+RUN [[ "$(./bin/syntran -c 'let a = args(); size(a);' -- foo bar 'hello world' | tr -d '[:space:]')" == "3" ]]
+
+# `tr` deletes all spaces, while this `sed` only removes *leading* spaces
+RUN [[ "$(./bin/syntran -c 'let a = args(); a[0];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "foo" ]]
+RUN [[ "$(./bin/syntran -c 'let a = args(); a[2];' -- foo bar 'hello world' | sed 's/^[[:space:]]*//')" == "hello world" ]]
 

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -4,10 +4,10 @@ FROM rockylinux:9
 WORKDIR /workdir
 
 # TODO: update and install all in one line because docker can break otherwise
-RUN dnf update -y
-RUN dnf install -y vim
-RUN dnf install -y git
-RUN dnf install -y gcc-toolset-13-gcc-gfortran
+RUN dnf update -y && dnf install -y \
+	vim \
+	git \
+	gcc-toolset-13-gcc-gfortran
 
 ## Static libc.a and libm.a can also be installed, but it does not remove the dependency on libc.so etc. from syntran
 #dnf --enablerepo=crb install glibc-static -y

--- a/samples/args.syntran
+++ b/samples/args.syntran
@@ -1,8 +1,8 @@
-// Test script for argv() function
+// Test script for args() function
 //
-// Usage: syntran argv.syntran -- arg1 arg2 ...
+// Usage: syntran args.syntran -- arg1 arg2 ...
 
-let args = argv();
+let args = args();
 println("Number of arguments: ", size(args));
 
 if size(args) > 0

--- a/samples/args.syntran
+++ b/samples/args.syntran
@@ -1,6 +1,13 @@
 // Test script for std::args() function
 //
-// Usage: syntran args.syntran -- arg1 arg2 ...
+// Usage:
+//     syntran args.syntran -- arg1 arg2 ...
+//
+// Examples:
+//     syntran args.syntran -- foo bar baz
+//     syntran args.syntran -- "hello world" test
+//
+// Arguments after `--` are passed to the script. Use quotes for args with spaces.
 
 let args = std::args();
 println("Number of arguments: ", size(args));

--- a/samples/argv.syntran
+++ b/samples/argv.syntran
@@ -1,0 +1,19 @@
+// Test script for argv() function
+//
+// Usage: syntran argv.syntran -- arg1 arg2 ...
+
+let args = argv();
+println("Number of arguments: ", size(args));
+
+if size(args) > 0
+{
+    println("Arguments:");
+    for arg in args
+    {
+        println("  ", arg);
+    }
+}
+else
+{
+    println("No arguments provided (pass args after `--`)");
+}

--- a/src/app.f90
+++ b/src/app.f90
@@ -39,6 +39,9 @@ module syntran__app_m
 			version          = .false., &
 			help             = .false.
 
+		! Script arguments passed after `--`
+		type(string_vector_t) :: script_args
+
 	end type args_t
 
 contains
@@ -165,6 +168,7 @@ function parse_args() result(args)
 	! Defaults
 	args%maxerr = maxerr_def
 	args%color  = COLOR_AUTO
+	args%script_args = new_string_vector()
 
 	argc = command_argument_count()
 	!print *, "argc = ", argc
@@ -219,6 +223,14 @@ function parse_args() result(args)
 
 		case ("--version")
 			args%version = .true.
+
+		case ("--")
+			! Capture all remaining arguments as script arguments
+			do while (i < argc)
+				call get_next_arg(i, str_)
+				call args%script_args%push(str_)
+			end do
+			exit
 
 		case default
 
@@ -295,8 +307,7 @@ function parse_args() result(args)
 		! `[options]`
 
 		write(*,*) fg_bold//"Usage:"//color_reset
-		write(*,*) "    syntran <file.syntran> [--fmax-errors <n>] " &
-			//"[-i | --interactive] [-q | --quiet] [--color (auto|off|on)]"
+		write(*,*) "    syntran <file.syntran> [options] [-- <script args>...]"
 		write(*,*) "    syntran"
 		write(*,*) "    syntran -c <cmd> | --command <cmd>"
 		write(*,*) "    syntran -h | --help"
@@ -311,6 +322,7 @@ function parse_args() result(args)
 			//"error messages to <n> [default: "//str(maxerr_def)//"]"
 		write(*,*) "    -i --interactive    Interpret a file then start an interactive shell"
 		write(*,*) "    -q --quiet          Don't print the banner, only errors and println calls"
+		write(*,*) "    -- <args>...        Pass remaining arguments to the script via argv()"
 		write(*,*)
 
 		if (.not. args%help) call exit(EXIT_FAILURE)

--- a/src/app.f90
+++ b/src/app.f90
@@ -322,7 +322,7 @@ function parse_args() result(args)
 			//"error messages to <n> [default: "//str(maxerr_def)//"]"
 		write(*,*) "    -i --interactive    Interpret a file then start an interactive shell"
 		write(*,*) "    -q --quiet          Don't print the banner, only errors and println calls"
-		write(*,*) "    -- <args>...        Pass remaining arguments to the script via argv()"
+		write(*,*) "    -- <args>...        Pass remaining arguments to the script via args()"
 		write(*,*)
 
 		if (.not. args%help) call exit(EXIT_FAILURE)

--- a/src/app.f90
+++ b/src/app.f90
@@ -322,7 +322,7 @@ function parse_args() result(args)
 			//"error messages to <n> [default: "//str(maxerr_def)//"]"
 		write(*,*) "    -i --interactive    Interpret a file then start an interactive shell"
 		write(*,*) "    -q --quiet          Don't print the banner, only errors and println calls"
-		write(*,*) "    -- <args>...        Pass remaining arguments to the script via args()"
+		write(*,*) "    -- <args>...        Pass remaining arguments to script via std::args()"
 		write(*,*)
 
 		if (.not. args%help) call exit(EXIT_FAILURE)

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,14 +30,6 @@ module syntran__core_m
 		syntran_patch =  1
 
 	! TODO:
-	!  - cmd args
-	!    * useful for aoc
-	!      + switching test/real input is annoying without cmd args. must resort
-	!        to commenting/uncommenting line(s) in code
-	!    * args would be useful for logo sample, e.g. image size and some
-	!      control color options
-	!    * pass after a ` -- `?
-	!    * related: environment variables
 	!  - minloc, maxloc, findloc fns
 	!    * useful for aoc
 	!    * i'm leaning towards 2.0 instead of namespaces

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -1993,7 +1993,7 @@ recursive subroutine eval_fn_call_intr(node, state, res)
 		call syntax_eval(node%args(1), state, arg1)
 		res%sca%bool = any(arg1%array%bool)
 
-	case ("argv")
+	case ("args")
 
 		! Return script arguments passed after `--` as a string array
 		res%type = array_type

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -37,6 +37,9 @@ module syntran__eval_m
 		! nightmare if you grep for "break" and don't find "broke"
 		logical :: returned, breaked, continued
 
+		! Script arguments passed after `--` on the command line
+		type(string_vector_t) :: script_args
+
 	end type state_t
 
 !===============================================================================
@@ -1989,6 +1992,22 @@ recursive subroutine eval_fn_call_intr(node, state, res)
 
 		call syntax_eval(node%args(1), state, arg1)
 		res%sca%bool = any(arg1%array%bool)
+
+	case ("argv")
+
+		! Return script arguments passed after `--` as a string array
+		res%type = array_type
+		allocate(res%array)
+		res%array%type = str_type
+		res%array%rank = 1
+		res%array%len_ = state%script_args%len_
+		allocate(res%array%size(1))
+		res%array%size(1) = res%array%len_
+
+		allocate(res%array%str(res%array%len_))
+		do i = 1, state%script_args%len_
+			res%array%str(i) = state%script_args%v(i)
+		end do
 
 	case default
 

--- a/src/intr_fns.f90
+++ b/src/intr_fns.f90
@@ -52,7 +52,7 @@ subroutine declare_intr_fns(fns)
 		acosd_f32_fn, acosd_f64_fn, acosd_f32_arr_fn, acosd_f64_arr_fn, &
 		asind_f32_fn, asind_f64_fn, asind_f32_arr_fn, asind_f64_arr_fn, &
 		atand_f32_fn, atand_f64_fn, atand_f32_arr_fn, atand_f64_arr_fn, &
-		repeat_fn, argv_fn
+		repeat_fn, args_fn
 
 	! This used to get incremented automatically inside of fns%insert, but I
 	! changed it.  I don't think it matters for intrinsic fns anyway, because
@@ -1270,15 +1270,15 @@ subroutine declare_intr_fns(fns)
 
 	! argv() returns an array of strings containing command-line arguments
 	! passed after `--`
-	argv_fn%type%type = array_type
-	allocate(argv_fn%type%array)
-	argv_fn%type%array%type = str_type
-	argv_fn%type%array%rank = 1
+	args_fn%type%type = array_type
+	allocate(args_fn%type%array)
+	args_fn%type%array%type = str_type
+	args_fn%type%array%rank = 1
 
-	allocate(argv_fn%params(0))
-	allocate(argv_fn%param_names%v(0))
+	allocate(args_fn%params(0))
+	allocate(args_fn%param_names%v(0))
 
-	call fns%insert("argv", argv_fn, id_index)
+	call fns%insert("args", args_fn, id_index)
 
 	!********
 
@@ -1979,7 +1979,7 @@ subroutine declare_intr_fns(fns)
 			size_fn       , &
 			str_fn        , &
 			writeln_fn    , &
-			argv_fn         &
+			args_fn         &
 		]
 
 	num_fns = size(fns%fns)

--- a/src/intr_fns.f90
+++ b/src/intr_fns.f90
@@ -1268,7 +1268,7 @@ subroutine declare_intr_fns(fns)
 
 	!********
 
-	! argv() returns an array of strings containing command-line arguments
+	! args() returns an array of strings containing command-line arguments
 	! passed after `--`
 	args_fn%type%type = array_type
 	allocate(args_fn%type%array)

--- a/src/intr_fns.f90
+++ b/src/intr_fns.f90
@@ -52,7 +52,7 @@ subroutine declare_intr_fns(fns)
 		acosd_f32_fn, acosd_f64_fn, acosd_f32_arr_fn, acosd_f64_arr_fn, &
 		asind_f32_fn, asind_f64_fn, asind_f32_arr_fn, asind_f64_arr_fn, &
 		atand_f32_fn, atand_f64_fn, atand_f32_arr_fn, atand_f64_arr_fn, &
-		repeat_fn
+		repeat_fn, argv_fn
 
 	! This used to get incremented automatically inside of fns%insert, but I
 	! changed it.  I don't think it matters for intrinsic fns anyway, because
@@ -1268,6 +1268,20 @@ subroutine declare_intr_fns(fns)
 
 	!********
 
+	! argv() returns an array of strings containing command-line arguments
+	! passed after `--`
+	argv_fn%type%type = array_type
+	allocate(argv_fn%type%array)
+	argv_fn%type%array%type = str_type
+	argv_fn%type%array%rank = 1
+
+	allocate(argv_fn%params(0))
+	allocate(argv_fn%param_names%v(0))
+
+	call fns%insert("argv", argv_fn, id_index)
+
+	!********
+
 	! TODO: add fns for parsing str to other types (bool, etc.)
 
 	! Should this accept any type?  f32 can be converted implicitly so there
@@ -1964,7 +1978,8 @@ subroutine declare_intr_fns(fns)
 			readln_fn     , &
 			size_fn       , &
 			str_fn        , &
-			writeln_fn      &
+			writeln_fn    , &
+			argv_fn         &
 		]
 
 	num_fns = size(fns%fns)

--- a/src/intr_fns.f90
+++ b/src/intr_fns.f90
@@ -1269,7 +1269,7 @@ subroutine declare_intr_fns(fns)
 	!********
 
 	! std::args() returns an array of strings containing command-line arguments
-	! passed after `--`.  This is a std-only function: it must be called as
+	! passed after `--`.  This is an std-only function: it must be called as
 	! std::args(), not just args()
 	args_fn%type%type = array_type
 	allocate(args_fn%type%array)

--- a/src/main.f90
+++ b/src/main.f90
@@ -37,16 +37,18 @@ program main
 		! workspace after running a startup file
 		!
 		! TODO: add a test that covers a "-i" interactive run
-		res = syntran_interpret(startup_file = args%syntran_file)
+		res = syntran_interpret(startup_file = args%syntran_file, &
+			script_args = args%script_args)
 
 	else if (args%syntran_file_arg) then
 		! Interpret a file and exit
-		res = syntran_interpret_file(args%syntran_file, quiet_info = args%quiet)
+		res = syntran_interpret_file(args%syntran_file, quiet_info = args%quiet, &
+			script_args = args%script_args)
 		if (.not. args%quiet) write(*,*) '    '//res
 
 	else if (args%command_arg) then
 		! Interpret a cmd arg string
-		res = syntran_eval(args%command)
+		res = syntran_eval(args%command, script_args = args%script_args)
 		if (.not. args%quiet) write(*,*) '    '//res
 
 		! python -c command doesn't print anything unless you call print()
@@ -54,7 +56,7 @@ program main
 
 	else
 		! Start a clean interactive REPL shell (without any startup file)
-		res = syntran_interpret()
+		res = syntran_interpret(script_args = args%script_args)
 
 	end if
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -158,7 +158,7 @@ recursive module function parse_fn_call(parser, module_prefix, identifier) resul
 	!print *, "fn id_index = ", id_index
 	if (io /= exit_success) then
 
-		! Check if this is a std-only function that requires the std:: prefix.
+		! Check if this is an std-only function that requires the std:: prefix.
 		! Do this before the ipass==0 early return so the type is set correctly
 		! in both passes, preventing cascading errors.
 		if (.not. present(module_prefix)) then

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -158,22 +158,32 @@ recursive module function parse_fn_call(parser, module_prefix, identifier) resul
 	!print *, "fn id_index = ", id_index
 	if (io /= exit_success) then
 
+		! Check if this is a std-only function that requires the std:: prefix.
+		! Do this before the ipass==0 early return so the type is set correctly
+		! in both passes, preventing cascading errors.
+		if (.not. present(module_prefix)) then
+			fn = parser%fns%search("std::" // fn_call%identifier%text, id_index, io_std)
+			if (io_std == exit_success) then
+				! Set the return type from the found function to prevent
+				! cascading errors from the untyped result
+				fn_call%val = fn%type
+				fn_call%kind = fn_call_intr_expr
+
+				! Only push the error in pass 1
+				if (parser%ipass /= 0) then
+					span = new_span(identifier_%pos, len(identifier_%text))
+					call parser%diagnostics%push( &
+						err_std_only_fn(parser%context(), &
+						span, identifier_%text))
+				end if
+				return
+			end if
+		end if
+
 		if (parser%ipass == 0) then
 			fn_call%id_index = 0
 			fn_call%kind = fn_call_expr
 			return
-		end if
-
-		! Check if this is a std-only function that requires the std:: prefix
-		if (.not. present(module_prefix)) then
-			fn = parser%fns%search("std::" // fn_call%identifier%text, id_index, io_std)
-			if (io_std == exit_success) then
-				span = new_span(identifier_%pos, len(identifier_%text))
-				call parser%diagnostics%push( &
-					err_std_only_fn(parser%context(), &
-					span, identifier_%text))
-				return
-			end if
 		end if
 
 		span = new_span(identifier_%pos, len(identifier_%text))

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -17,7 +17,7 @@ contains
 
 !===============================================================================
 
-function syntran_interpret(str_, quiet, startup_file) result(res_str)
+function syntran_interpret(str_, quiet, startup_file, script_args) result(res_str)
 
 	! This is the interactive interpreter shell REPL
 	!
@@ -37,6 +37,7 @@ function syntran_interpret(str_, quiet, startup_file) result(res_str)
 	character(len = *), intent(in), optional :: str_
 	logical, intent(in), optional :: quiet
 	character(len = *), intent(in), optional :: startup_file
+	type(string_vector_t), optional, intent(in) :: script_args
 
 	character(len = :), allocatable :: res_str
 
@@ -75,7 +76,7 @@ function syntran_interpret(str_, quiet, startup_file) result(res_str)
 	end if
 	!print *, "src_file = ", src_file
 
-	call init_state(state)
+	call init_state(state, script_args)
 	state%quiet = .false.
 	if (present(quiet)) state%quiet = quiet
 
@@ -348,7 +349,7 @@ end function syntran_eval_f64
 
 !===============================================================================
 
-subroutine init_state(state)
+subroutine init_state(state, script_args)
 
 	! TODO: move to eval.f90
 
@@ -359,6 +360,7 @@ subroutine init_state(state)
 	! could be a class-bound procedure
 
 	type(state_t), intent(inout) :: state
+	type(string_vector_t), intent(in), optional :: script_args
 
 	call declare_intr_fns(state%fns)
 
@@ -375,13 +377,20 @@ subroutine init_state(state)
 	state%locs%scope_cap = SCOPE_CAP_INIT
 	allocate(state%locs%dicts( state%locs%scope_cap) )
 
+	! Script arguments passed after `--`
+	if (present(script_args)) then
+		state%script_args = script_args
+	else
+		state%script_args = new_string_vector()
+	end if
+
 	!print *, "init size fns = ", size(state%fns%fns)
 
 end subroutine init_state
 
 !===============================================================================
 
-function syntran_eval(str_, quiet, src_file, chdir_) result(res)
+function syntran_eval(str_, quiet, src_file, chdir_, script_args) result(res)
 
 	! Note that this chdir_ optional arg is a str_, while the chdir_ optional arg
 	! for syntran_interpret_file() is boolean
@@ -395,6 +404,7 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 	logical, optional, intent(in) :: quiet
 	character(len = *), optional, intent(in) :: src_file
 	character(len = *), optional, intent(in) :: chdir_
+	type(string_vector_t), optional, intent(in) :: script_args
 
 	!********
 
@@ -410,7 +420,7 @@ function syntran_eval(str_, quiet, src_file, chdir_) result(res)
 	!print *, ''
 	!print *, 'str_ = ', str_
 
-	call init_state(state)
+	call init_state(state, script_args)
 	state%quiet = .false.
 	if (present(quiet)) state%quiet = quiet
 
@@ -475,7 +485,7 @@ end function syntran_eval
 
 !===============================================================================
 
-function syntran_interpret_file(filename, quiet, quiet_info, chdir_) result(res)
+function syntran_interpret_file(filename, quiet, quiet_info, chdir_, script_args) result(res)
 
 	! TODO:
 	!   - enable input echo for file input (not for stdin)
@@ -500,6 +510,8 @@ function syntran_interpret_file(filename, quiet, quiet_info, chdir_) result(res)
 	logical, optional, intent(in) :: quiet, quiet_info
 
 	logical, optional, intent(in) :: chdir_
+
+	type(string_vector_t), optional, intent(in) :: script_args
 
 	!********
 
@@ -533,9 +545,10 @@ function syntran_interpret_file(filename, quiet, quiet_info, chdir_) result(res)
 
 	if (chdirl) then
 		res = trim(adjustl(syntran_eval(source_text, state%quiet, filename, &
-			chdir_ = get_dir(filename))))
+			chdir_ = get_dir(filename), script_args = script_args)))
 	else
-		res = trim(adjustl(syntran_eval(source_text, state%quiet, filename)))
+		res = trim(adjustl(syntran_eval(source_text, state%quiet, filename, &
+			script_args = script_args)))
 	end if
 
 end function syntran_interpret_file

--- a/src/tests/core.f90
+++ b/src/tests/core.f90
@@ -14,11 +14,26 @@ module syntran__test_core_m
 		eval_f64  => syntran_eval_f64
 
 	use syntran__utils_m, only: fg_bright_red, fg_bright_green, line_feed, &
-		findlocl1, console_color, console_color_reset
+		findlocl1, console_color, console_color_reset, &
+		string_vector_t, new_string_vector
 
 	implicit none
 
 contains
+
+!===============================================================================
+
+function eval_with_args(str_, script_args) result(res)
+
+	! Evaluate a syntran string with script arguments (for testing args())
+
+	character(len = *), intent(in) :: str_
+	type(string_vector_t), intent(in) :: script_args
+	character(len = :), allocatable :: res
+
+	res = eval(str_, script_args = script_args)
+
+end function eval_with_args
 
 !===============================================================================
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4615,6 +4615,67 @@ end subroutine unit_test_bad_syntax
 
 !===============================================================================
 
+subroutine unit_test_args(npass, nfail)
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'args() intrinsic function'
+
+	logical, allocatable :: tests(:)
+	type(string_vector_t) :: script_args
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	! Test with no arguments
+	script_args = new_string_vector()
+	tests = &
+		[   &
+			eval_with_args('size(args());', script_args) == '0', &
+			eval_with_args('let a = args(); size(a);', script_args) == '0' &
+		]
+	call unit_test_coda(tests, label//' (empty)', npass, nfail)
+
+	! Test with arguments
+	script_args = new_string_vector()
+	call script_args%push('hello')
+	call script_args%push('world')
+	call script_args%push('42')
+
+	tests = &
+		[   &
+			eval_with_args('size(args());', script_args) == '3', &
+			eval_with_args('args()[0];', script_args) == 'hello', &
+			eval_with_args('args()[1];', script_args) == 'world', &
+			eval_with_args('args()[2];', script_args) == '42', &
+			eval_with_args('let a = args(); a[0];', script_args) == 'hello', &
+			eval_with_args('let a = args(); a[1];', script_args) == 'world', &
+			eval_with_args('let a = args(); a[2];', script_args) == '42', &
+			eval_with_args('let a = args(); size(a);', script_args) == '3' &
+		]
+	call unit_test_coda(tests, label//' (with args)', npass, nfail)
+
+	! Test with string containing spaces
+	script_args = new_string_vector()
+	call script_args%push('hello world')
+	call script_args%push('foo bar baz')
+
+	tests = &
+		[   &
+			eval_with_args('size(args());', script_args) == '2', &
+			eval_with_args('args()[0];', script_args) == 'hello world', &
+			eval_with_args('args()[1];', script_args) == 'foo bar baz', &
+			eval_with_args('len(args()[0]);', script_args) == '11' &
+		]
+	call unit_test_coda(tests, label//' (with spaces)', npass, nfail)
+
+end subroutine unit_test_args
+
+!===============================================================================
+
 subroutine unit_tests(iostat)
 
 	implicit none
@@ -4685,6 +4746,7 @@ subroutine unit_tests(iostat)
 	call unit_test_bitwise_2  (npass, nfail)
 	call unit_test_ref        (npass, nfail)
 	call unit_test_recursion  (npass, nfail)
+	call unit_test_args       (npass, nfail)
 
 	! TODO: add tests that mock interpreting one line at a time (as opposed to
 	! whole files)

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4648,9 +4648,6 @@ subroutine unit_test_args(npass, nfail)
 	tests = &
 		[   &
 			eval_with_args('size(args());', script_args) == '3', &
-			eval_with_args('args()[0];', script_args) == 'hello', &
-			eval_with_args('args()[1];', script_args) == 'world', &
-			eval_with_args('args()[2];', script_args) == '42', &
 			eval_with_args('let a = args(); a[0];', script_args) == 'hello', &
 			eval_with_args('let a = args(); a[1];', script_args) == 'world', &
 			eval_with_args('let a = args(); a[2];', script_args) == '42', &
@@ -4666,9 +4663,9 @@ subroutine unit_test_args(npass, nfail)
 	tests = &
 		[   &
 			eval_with_args('size(args());', script_args) == '2', &
-			eval_with_args('args()[0];', script_args) == 'hello world', &
-			eval_with_args('args()[1];', script_args) == 'foo bar baz', &
-			eval_with_args('len(args()[0]);', script_args) == '11' &
+			eval_with_args('let a = args(); a[0];', script_args) == 'hello world', &
+			eval_with_args('let a = args(); a[1];', script_args) == 'foo bar baz', &
+			eval_with_args('let a = args(); len(a[0]);', script_args) == '11' &
 		]
 	call unit_test_coda(tests, label//' (with spaces)', npass, nfail)
 


### PR DESCRIPTION
## Summary
- Add `std::args()` function that returns command-line arguments passed after `--` as a string array
- This is an **std-only function**: must be called as `std::args()`, not just `args()`
- Users can define their own `args()` functions without conflict

## Usage
```
syntran myscript.syntran -- arg1 arg2 "hello world"
```

```rust
let args = std::args();
println("Number of arguments: ", size(args));
for arg in args {
    println("  ", arg);
}
```

## Design
- New intrinsics going forward require the `std::` prefix
- Legacy 1.0 intrinsics (println, size, etc.) remain callable with or without `std::`
- Calling `args()` without `std::` gives a helpful error message

## Test plan
- [x] Unit tests via `eval_with_args()` for std::args()
- [x] Test user-defined args() function works
- [x] Test coexistence of std::args() and user-defined args()
- [x] Docker tests with actual command-line arguments
- [x] All 2060 unit tests pass