### PR TITLE
Add basic namespace/module support with std:: and use statements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ fpm run --profile debug -- src/tests/test-src/modules/test-01.syntran
 ```
 
 ### Evaluating a script as a command-line string
-To run a syntran script without having it saved as a file:
+To run a syntran script without saving it as a file:
 ```bash
 fpm run -- -c 'println(\"hello world\");'
 ```
@@ -58,6 +58,8 @@ The interpreter follows a classic lexer → parser → evaluator pipeline, imple
 - `src/eval.f90` - AST evaluation/interpretation
 - `src/types.f90` - Fortran type definitions
 - `src/value.f90` - Runtime value representation
+- `src/errors.f90` - Syntran error messages
+- `src/intr_fns.f90` - Intrinsic (built-in) function interfaces
 
 ### Math Operations (auto-generated)
 Binary arithmetic operations are generated from `src/math_bin_template.f90` via `src/gen_math.sh`:
@@ -82,7 +84,12 @@ Module paths in `use` statements are resolved relative to the current source fil
 
 ## Key Source Locations
 
-- `src/tests/test-src/` - Syntran script test files by category
+- `src/tests/test.f90` - Unit test orchestrator
+- `src/tests/test-src/` - Syntran script unit test files by category
 - `src/tests/long/aoc/` - Longer integration tests
 - `samples/` - Example syntran programs (not tested in CI)
 - `doc/README.md` - Intrinsic function documentation
+
+New features and bug fixes should have unit tests.
+Short syntran program strings can be evaluated directly in `test.f90`.
+Anything longer than a few lines can go in a `*.syntran` file under `test-src`, but it needs to be called using `interpret_file()` in `test.f90`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Syntran
+
+Syntran is an array-oriented programming language with an interpreter written in Fortran. It's similar to MATLAB but with curly braces, type checking, and zero-indexed arrays. The name is a portmanteau of "syntax translator" (like FORTRAN = formula translator).
+
+## Build Commands
+
+Two build systems are supported: CMake and FPM (Fortran Package Manager).
+
+### CMake (primary)
+```bash
+./build.sh           # Debug build (default)
+./build.sh release   # Release build
+```
+Binary output: `./build/Debug/syntran` or `./build/Release/syntran`
+
+### FPM
+```bash
+fpm build                   # Debug build
+fpm build --profile release # Release build
+fpm run                     # Build and run interpreter
+fpm run -- file.syntran     # Run a syntran file
+```
+
+## Running Tests
+
+### Short tests (quick)
+```bash
+fpm test test       # FPM: run short tests only
+./build/Debug/test  # CMake: run test executable
+```
+
+### Long tests (Advent of Code solutions)
+```bash
+fpm test long       # Takes longer, tests AOC solutions
+```
+
+### Running a single test file
+Syntran script tests are in `src/tests/test-src/` organized by category. To run one:
+```bash
+./build/Debug/syntran src/tests/test-src/modules/test-01.syntran
+```
+
+## Architecture Overview
+
+The interpreter follows a classic lexer → parser → evaluator pipeline, implemented in Fortran modules:
+
+### Core Pipeline
+- `src/lex.f90` - Lexical analysis (tokenization)
+- `src/parse.f90` - Main parser orchestration
+- `src/parse_*.f90` - Parser submodules:
+  - `parse_expr.f90` - Expression parsing
+  - `parse_control.f90` - Control flow (if/while/for) and **module imports (`use` statements)**
+  - `parse_fn.f90` - Function declarations
+  - `parse_array.f90` - Array syntax
+  - `parse_misc.f90` - Preprocessing (`#include`) and other misc parsing
+- `src/eval.f90` - AST evaluation/interpretation
+- `src/types.f90` - Type system definitions
+- `src/value.f90` - Runtime value representation
+
+### Math Operations (auto-generated)
+Binary arithmetic operations are generated from `src/math_bin_template.f90` via `src/gen_math.sh`:
+- `src/math_bin_add.f90`, `math_bin_subtract.f90`, `math_bin_mul.f90`, `math_bin_div.f90`, `math_bin_pow.f90`
+
+Bitwise operations follow the same pattern in `src/math_bit_*.f90`.
+
+### Public API
+- `src/syntran.f90` - Public API module (REPL, file interpretation)
+- `src/core.f90` - Internal core module that pulls together all submodules
+
+### Entry Points
+- `src/main.f90` - CLI entry point
+- `src/app.f90` - Application-level utilities (argument parsing, etc.)
+
+## Module Import System
+
+Module paths in `use` statements are resolved relative to the current source file's directory. Supported syntax:
+- `use mymodule;` - Qualified import from same directory
+- `use mymodule::*;` - Unqualified glob import
+- `use math/vectors;` - Subdirectory import (becomes `math::vectors::fn`)
+
+**Note:** Parent directory references (`../`) are NOT supported for `use` statements, but ARE supported for `#include()` directives.
+
+## Key Source Locations
+
+- `src/tests/test-src/` - Syntran script test files by category
+- `src/tests/long/aoc/` - Advent of Code solutions used as integration tests
+- `samples/` - Example syntran programs (not tested in CI)
+- `doc/README.md` - Intrinsic function documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,45 +4,43 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Syntran
 
-Syntran is an array-oriented programming language with an interpreter written in Fortran. It's similar to MATLAB but with curly braces, type checking, and zero-indexed arrays. The name is a portmanteau of "syntax translator" (like FORTRAN = formula translator).
+Syntran is an array-oriented programming language with an interpreter written in Fortran. It's similar to MATLAB but with curly braces, type checking, and zero-indexed arrays.
 
 ## Build Commands
 
-Two build systems are supported: CMake and FPM (Fortran Package Manager).
-
-### CMake (primary)
-```bash
-./build.sh           # Debug build (default)
-./build.sh release   # Release build
-```
-Binary output: `./build/Debug/syntran` or `./build/Release/syntran`
+Two build systems are supported: FPM (Fortran Package Manager) and CMake.
 
 ### FPM
 ```bash
-fpm build                   # Debug build
+fpm build --profile debug   # Debug build, preferred for development
 fpm build --profile release # Release build
-fpm run                     # Build and run interpreter
-fpm run -- file.syntran     # Run a syntran file
+fpm run --profile debug     # Build and run interpreter
+fpm run --profile debug -- file.syntran     # Run a syntran file
+yes | fpm clean             # Clean build artifacts
 ```
 
 ## Running Tests
 
 ### Short tests (quick)
 ```bash
-fpm test test       # FPM: run short tests only
-./build/Debug/test  # CMake: run test executable
+fpm test test --profile debug      # FPM: run short tests only
 ```
 
-### Long tests (Advent of Code solutions)
-```bash
-fpm test long       # Takes longer, tests AOC solutions
-```
+Commands like `fpm test` and `fpm run` automatically invoke `fpm build`, so
+there's no need to manually build first.
 
 ### Running a single test file
 Syntran script tests are in `src/tests/test-src/` organized by category. To run one:
 ```bash
-./build/Debug/syntran src/tests/test-src/modules/test-01.syntran
+fpm run --profile debug -- src/tests/test-src/modules/test-01.syntran
 ```
+
+### Evaluating a script as a command-line string
+To run a syntran script without having it saved as a file:
+```bash
+fpm run -- -c 'println(\"hello world\");'
+```
+FPM requires escaping quotes within command arguments.
 
 ## Architecture Overview
 
@@ -58,7 +56,7 @@ The interpreter follows a classic lexer → parser → evaluator pipeline, imple
   - `parse_array.f90` - Array syntax
   - `parse_misc.f90` - Preprocessing (`#include`) and other misc parsing
 - `src/eval.f90` - AST evaluation/interpretation
-- `src/types.f90` - Type system definitions
+- `src/types.f90` - Fortran type definitions
 - `src/value.f90` - Runtime value representation
 
 ### Math Operations (auto-generated)
@@ -69,7 +67,7 @@ Bitwise operations follow the same pattern in `src/math_bit_*.f90`.
 
 ### Public API
 - `src/syntran.f90` - Public API module (REPL, file interpretation)
-- `src/core.f90` - Internal core module that pulls together all submodules
+- `src/core.f90` - Internal core module that pulls together all other modules
 
 ### Entry Points
 - `src/main.f90` - CLI entry point
@@ -82,11 +80,9 @@ Module paths in `use` statements are resolved relative to the current source fil
 - `use mymodule::*;` - Unqualified glob import
 - `use math/vectors;` - Subdirectory import (becomes `math::vectors::fn`)
 
-**Note:** Parent directory references (`../`) are NOT supported for `use` statements, but ARE supported for `#include()` directives.
-
 ## Key Source Locations
 
 - `src/tests/test-src/` - Syntran script test files by category
-- `src/tests/long/aoc/` - Advent of Code solutions used as integration tests
+- `src/tests/long/aoc/` - Longer integration tests
 - `samples/` - Example syntran programs (not tested in CI)
 - `doc/README.md` - Intrinsic function documentation

--- a/src/consts.f90
+++ b/src/consts.f90
@@ -22,6 +22,8 @@ module syntran__consts_m
 	! Token and syntax node kinds enum.  Is there a better way to do this that
 	! allows re-ordering enums?  Currently it would break kind_name()
 	integer, parameter ::          &
+			use_keyword           = 120, &
+			double_colon_token    = 119, &
 			arr_sub               = 118, &
 			pipe_equals_token     = 117, &
 			caret_equals_token    = 116, &
@@ -272,6 +274,8 @@ function kind_token(kind)
 			"^=                   ", & ! 116
 			"|=                   ", & ! 117
 			"arr_sub              ", & ! 118
+			"::                   ", & ! 119
+			"use                  ", & ! 120
 			"unknown              "  & ! inf
 		]
 
@@ -411,6 +415,8 @@ function kind_name(kind)
 			"caret_equals_token   ", & ! 116
 			"pipe_equals_token    ", & ! 117
 			"arr_sub              ", & ! 118
+			"double_colon_token   ", & ! 119
+			"use_keyword          ", & ! 120
 			"unknown              "  & ! inf (trailing comma hack)
 		]
 			! FIXME: update kind_tokens array too

--- a/src/core.f90
+++ b/src/core.f90
@@ -433,7 +433,7 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	!********
 
-	character(len = :), allocatable :: src_filel, fn_name
+	character(len = :), allocatable :: src_filel, fn_name, var_name
 
 	integer :: i, io, dummy, unit_
 
@@ -443,6 +443,7 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	type(fn_t) :: fn
 	type(fns_t) :: fns0
+	type(value_t) :: var_val
 
 	! This no longer seems to make a difference.  Previously, without `save`,
 	! gfortran crashes when this goes out of scope.  Maybe I need to work on a
@@ -723,6 +724,16 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	end do
 	!print *, "done looking up fns"
+
+	! Initialize module variables in vars%vals with their types from the dict.
+	! This is needed because module let statements are not evaluated (only parsed).
+	do i = 1, parser%var_names%len_
+		var_name = parser%var_names%v(i)%s
+		call vars%search(var_name, dummy, io, var_val)
+		if (io == exit_success .and. dummy >= 1 .and. dummy <= size(vars%vals)) then
+			vars%vals(dummy) = var_val
+		end if
+	end do
 
 	!if (allocated(parser%structs)) then
 	!	! TODO: manually finalize recursively?

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,6 +30,11 @@ module syntran__core_m
 		syntran_patch =  1
 
 	! TODO:
+	!  - what happens if you use the same module twice? same form both times or
+	!    mix qualified and unqualified?
+	!  - module variables don't work -- it segfaults
+	!  - i like claude's "double_colon_token" name. i should change things like
+	!    "sstar_token", "pplus_token", etc. to "double_star_token" ...
 	!  - if you try to return something (e.g. i32) from a void/null fn, the
 	!    error says the fn should return "unknown" but it should say void (or
 	!    null?)
@@ -37,6 +42,7 @@ module syntran__core_m
 	!    * potentially important for resolving name clashes when you're using
 	!      someone else's library, but you don't want to change the names they
 	!      chose
+	!  - document modules in readme, recommend over #include
 	!  - cmd args
 	!    * useful for aoc
 	!      + switching test/real input is annoying without cmd args. must resort

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,6 +30,13 @@ module syntran__core_m
 		syntran_patch =  1
 
 	! TODO:
+	!  - if you try to return something (e.g. i32) from a void/null fn, the
+	!    error says the fn should return "unknown" but it should say void (or
+	!    null?)
+	!  - "use module as alias;"
+	!    * potentially important for resolving name clashes when you're using
+	!      someone else's library, but you don't want to change the names they
+	!      chose
 	!  - cmd args
 	!    * useful for aoc
 	!      + switching test/real input is annoying without cmd args. must resort

--- a/src/core.f90
+++ b/src/core.f90
@@ -30,9 +30,13 @@ module syntran__core_m
 		syntran_patch =  1
 
 	! TODO:
+	!  - module arrays don't work, structs probably don't work either
+	!    * scope is creeping well beyond the immediate need of avoiding std fn
+	!      clashes. maybe hold off on this
+	!    * module let statements are not evaluated, only parsed. could this
+	!      cause evaluation problems? maybe just handle it like includes
 	!  - what happens if you use the same module twice? same form both times or
 	!    mix qualified and unqualified?
-	!  - module variables don't work -- it segfaults
 	!  - i like claude's "double_colon_token" name. i should change things like
 	!    "sstar_token", "pplus_token", etc. to "double_star_token" ...
 	!  - if you try to return something (e.g. i32) from a void/null fn, the

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -382,6 +382,18 @@ function err_redeclare_fn(context, span, fn) result(err)
 
 end function err_redeclare_fn
 
+function err_redeclare_intr_fn(context, span, fn) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: fn
+	err = err_prefix &
+		//'function `'//fn//'` is already a built-in function' &
+		//underline(context, span)//" function already exists"//color_reset
+
+end function err_redeclare_intr_fn
+
 !===============================================================================
 
 function err_redeclare_struct(context, span, struct) result(err)
@@ -1152,21 +1164,6 @@ function err_mod_read(context, span, filename) result(err)
 		//" cannot read file"//color_reset
 
 end function err_mod_read
-
-!===============================================================================
-
-function err_shadow_intr(context, span, fn_name) result(err)
-	type(text_context_t) :: context
-	type(text_span_t), intent(in) :: span
-	character(len = :), allocatable :: err
-
-	character(len = *), intent(in) :: fn_name
-	err = err_prefix &
-		//'module function `'//fn_name//'` shadows intrinsic function' &
-		//underline(context, span) &
-		//" cannot shadow intrinsic"//color_reset
-
-end function err_shadow_intr
 
 !===============================================================================
 

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -1155,6 +1155,21 @@ end function err_mod_read
 
 !===============================================================================
 
+function err_shadow_intr(context, span, fn_name) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: fn_name
+	err = err_prefix &
+		//'module function `'//fn_name//'` shadows intrinsic function' &
+		//underline(context, span) &
+		//" cannot shadow intrinsic"//color_reset
+
+end function err_shadow_intr
+
+!===============================================================================
+
 function err_404(filename) result(err)
 	character(len = *), intent(in) :: filename
 	character(len = :), allocatable :: err

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -1125,6 +1125,36 @@ end function err_inc_read
 
 !===============================================================================
 
+function err_mod_404(context, span, filename) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: filename
+	err = err_prefix &
+		//'module file `'//filename//'` not found' &
+		//underline(context, span) &
+		//" file not found"//color_reset
+
+end function err_mod_404
+
+!===============================================================================
+
+function err_mod_read(context, span, filename) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: filename
+	err = err_prefix &
+		//'module file `'//filename//'` cannot be read' &
+		//underline(context, span) &
+		//" cannot read file"//color_reset
+
+end function err_mod_read
+
+!===============================================================================
+
 function err_404(filename) result(err)
 	character(len = *), intent(in) :: filename
 	character(len = :), allocatable :: err

--- a/src/intr_fns.f90
+++ b/src/intr_fns.f90
@@ -1975,6 +1975,29 @@ end subroutine declare_intr_fns
 
 !===============================================================================
 
+logical function is_overloaded_intr(fn_name)
+
+	! Check if a function name is an overloaded intrinsic function.
+	! These are intrinsics that have type-specific implementations
+	! (e.g., "dot" -> "0dot_i32", "0dot_f32", etc.)
+
+	character(len = *), intent(in) :: fn_name
+
+	select case (fn_name)
+	case ("exp", "log", "log10", "log2", "sqrt", "abs", &
+		"cos", "sin", "tan", "cosd", "sind", "tand", &
+		"acos", "asin", "atan", "acosd", "asind", "atand", &
+		"min", "max", "i32", "i64", &
+		"sum", "minval", "maxval", "product", "norm2", "dot")
+		is_overloaded_intr = .true.
+	case default
+		is_overloaded_intr = .false.
+	end select
+
+end function is_overloaded_intr
+
+!===============================================================================
+
 recursive subroutine resolve_overload(args, fn_call, has_rank)
 
 	! Resolve special overloaded intrinsic fns

--- a/src/intr_fns.f90
+++ b/src/intr_fns.f90
@@ -1980,6 +1980,9 @@ logical function is_overloaded_intr(fn_name)
 	! Check if a function name is an overloaded intrinsic function.
 	! These are intrinsics that have type-specific implementations
 	! (e.g., "dot" -> "0dot_i32", "0dot_f32", etc.)
+	!
+	! This list must be kept in sync with the cases in resolve_overload() below.
+	! If a new overloaded intrinsic is added there, add it here too.
 
 	character(len = *), intent(in) :: fn_name
 

--- a/src/lex.f90
+++ b/src/lex.f90
@@ -771,7 +771,12 @@ function lex(lexer) result(token)
 			token = new_token(rbracket_token, lexer%pos, lexer%current())
 
 		case (":")
-			token = new_token(colon_token, lexer%pos, lexer%current())
+			if (lexer%lookahead() == ":") then
+				lexer%pos = lexer%pos + 1
+				token = new_token(double_colon_token, lexer%pos, "::")
+			else
+				token = new_token(colon_token, lexer%pos, lexer%current())
+			end if
 
 		case (";")
 			token = new_token(semicolon_token, lexer%pos, lexer%current())

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -90,6 +90,7 @@ module syntran__parse_m
 				parse_return_statement, &
 				parse_break_statement, &
 				parse_continue_statement, &
+				parse_use_statement, &
 				parse_name_expr, &
 				parse_primary_expr, &
 				parse_size, &
@@ -197,6 +198,11 @@ module syntran__parse_m
 			class(parser_t) :: parser
 			type(syntax_node_t) :: statement
 		end function parse_continue_statement
+
+		module function parse_use_statement(parser) result(statement)
+			class(parser_t) :: parser
+			type(syntax_node_t) :: statement
+		end function parse_use_statement
 
 		recursive module function parse_for_statement(parser) result(statement)
 			class(parser_t) :: parser

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -46,6 +46,7 @@ module syntran__parse_m
 		type(fns_t) :: fns
 		integer :: num_fns = 0
 		type(string_vector_t) :: fn_names
+		type(string_vector_t) :: var_names  ! track module-level variable names
 
 		type(structs_t) :: structs
 		integer :: num_structs = 0

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -82,6 +82,7 @@ module syntran__parse_m
 				parse_expr_statement, &
 				parse_fn_declaration, &
 				parse_fn_call, &
+				parse_qualified_expr, &
 				parse_struct_declaration, &
 				parse_struct_instance, &
 				parse_for_statement, &
@@ -124,6 +125,11 @@ module syntran__parse_m
 			class(parser_t) :: parser
 			type(syntax_node_t) :: fn_call
 		end function parse_fn_call
+
+		recursive module function parse_qualified_expr(parser) result(expr)
+			class(parser_t) :: parser
+			type(syntax_node_t) :: expr
+		end function parse_qualified_expr
 
 		module subroutine parse_type(parser, type_text, type)
 			class(parser_t) :: parser

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -122,8 +122,10 @@ module syntran__parse_m
 			type(syntax_node_t) :: decl
 		end function parse_fn_declaration
 
-		recursive module function parse_fn_call(parser) result(fn_call)
+		recursive module function parse_fn_call(parser, module_prefix, identifier) result(fn_call)
 			class(parser_t) :: parser
+			character(len = *), intent(in), optional :: module_prefix
+			type(syntax_token_t), intent(in), optional :: identifier
 			type(syntax_node_t) :: fn_call
 		end function parse_fn_call
 

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -139,6 +139,13 @@ module function parse_use_statement(parser) result(statement)
 	mod_identifier = parser%match(identifier_token)
 	module_name = mod_identifier%text
 
+	! Handle module paths with slashes (e.g., `use math/vectors::*;`)
+	do while (parser%current_kind() == slash_token)
+		star = parser%match(slash_token)  ! reuse star token variable
+		name_identifier = parser%match(identifier_token)
+		module_name = module_name // "/" // name_identifier%text
+	end do
+
 	! Check for `use module;` (qualified import) vs `use module::*;` (glob import)
 	if (parser%current_kind() == double_colon_token) then
 		double_colon = parser%match(double_colon_token)

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -150,6 +150,14 @@ module function parse_use_statement(parser) result(statement)
 		module_path = module_path // "../"
 	end do
 
+	! Handle current directory reference (e.g., `use ./module;`)
+	if (parser%current_kind() == dot_token .and. &
+	    parser%peek_kind(1) == slash_token) then
+		star = parser%match(dot_token)
+		star = parser%match(slash_token)
+		module_path = module_path // "./"
+	end if
+
 	mod_identifier = parser%match(identifier_token)
 	module_name = mod_identifier%text
 	module_path = module_path // module_name

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -112,13 +112,18 @@ end function parse_continue_statement
 
 module function parse_use_statement(parser) result(statement)
 
-	! Parse `use module::name;` or `use module::*;`
+	! Parse `use module;` or `use module::*;` or `use module::name;`
+	!
+	! - `use module;`       imports functions as module::fn (qualified access)
+	! - `use module::*;`    imports all functions as fn (unqualified access)
+	! - `use module::name;` imports specific function as name (unqualified)
 
 	class(parser_t) :: parser
 	type(syntax_node_t) :: statement
 	!********
 	character(len = :), allocatable :: module_name, import_name
 	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
+	character(len = :), allocatable :: insert_name
 	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
 		name_identifier, semi, star
 	type(text_span_t) :: span
@@ -127,21 +132,30 @@ module function parse_use_statement(parser) result(statement)
 	type(text_context_vector_t) :: mod_contexts
 	type(fn_t) :: fn
 	integer :: i, io, iostat, mod_unit_
+	logical :: qualified_import
 
 	use_token = parser%match(use_keyword)
 
 	mod_identifier = parser%match(identifier_token)
 	module_name = mod_identifier%text
 
-	double_colon = parser%match(double_colon_token)
+	! Check for `use module;` (qualified import) vs `use module::*;` (glob import)
+	if (parser%current_kind() == double_colon_token) then
+		double_colon = parser%match(double_colon_token)
 
-	! Check for glob import (use module::*)
-	if (parser%current_kind() == star_token) then
-		star = parser%match(star_token)
-		import_name = "*"
+		! Check for glob import (use module::*)
+		if (parser%current_kind() == star_token) then
+			star = parser%match(star_token)
+			import_name = "*"
+		else
+			name_identifier = parser%match(identifier_token)
+			import_name = name_identifier%text
+		end if
+		qualified_import = .false.
 	else
-		name_identifier = parser%match(identifier_token)
-		import_name = name_identifier%text
+		! `use module;` - qualified import
+		import_name = ""
+		qualified_import = .true.
 	end if
 
 	semi = parser%match(semicolon_token)
@@ -207,12 +221,19 @@ module function parse_use_statement(parser) result(statement)
 		fn = mod_parser%fns%search(fn_name, io, iostat)
 		if (iostat /= exit_success) cycle
 
+		! Determine the name to insert: qualified (module::fn) or unqualified (fn)
+		if (qualified_import) then
+			insert_name = module_name // "::" // fn_name
+		else
+			insert_name = fn_name
+		end if
+
 		! Insert into current parser with new id_index
 		parser%num_fns = parser%num_fns + 1
-		call parser%fns%insert(fn_name, fn, parser%num_fns, io)
+		call parser%fns%insert(insert_name, fn, parser%num_fns, io)
 
 		! Only push to fn_names in the first pass (like parse_fn_declaration)
-		if (parser%ipass == 0) call parser%fn_names%push(fn_name)
+		if (parser%ipass == 0) call parser%fn_names%push(insert_name)
 	end do
 
 end function parse_use_statement

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -246,13 +246,16 @@ module function parse_use_statement(parser) result(statement)
 			insert_name = fn_name
 
 			! Check if this would shadow an intrinsic function.
-			! First check for exact name match
+			! First check for exact name match (use nested if since Fortran
+			! does not short-circuit .and. and id_index may be undefined)
 			dummy_fn = parser%fns%search(fn_name, id_index, iostat2)
-			if (iostat2 == exit_success .and. id_index <= parser%fns%num_intr_fns) then
-				span = new_span(mod_identifier%pos, len(mod_identifier%text))
-				call parser%diagnostics%push( &
-					err_shadow_intr(parser%context(), span, fn_name))
-				cycle
+			if (iostat2 == exit_success) then
+				if (id_index <= parser%fns%num_intr_fns) then
+					span = new_span(mod_identifier%pos, len(mod_identifier%text))
+					call parser%diagnostics%push( &
+						err_shadow_intr(parser%context(), span, fn_name))
+					cycle
+				end if
 			end if
 			! Check for overloaded intrinsics (e.g., dot, abs, sum, etc.)
 			if (is_overloaded_intr(fn_name)) then

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -3,6 +3,8 @@
 
 submodule (syntran__parse_m) syntran__parse_control
 
+	use syntran__intr_fns_m
+
 	implicit none
 
 	! FIXME: remember to prepend routines like `module function` or `module
@@ -116,9 +118,15 @@ module function parse_use_statement(parser) result(statement)
 	type(syntax_node_t) :: statement
 	!********
 	character(len = :), allocatable :: module_name, import_name
+	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
 	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
 		name_identifier, semi, star
 	type(text_span_t) :: span
+	type(parser_t) :: mod_parser
+	type(syntax_node_t) :: mod_unit
+	type(text_context_vector_t) :: mod_contexts
+	type(fn_t) :: fn
+	integer :: i, io, iostat, mod_unit_
 
 	use_token = parser%match(use_keyword)
 
@@ -145,14 +153,67 @@ module function parse_use_statement(parser) result(statement)
 	! For std::, all intrinsics are already globally available
 	if (module_name == "std") return
 
-	! User-defined modules are not yet fully implemented.
-	! The syntax is recognized but module loading is not complete.
-	! For now, report an error for non-std modules.
-	span = new_span(mod_identifier%pos, len(mod_identifier%text))
-	call parser%diagnostics%push( &
-		"Error: user-defined modules are not yet implemented. " // &
-		"Module `" // module_name // "` cannot be loaded." // &
-		" Only `use std::*` is currently supported.")
+	! Get the directory of the current source file
+	src_dir = get_dir(parser%contexts%v(parser%current_unit())%src_file)
+	mod_filename = src_dir // module_name // ".syntran"
+
+	! Check if module file exists
+	if (.not. exists(mod_filename)) then
+		span = new_span(mod_identifier%pos, len(mod_identifier%text))
+		call parser%diagnostics%push( &
+			err_mod_404(parser%context(), span, mod_filename))
+		return
+	end if
+
+	! Read the module file
+	mod_text = read_file(mod_filename, iostat)
+	if (iostat /= exit_success) then
+		span = new_span(mod_identifier%pos, len(mod_identifier%text))
+		call parser%diagnostics%push( &
+			err_mod_read(parser%context(), span, mod_filename))
+		return
+	end if
+
+	! Create a new parser for the module
+	mod_contexts = new_context_vector()
+	mod_unit_ = 0
+	mod_parser = new_parser(mod_text, mod_filename, mod_contexts, mod_unit_)
+
+	! Initialize intrinsic functions for the module parser.
+	! We use declare_intr_fns instead of copying from the main parser's dict
+	! to avoid copying previously imported module functions which would cause
+	! redeclaration errors in pass 1.
+	call declare_intr_fns(mod_parser%fns)
+	mod_parser%num_fns = mod_parser%fns%num_intr_fns
+
+	! Parse the module
+	mod_unit = mod_parser%parse_unit()
+
+	! Check for parsing errors in the module (only in first pass)
+	if (parser%ipass == 0 .and. mod_parser%diagnostics%len_ > 0) then
+		call parser%diagnostics%push( &
+			"Error: failed to parse module `" // module_name // "`:")
+		do i = 1, mod_parser%diagnostics%len_
+			call parser%diagnostics%push(mod_parser%diagnostics%v(i)%s)
+		end do
+		return
+	end if
+
+	! Copy parsed functions from module parser to current parser
+	do i = 1, mod_parser%fn_names%len_
+		fn_name = mod_parser%fn_names%v(i)%s
+
+		! Look up the function in the module parser
+		fn = mod_parser%fns%search(fn_name, io, iostat)
+		if (iostat /= exit_success) cycle
+
+		! Insert into current parser with new id_index
+		parser%num_fns = parser%num_fns + 1
+		call parser%fns%insert(fn_name, fn, parser%num_fns, io)
+
+		! Only push to fn_names in the first pass (like parse_fn_declaration)
+		if (parser%ipass == 0) call parser%fn_names%push(fn_name)
+	end do
 
 end function parse_use_statement
 

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -116,9 +116,10 @@ module function parse_use_statement(parser) result(statement)
 
 	! Parse `use module;` or `use module::*;` or `use module::name;`
 	!
-	! - `use module;`       imports functions as module::fn (qualified access)
-	! - `use module::*;`    imports all functions as fn (unqualified access)
-	! - `use module::name;` imports specific function as name (unqualified)
+	! - `use module;`         imports functions as module::fn (qualified access)
+	! - `use module::*;`      imports all functions (unqualified access)
+	! - `use module::name;`   imports specific function name (unqualified)
+	! - `use path/to/module;  imports path/to/module.syntran, can be combined with qualified or unqualified forms above
 
 	class(parser_t) :: parser
 	type(syntax_node_t) :: statement
@@ -264,13 +265,16 @@ module function parse_use_statement(parser) result(statement)
 		else
 			insert_name = fn_name
 
-			! Check if this would shadow an overloaded intrinsic function.
-			! Note: we only check overloaded intrinsics here because non-overloaded
-			! intrinsics have unique internal names (not user-visible names).
+			! Check if this would shadow an overloaded intrinsic function. Note:
+			! we only check overloaded intrinsics here because non-overloaded
+			! intrinsics are handled mostly like normal user-defined fns
+			!
+			! TODO: is this still needed since we already handle
+			! err_redeclare_intr_fn() elsewhere?
 			if (is_overloaded_intr(fn_name)) then
 				span = new_span(mod_identifier%pos, len(mod_identifier%text))
 				call parser%diagnostics%push( &
-					err_shadow_intr(parser%context(), span, fn_name))
+					err_redeclare_intr_fn(parser%context(), span, fn_name))
 				cycle
 			end if
 		end if

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -121,7 +121,7 @@ module function parse_use_statement(parser) result(statement)
 	class(parser_t) :: parser
 	type(syntax_node_t) :: statement
 	!********
-	character(len = :), allocatable :: module_name, import_name
+	character(len = :), allocatable :: module_name, import_name, module_path
 	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
 	character(len = :), allocatable :: insert_name
 	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
@@ -137,14 +137,29 @@ module function parse_use_statement(parser) result(statement)
 
 	use_token = parser%match(use_keyword)
 
+	! Handle parent directory references (e.g., `use ../module;` or `use ../../module;`)
+	! module_path includes "../" for file resolution, module_name is for namespacing
+	module_path = ""
+	do while (parser%current_kind() == dot_token .and. &
+	          parser%peek_kind(1) == dot_token .and. &
+	          parser%peek_kind(2) == slash_token)
+		! Match ".." and "/"
+		star = parser%match(dot_token)    ! reuse star token variable
+		star = parser%match(dot_token)
+		star = parser%match(slash_token)
+		module_path = module_path // "../"
+	end do
+
 	mod_identifier = parser%match(identifier_token)
 	module_name = mod_identifier%text
+	module_path = module_path // module_name
 
 	! Handle module paths with slashes (e.g., `use math/vectors::*;`)
 	do while (parser%current_kind() == slash_token)
 		star = parser%match(slash_token)  ! reuse star token variable
 		name_identifier = parser%match(identifier_token)
 		module_name = module_name // "/" // name_identifier%text
+		module_path = module_path // "/" // name_identifier%text
 	end do
 
 	! Check for `use module;` (qualified import) vs `use module::*;` (glob import)
@@ -177,7 +192,7 @@ module function parse_use_statement(parser) result(statement)
 
 	! Get the directory of the current source file
 	src_dir = get_dir(parser%contexts%v(parser%current_unit())%src_file)
-	mod_filename = src_dir // module_name // ".syntran"
+	mod_filename = src_dir // module_path // ".syntran"
 
 	! Check if module file exists
 	if (.not. exists(mod_filename)) then

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -108,6 +108,56 @@ end function parse_continue_statement
 
 !===============================================================================
 
+module function parse_use_statement(parser) result(statement)
+
+	! Parse `use module::name;` or `use module::*;`
+
+	class(parser_t) :: parser
+	type(syntax_node_t) :: statement
+	!********
+	character(len = :), allocatable :: module_name, import_name
+	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
+		name_identifier, semi, star
+	type(text_span_t) :: span
+
+	use_token = parser%match(use_keyword)
+
+	mod_identifier = parser%match(identifier_token)
+	module_name = mod_identifier%text
+
+	double_colon = parser%match(double_colon_token)
+
+	! Check for glob import (use module::*)
+	if (parser%current_kind() == star_token) then
+		star = parser%match(star_token)
+		import_name = "*"
+	else
+		name_identifier = parser%match(identifier_token)
+		import_name = name_identifier%text
+	end if
+
+	semi = parser%match(semicolon_token)
+
+	! Return an empty statement (no-op)
+	statement%kind = expr_statement
+	statement%is_empty = .true.
+
+	! For std::, all intrinsics are already globally available
+	if (module_name == "std") return
+
+	! User-defined modules are not yet fully implemented.
+	! The syntax is recognized but module loading is not complete.
+	! For now, report an error for non-std modules.
+	span = new_span(mod_identifier%pos, len(mod_identifier%text))
+	call parser%diagnostics%push( &
+		"Error: user-defined modules are not yet implemented. " // &
+		"Module `" // module_name // "` cannot be loaded." // &
+		" Only `use std::*` is currently supported.")
+
+end function parse_use_statement
+
+!===============================================================================
+
 recursive module function parse_if_statement(parser) result(statement)
 
 	class(parser_t) :: parser
@@ -431,6 +481,9 @@ recursive module function parse_statement(parser) result(statement)
 
 	case (continue_keyword)
 		statement = parser%parse_continue_statement()
+
+	case (use_keyword)
+		statement = parser%parse_use_statement()
 
 	case default
 		pos_beg   = parser%peek_pos(0)

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -125,13 +125,13 @@ module function parse_use_statement(parser) result(statement)
 	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
 	character(len = :), allocatable :: insert_name
 	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
-		name_identifier, semi, star
+		name_identifier, semi, star, dummy
 	type(text_span_t) :: span
 	type(parser_t) :: mod_parser
 	type(syntax_node_t) :: mod_unit
 	type(text_context_vector_t) :: mod_contexts
 	type(fn_t) :: fn
-	integer :: i, io, iostat, mod_unit_, slash_pos
+	integer :: i, io, iostat, mod_unit_
 	logical :: qualified_import
 	character(len = :), allocatable :: qualified_prefix
 
@@ -144,17 +144,17 @@ module function parse_use_statement(parser) result(statement)
 	          parser%peek_kind(1) == dot_token .and. &
 	          parser%peek_kind(2) == slash_token)
 		! Match ".." and "/"
-		star = parser%match(dot_token)    ! reuse star token variable
-		star = parser%match(dot_token)
-		star = parser%match(slash_token)
+		dummy = parser%match(dot_token)
+		dummy = parser%match(dot_token)
+		dummy = parser%match(slash_token)
 		module_path = module_path // "../"
 	end do
 
 	! Handle current directory reference (e.g., `use ./module;`)
 	if (parser%current_kind() == dot_token .and. &
 	    parser%peek_kind(1) == slash_token) then
-		star = parser%match(dot_token)
-		star = parser%match(slash_token)
+		dummy = parser%match(dot_token)
+		dummy = parser%match(slash_token)
 		module_path = module_path // "./"
 	end if
 
@@ -164,7 +164,7 @@ module function parse_use_statement(parser) result(statement)
 
 	! Handle module paths with slashes (e.g., `use math/vectors::*;`)
 	do while (parser%current_kind() == slash_token)
-		star = parser%match(slash_token)  ! reuse star token variable
+		dummy = parser%match(slash_token)
 		name_identifier = parser%match(identifier_token)
 		module_name = module_name // "/" // name_identifier%text
 		module_path = module_path // "/" // name_identifier%text
@@ -257,13 +257,7 @@ module function parse_use_statement(parser) result(statement)
 		! e.g., "math/vectors" -> "math::vectors::fn"
 		if (qualified_import) then
 			! Replace "/" with "::" in module_name for qualified prefix
-			qualified_prefix = module_name
-			slash_pos = index(qualified_prefix, "/")
-			do while (slash_pos > 0)
-				qualified_prefix = qualified_prefix(1:slash_pos-1) // "::" &
-					// qualified_prefix(slash_pos+1:)
-				slash_pos = index(qualified_prefix, "/")
-			end do
+			qualified_prefix = replace_all(module_name, "/", "::")
 			insert_name = qualified_prefix // "::" // fn_name
 		else
 			insert_name = fn_name

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -126,7 +126,7 @@ module function parse_use_statement(parser) result(statement)
 	!********
 	character(len = :), allocatable :: module_name, import_name, module_path
 	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
-	character(len = :), allocatable :: insert_name
+	character(len = :), allocatable :: insert_name, var_name
 	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
 		name_identifier, semi, star, dummy
 	type(text_span_t) :: span
@@ -134,7 +134,8 @@ module function parse_use_statement(parser) result(statement)
 	type(syntax_node_t) :: mod_unit
 	type(text_context_vector_t) :: mod_contexts
 	type(fn_t) :: fn
-	integer :: i, io, iostat, mod_unit_
+	type(value_t) :: var_val
+	integer :: i, io, iostat, mod_unit_, id_index
 	logical :: qualified_import
 	character(len = :), allocatable :: qualified_prefix
 
@@ -234,8 +235,16 @@ module function parse_use_statement(parser) result(statement)
 	call declare_intr_fns(mod_parser%fns)
 	mod_parser%num_fns = mod_parser%fns%num_intr_fns
 
+	! Share variable numbering with parent parser. Module variables will get
+	! indices continuing from parent's count, avoiding the need for remapping.
+	! This is similar to how #include works.
+	mod_parser%num_vars = parser%num_vars
+
 	! Parse the module
 	mod_unit = mod_parser%parse_unit()
+
+	! Update parent's variable count to include module variables
+	parser%num_vars = mod_parser%num_vars
 
 	! Check for parsing errors in the module (only in first pass)
 	if (parser%ipass == 0 .and. mod_parser%diagnostics%len_ > 0) then
@@ -285,6 +294,28 @@ module function parse_use_statement(parser) result(statement)
 
 		! Only push to fn_names in the first pass (like parse_fn_declaration)
 		if (parser%ipass == 0) call parser%fn_names%push(insert_name)
+	end do
+
+	! Copy parsed module variables to current parser.
+	! Since we shared num_vars before parsing, indices already match - no remapping needed.
+	do i = 1, mod_parser%var_names%len_
+		var_name = mod_parser%var_names%v(i)%s
+
+		! Look up the variable in the module parser
+		call mod_parser%vars%search(var_name, id_index, iostat, var_val)
+		if (iostat /= exit_success) cycle
+
+		! Determine insert name (qualified or unqualified)
+		if (qualified_import) then
+			qualified_prefix = replace_all(module_name, "/", "::")
+			insert_name = qualified_prefix // "::" // var_name
+		else
+			insert_name = var_name
+		end if
+
+		! Insert with same id_index (no remapping needed)
+		call parser%vars%insert(insert_name, var_val, id_index, io)
+		if (parser%ipass == 0) call parser%var_names%push(insert_name)
 	end do
 
 end function parse_use_statement

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -130,9 +130,10 @@ module function parse_use_statement(parser) result(statement)
 	type(parser_t) :: mod_parser
 	type(syntax_node_t) :: mod_unit
 	type(text_context_vector_t) :: mod_contexts
-	type(fn_t) :: fn
-	integer :: i, io, iostat, mod_unit_
+	type(fn_t) :: fn, dummy_fn
+	integer :: i, io, iostat, iostat2, mod_unit_, id_index, slash_pos
 	logical :: qualified_import
+	character(len = :), allocatable :: qualified_prefix
 
 	use_token = parser%match(use_keyword)
 
@@ -229,10 +230,37 @@ module function parse_use_statement(parser) result(statement)
 		if (iostat /= exit_success) cycle
 
 		! Determine the name to insert: qualified (module::fn) or unqualified (fn)
+		! For qualified imports, convert path separators to namespace separators
+		! e.g., "math/vectors" -> "math::vectors::fn"
 		if (qualified_import) then
-			insert_name = module_name // "::" // fn_name
+			! Replace "/" with "::" in module_name for qualified prefix
+			qualified_prefix = module_name
+			slash_pos = index(qualified_prefix, "/")
+			do while (slash_pos > 0)
+				qualified_prefix = qualified_prefix(1:slash_pos-1) // "::" &
+					// qualified_prefix(slash_pos+1:)
+				slash_pos = index(qualified_prefix, "/")
+			end do
+			insert_name = qualified_prefix // "::" // fn_name
 		else
 			insert_name = fn_name
+
+			! Check if this would shadow an intrinsic function.
+			! First check for exact name match
+			dummy_fn = parser%fns%search(fn_name, id_index, iostat2)
+			if (iostat2 == exit_success .and. id_index <= parser%fns%num_intr_fns) then
+				span = new_span(mod_identifier%pos, len(mod_identifier%text))
+				call parser%diagnostics%push( &
+					err_shadow_intr(parser%context(), span, fn_name))
+				cycle
+			end if
+			! Check for overloaded intrinsics (e.g., dot, abs, sum, etc.)
+			if (is_overloaded_intr(fn_name)) then
+				span = new_span(mod_identifier%pos, len(mod_identifier%text))
+				call parser%diagnostics%push( &
+					err_shadow_intr(parser%context(), span, fn_name))
+				cycle
+			end if
 		end if
 
 		! Insert into current parser with new id_index

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -130,8 +130,8 @@ module function parse_use_statement(parser) result(statement)
 	type(parser_t) :: mod_parser
 	type(syntax_node_t) :: mod_unit
 	type(text_context_vector_t) :: mod_contexts
-	type(fn_t) :: fn, dummy_fn
-	integer :: i, io, iostat, iostat2, mod_unit_, id_index, slash_pos
+	type(fn_t) :: fn
+	integer :: i, io, iostat, mod_unit_, slash_pos
 	logical :: qualified_import
 	character(len = :), allocatable :: qualified_prefix
 
@@ -245,19 +245,9 @@ module function parse_use_statement(parser) result(statement)
 		else
 			insert_name = fn_name
 
-			! Check if this would shadow an intrinsic function.
-			! First check for exact name match (use nested if since Fortran
-			! does not short-circuit .and. and id_index may be undefined)
-			dummy_fn = parser%fns%search(fn_name, id_index, iostat2)
-			if (iostat2 == exit_success) then
-				if (id_index <= parser%fns%num_intr_fns) then
-					span = new_span(mod_identifier%pos, len(mod_identifier%text))
-					call parser%diagnostics%push( &
-						err_shadow_intr(parser%context(), span, fn_name))
-					cycle
-				end if
-			end if
-			! Check for overloaded intrinsics (e.g., dot, abs, sum, etc.)
+			! Check if this would shadow an overloaded intrinsic function.
+			! Note: we only check overloaded intrinsics here because non-overloaded
+			! intrinsics have unique internal names (not user-visible names).
 			if (is_overloaded_intr(fn_name)) then
 				span = new_span(mod_identifier%pos, len(mod_identifier%text))
 				call parser%diagnostics%push( &

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -112,6 +112,8 @@ end function parse_continue_statement
 
 module function parse_use_statement(parser) result(statement)
 
+	use syntran__errors_m
+
 	! Parse `use module;` or `use module::*;` or `use module::name;`
 	!
 	! - `use module;`       imports functions as module::fn (qualified access)
@@ -237,7 +239,7 @@ module function parse_use_statement(parser) result(statement)
 	! Check for parsing errors in the module (only in first pass)
 	if (parser%ipass == 0 .and. mod_parser%diagnostics%len_ > 0) then
 		call parser%diagnostics%push( &
-			"Error: failed to parse module `" // module_name // "`:")
+			err_prefix // "failed to parse module `" // module_name // "`:" // color_reset)
 		do i = 1, mod_parser%diagnostics%len_
 			call parser%diagnostics%push(mod_parser%diagnostics%v(i)%s)
 		end do

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -467,7 +467,10 @@ recursive module function parse_primary_expr(parser) result(expr)
 
 			!print *, "parser%peek_kind(1) = ", kind_name(parser%peek_kind(1))
 
-			if (parser%peek_kind(1) == lparen_token) then
+			if (parser%peek_kind(1) == double_colon_token) then
+				! Qualified name like `std::println()` or `mod::fn()`
+				expr = parser%parse_qualified_expr()
+			else if (parser%peek_kind(1) == lparen_token) then
 				expr = parser%parse_fn_call()
 			else if (parser%peek_kind(1) == lbrace_token) then
 

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -138,6 +138,89 @@ recursive module function parse_expr_statement(parser) result(expr)
 
 	end if
 
+	! Handle qualified assignment: mod::var = value
+	if (parser%peek_kind(0) == identifier_token .and. &
+	    parser%peek_kind(1) == double_colon_token) then
+
+		pos0 = parser%pos
+
+		! Parse the qualified name (mod::var or mod1::mod2::var)
+		identifier = parser%match(identifier_token)
+		expr%module_prefix = identifier%text
+
+		op = parser%match(double_colon_token)
+
+		identifier = parser%match(identifier_token)
+
+		! Handle nested namespaces: mod1::mod2::var
+		do while (parser%current_kind() == double_colon_token)
+			expr%module_prefix = expr%module_prefix // "::" // identifier%text
+			op = parser%match(double_colon_token)
+			identifier = parser%match(identifier_token)
+		end do
+
+		if (.not. is_assignment_op(parser%current_kind())) then
+			! Not an assignment, rewind and let parse_expr handle it
+			parser%pos = pos0
+		else
+			! It's a qualified assignment
+			expr%identifier = identifier
+
+			call parser%vars%search(expr%module_prefix // "::" // identifier%text, &
+				expr%id_index, search_io, expr%val)
+
+			if (search_io /= exit_success) then
+				span = new_span(identifier%pos, len(identifier%text))
+				call parser%diagnostics%push( &
+					err_undeclare_var(parser%context(), span, identifier%text))
+			end if
+
+			expr%is_loc = .false.
+
+			op    = parser%next()
+			right = parser%parse_expr_statement()
+
+			expr%kind = assignment_expr
+
+			if (.not. allocated(expr%right)) allocate(expr%right)
+			expr%op    = op
+			expr%right = right
+
+			ltype = expr%val%type
+			rtype = expr%right%val%type
+
+			larrtype = unknown_type
+			rarrtype = unknown_type
+			if (ltype == array_type) larrtype = expr%val%array%type
+			if (rtype == array_type) rarrtype = expr%right%val%array%type
+
+			is_op_allowed = is_binary_op_allowed(ltype, op%kind, rtype, larrtype, rarrtype)
+
+			if (.not. is_op_allowed) then
+				span = new_span(op%pos, len(op%text))
+				call parser%diagnostics%push( &
+					err_binary_types(parser%context(), &
+					span, op%text, &
+					type_name(expr%val), &
+					type_name(expr%right%val)))
+			end if
+
+			if (ltype == array_type .and. rtype == array_type) then
+				lrank = expr%val%array%rank
+				rrank = expr%right%val%array%rank
+
+				if (lrank /= rrank) then
+					span = new_span(op%pos, len(op%text))
+					call parser%diagnostics%push( &
+						err_binary_ranks(parser%context(), &
+						span, op%text, lrank, rrank))
+				end if
+			end if
+
+			return
+		end if
+	end if
+
 	if (parser%peek_kind(0) == identifier_token) then
 
 		! There may or may not be a subscript expression after an identifier, so

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -120,6 +120,9 @@ recursive module function parse_expr_statement(parser) result(expr)
 		else
 			call parser%vars%insert(identifier%text, expr%val, &
 				expr%id_index, io, overwrite = overwrite)
+
+			! Track module-level variable names (like fn_names for functions)
+			if (parser%ipass == 0) call parser%var_names%push(identifier%text)
 		end if
 
 		!print *, 'io = ', io

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -631,6 +631,15 @@ module function parse_fn_declaration(parser) result(decl)
 			span, identifier%text))
 	end if
 
+	! Check if this would shadow an overloaded intrinsic function.
+	! Non-overloaded intrinsics are handled by the err_redeclare_fn() check
+	! above
+	if (is_overloaded_intr(identifier%text)) then
+		span = new_span(identifier%pos, len(identifier%text))
+		call parser%diagnostics%push( &
+			err_redeclare_intr_fn(parser%context(), span, identifier%text))
+	end if
+
 	!print *, 'size(decl%params) = ', size(decl%params)
 	!print *, 'decl%params = ', decl%params
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -17,15 +17,18 @@ contains
 
 !===============================================================================
 
-recursive module function parse_fn_call(parser) result(fn_call)
+recursive module function parse_fn_call(parser, module_prefix, identifier) result(fn_call)
 
 	class(parser_t) :: parser
+	character(len = *), intent(in), optional :: module_prefix
+	type(syntax_token_t), intent(in), optional :: identifier
 
 	type(syntax_node_t) :: fn_call
 
 	!********
 
-	character(len = :), allocatable :: exp_type, act_type, param_name
+	character(len = :), allocatable :: exp_type, act_type, param_name, &
+		lookup_name, display_name
 
 	integer :: i, io, id_index, pos0, rank
 
@@ -38,7 +41,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 
 	type(syntax_node_t) :: arg
 	type(syntax_node_vector_t) :: args
-	type(syntax_token_t) :: identifier, comma, lparen, rparen, dummy, amp
+	type(syntax_token_t) :: identifier_, comma, lparen, rparen, dummy, amp
 
 	type(text_span_t) :: span
 
@@ -48,9 +51,13 @@ recursive module function parse_fn_call(parser) result(fn_call)
 	!print *, 'parse_fn_call'
 
 	! Function call expression
-	identifier = parser%match(identifier_token)
+	if (present(identifier)) then
+		identifier_ = identifier
+	else
+		identifier_ = parser%match(identifier_token)
+	end if
 
-	!print *, "identifier = ", identifier%text
+	!print *, "identifier_ = ", identifier_%text
 
 	args     = new_syntax_node_vector()
 	pos_args = new_integer_vector()
@@ -109,17 +116,38 @@ recursive module function parse_fn_call(parser) result(fn_call)
 	rparen  = parser%match(rparen_token)
 
 	fn_call%kind = fn_call_expr
-	fn_call%identifier = identifier
+	fn_call%identifier = identifier_
+
+	! Set module prefix if provided (for qualified calls like std::println)
+	if (present(module_prefix)) then
+		fn_call%module_prefix = module_prefix
+	end if
 
 	call resolve_overload(args, fn_call, has_rank)
 	if (has_rank) rank = fn_call%val%array%rank
 
 	! Lookup by fn_call%identifier%text (e.g. "0min_i32"), but log
-	! diagnostics based on identifier%text (e.g. "min")
+	! diagnostics based on identifier_%text (e.g. "min")
 	!
 	! Might need to add separate internal/external fn names for
 	! overloaded cases
-	fn = parser%fns%search(fn_call%identifier%text, id_index, io)
+	!
+	! For qualified calls, determine lookup name based on module prefix
+	if (present(module_prefix)) then
+		if (module_prefix == "std") then
+			! For std::, look up intrinsic without prefix
+			lookup_name = fn_call%identifier%text
+		else
+			! For user modules, look up with qualified name
+			lookup_name = module_prefix // "::" // fn_call%identifier%text
+		end if
+		display_name = module_prefix // "::" // identifier_%text
+	else
+		lookup_name = fn_call%identifier%text
+		display_name = identifier_%text
+	end if
+
+	fn = parser%fns%search(lookup_name, id_index, io)
 	!print *, "fn id_index = ", id_index
 	if (io /= exit_success) then
 
@@ -129,10 +157,10 @@ recursive module function parse_fn_call(parser) result(fn_call)
 			return
 		end if
 
-		span = new_span(identifier%pos, len(identifier%text))
+		span = new_span(identifier_%pos, len(identifier_%text))
 		call parser%diagnostics%push( &
 			err_undeclare_fn(parser%context(), &
-			span, identifier%text))
+			span, display_name))
 
 		! No more tokens are consumed below, so we can just return
 		! to skip cascading fn arg count/type errors
@@ -203,7 +231,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
 		call parser%diagnostics%push( &
 			err_bad_arg_count(parser%context(), &
-			span, identifier%text, size(fn%params), args%len_))
+			span, identifier_%text, size(fn%params), args%len_))
 		return
 
 	else if (args%len_ < size(fn%params) + fn%variadic_min) then
@@ -212,7 +240,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
 		call parser%diagnostics%push( &
 			err_too_few_args(parser%context(), &
-			span, identifier%text, &
+			span, identifier_%text, &
 			size(fn%params) + fn%variadic_min, args%len_))
 		return
 
@@ -223,7 +251,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
 		call parser%diagnostics%push( &
 			err_too_many_args(parser%context(), &
-			span, identifier%text, &
+			span, identifier_%text, &
 			size(fn%params) + fn%variadic_max, args%len_))
 		return
 
@@ -264,7 +292,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 				call parser%diagnostics%push(err_bad_arg_val( &
 					parser%context(), &
 					span, &
-					identifier%text, &
+					identifier_%text, &
 					i - 1, &  ! 0-based index in err msg
 					param_name &
 				))
@@ -272,7 +300,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 				call parser%diagnostics%push(err_bad_arg_ref( &
 					parser%context(), &
 					span, &
-					identifier%text, &
+					identifier_%text, &
 					i - 1, &
 					param_name &
 				))
@@ -302,7 +330,7 @@ recursive module function parse_fn_call(parser) result(fn_call)
 			call parser%diagnostics%push(err_bad_arg_type( &
 				parser%context(), &
 				span, &
-				identifier%text, &
+				identifier_%text, &
 				i - 1, &  ! 0-based index in err msg
 				param_name, &
 				exp_type, &
@@ -359,13 +387,7 @@ recursive module function parse_qualified_expr(parser) result(expr)
 
 	if (parser%current_kind() == lparen_token) then
 		! Qualified function call: std::println(...) or math::vectors::fn(...)
-		! Create a modified identifier for function lookup
-		fn_identifier%text = fn_name
-
-		! Temporarily set parser position back to parse the function call
-		! Actually, we need to handle this differently - parse the args here
-
-		expr = parse_qualified_fn_call(parser, module_name, fn_identifier)
+		expr = parser%parse_fn_call(module_name, fn_identifier)
 	else
 		! Qualified variable access (future: for user modules)
 		! For now, just report an error since std:: variables don't exist
@@ -376,228 +398,6 @@ recursive module function parse_qualified_expr(parser) result(expr)
 	end if
 
 end function parse_qualified_expr
-
-!===============================================================================
-
-recursive function parse_qualified_fn_call(parser, module_name, identifier) result(fn_call)
-
-	! Parse a qualified function call like std::println(...) or mod::fn(...)
-	! The module name and identifier have already been consumed
-
-	class(parser_t) :: parser
-	character(len = *), intent(in) :: module_name
-	type(syntax_token_t), intent(in) :: identifier
-
-	type(syntax_node_t) :: fn_call
-
-	!********
-
-	character(len = :), allocatable :: exp_type, act_type, param_name
-
-	integer :: i, io, id_index, pos0, rank
-
-	logical :: has_rank, param_is_ref, is_ok
-
-	type(fn_t) :: fn
-
-	type(integer_vector_t) :: pos_args
-	type(logical_vector_t) :: is_ref
-
-	type(syntax_node_t) :: arg
-	type(syntax_node_vector_t) :: args
-	type(syntax_token_t) :: comma, lparen, rparen, dummy, amp
-
-	type(text_span_t) :: span
-
-	type(value_t) :: param_val
-
-	args     = new_syntax_node_vector()
-	pos_args = new_integer_vector()
-	is_ref   = new_logical_vector()
-
-	lparen  = parser%match(lparen_token)
-
-	do while ( &
-		parser%current_kind() /= rparen_token .and. &
-		parser%current_kind() /= eof_token)
-
-		pos0 = parser%pos
-		call pos_args%push(parser%current_pos())
-
-		if (parser%current_kind() == amp_token) then
-			amp = parser%match(amp_token)
-			call is_ref%push(.true.)
-
-			arg = parser%parse_expr()
-
-			if (arg%kind /= name_expr) then
-				span = new_span(amp%pos, parser%current_pos() - amp%pos + 1)
-				call parser%diagnostics%push(err_non_name_ref( &
-					parser%context(), span))
-			end if
-
-			if (allocated(arg%lsubscripts)) then
-				span = new_span(amp%pos, parser%current_pos() - amp%pos + 1)
-				call parser%diagnostics%push(err_sub_ref( &
-					parser%context(), span))
-			end if
-		else
-			call is_ref%push(.false.)
-			arg = parser%parse_expr()
-		end if
-
-		call args%push(arg)
-
-		if (parser%current_kind() /= rparen_token) then
-			comma = parser%match(comma_token)
-		end if
-
-		if (parser%pos == pos0) dummy = parser%next()
-
-	end do
-	call pos_args%push(parser%current_pos() + 1)
-
-	rparen  = parser%match(rparen_token)
-
-	fn_call%kind = fn_call_expr
-	fn_call%identifier = identifier
-	fn_call%module_prefix = module_name
-
-	call resolve_overload(args, fn_call, has_rank)
-	if (has_rank) rank = fn_call%val%array%rank
-
-	! For std:: module, look up function in intrinsics without the prefix
-	if (module_name == "std") then
-		fn = parser%fns%search(fn_call%identifier%text, id_index, io)
-	else
-		! For user modules, look up with full qualified name (future implementation)
-		fn = parser%fns%search(module_name // "::" // fn_call%identifier%text, id_index, io)
-	end if
-
-	if (io /= exit_success) then
-
-		if (parser%ipass == 0) then
-			fn_call%id_index = 0
-			fn_call%kind = fn_call_expr
-			return
-		end if
-
-		span = new_span(identifier%pos, len(identifier%text))
-		call parser%diagnostics%push( &
-			err_undeclare_fn(parser%context(), &
-			span, module_name // "::" // identifier%text))
-
-		return
-
-	end if
-
-	if (fn%is_intr) fn_call%kind = fn_call_intr_expr
-
-	fn_call%val = fn%type
-	if (has_rank) then
-		if (.not. allocated(fn_call%val%array)) allocate(fn_call%val%array)
-		fn_call%val%array%rank = rank
-
-		if (.not. allocated(fn%type%array)) allocate(fn%type%array)
-		fn%type%array%rank = rank
-
-	end if
-
-	if (.not. fn%is_intr) then
-		allocate(fn_call%body)
-		fn_call%body = fn%node%body
-		fn_call%params = fn%node%params
-		fn_call%num_locs = fn%node%num_locs
-	end if
-
-	! Verify argument count (non-variadic)
-	if (fn%variadic_min < 0 .and. size(fn%params) /= args%len_) then
-		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
-		call parser%diagnostics%push( &
-			err_bad_arg_count(parser%context(), &
-			span, identifier%text, size(fn%params), args%len_))
-		return
-
-	else if (args%len_ < size(fn%params) + fn%variadic_min) then
-		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
-		call parser%diagnostics%push( &
-			err_too_few_args(parser%context(), &
-			span, identifier%text, &
-			size(fn%params) + fn%variadic_min, args%len_))
-		return
-
-	else if (fn%variadic_max >= 0 .and. &
-		args%len_ > size(fn%params) + fn%variadic_max) then
-		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
-		call parser%diagnostics%push( &
-			err_too_many_args(parser%context(), &
-			span, identifier%text, &
-			size(fn%params) + fn%variadic_max, args%len_))
-		return
-	end if
-
-	fn_call%is_ref = is_ref%v(1: is_ref%len_)
-
-	allocate(param_val%array)
-	do i = 1, args%len_
-
-		if (i <= size(fn%params)) then
-			param_val  = fn%params(i)
-			param_name = fn%param_names%v(i)%s
-		else
-			param_val%type = fn%variadic_type
-			param_name = fn%variadic_name
-		end if
-
-		param_is_ref = .false.
-		if (allocated(fn%node)) param_is_ref = fn%node%is_ref(i)
-
-		if (param_is_ref .neqv. is_ref%v(i)) then
-			span = new_span(pos_args%v(i), pos_args%v(i+1) - pos_args%v(i) - 1)
-			if (param_is_ref) then
-				call parser%diagnostics%push(err_bad_arg_val( &
-					parser%context(), &
-					span, &
-					identifier%text, &
-					i - 1, &
-					param_name &
-				))
-			else
-				call parser%diagnostics%push(err_bad_arg_ref( &
-					parser%context(), &
-					span, &
-					identifier%text, &
-					i - 1, &
-					param_name &
-				))
-			end if
-		end if
-
-		is_ok = .true.
-		is_ok = is_ok .and. types_match(param_val, args%v(i)%val) == TYPE_MATCH
-		is_ok = is_ok .or. (parser%ipass == 0 .and. args%v(i)%val%type == unknown_type)
-
-		if (.not. is_ok) then
-			exp_type = type_name(param_val)
-			act_type = type_name(args%v(i)%val)
-
-			span = new_span(pos_args%v(i), pos_args%v(i+1) - pos_args%v(i) - 1)
-			call parser%diagnostics%push(err_bad_arg_type( &
-				parser%context(), &
-				span, &
-				identifier%text, &
-				i - 1, &
-				param_name, &
-				exp_type, &
-				act_type))
-		end if
-	end do
-
-	fn_call%id_index = id_index
-
-	call syntax_nodes_copy(fn_call%args, args%v( 1: args%len_ ))
-
-end function parse_qualified_fn_call
 
 !===============================================================================
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -321,6 +321,275 @@ end function parse_fn_call
 
 !===============================================================================
 
+recursive module function parse_qualified_expr(parser) result(expr)
+
+	! Parse qualified names like `std::println()` or `mod::name`
+
+	class(parser_t) :: parser
+
+	type(syntax_node_t) :: expr
+
+	!********
+
+	character(len = :), allocatable :: module_name, fn_name
+
+	type(syntax_token_t) :: mod_identifier, double_colon, fn_identifier
+
+	! Get module name
+	mod_identifier = parser%match(identifier_token)
+	module_name = mod_identifier%text
+
+	! Consume ::
+	double_colon = parser%match(double_colon_token)
+
+	! Get the function/variable name
+	fn_identifier = parser%match(identifier_token)
+	fn_name = fn_identifier%text
+
+	if (parser%current_kind() == lparen_token) then
+		! Qualified function call: std::println(...)
+		! Create a modified identifier for function lookup
+		fn_identifier%text = fn_name
+
+		! Temporarily set parser position back to parse the function call
+		! Actually, we need to handle this differently - parse the args here
+
+		expr = parse_qualified_fn_call(parser, module_name, fn_identifier)
+	else
+		! Qualified variable access (future: for user modules)
+		! For now, just report an error since std:: variables don't exist
+		expr%kind = name_expr
+		expr%identifier = fn_identifier
+		expr%module_prefix = module_name
+		! TODO: implement module variable lookup
+	end if
+
+end function parse_qualified_expr
+
+!===============================================================================
+
+recursive function parse_qualified_fn_call(parser, module_name, identifier) result(fn_call)
+
+	! Parse a qualified function call like std::println(...) or mod::fn(...)
+	! The module name and identifier have already been consumed
+
+	class(parser_t) :: parser
+	character(len = *), intent(in) :: module_name
+	type(syntax_token_t), intent(in) :: identifier
+
+	type(syntax_node_t) :: fn_call
+
+	!********
+
+	character(len = :), allocatable :: exp_type, act_type, param_name
+
+	integer :: i, io, id_index, pos0, rank
+
+	logical :: has_rank, param_is_ref, is_ok
+
+	type(fn_t) :: fn
+
+	type(integer_vector_t) :: pos_args
+	type(logical_vector_t) :: is_ref
+
+	type(syntax_node_t) :: arg
+	type(syntax_node_vector_t) :: args
+	type(syntax_token_t) :: comma, lparen, rparen, dummy, amp
+
+	type(text_span_t) :: span
+
+	type(value_t) :: param_val
+
+	args     = new_syntax_node_vector()
+	pos_args = new_integer_vector()
+	is_ref   = new_logical_vector()
+
+	lparen  = parser%match(lparen_token)
+
+	do while ( &
+		parser%current_kind() /= rparen_token .and. &
+		parser%current_kind() /= eof_token)
+
+		pos0 = parser%pos
+		call pos_args%push(parser%current_pos())
+
+		if (parser%current_kind() == amp_token) then
+			amp = parser%match(amp_token)
+			call is_ref%push(.true.)
+
+			arg = parser%parse_expr()
+
+			if (arg%kind /= name_expr) then
+				span = new_span(amp%pos, parser%current_pos() - amp%pos + 1)
+				call parser%diagnostics%push(err_non_name_ref( &
+					parser%context(), span))
+			end if
+
+			if (allocated(arg%lsubscripts)) then
+				span = new_span(amp%pos, parser%current_pos() - amp%pos + 1)
+				call parser%diagnostics%push(err_sub_ref( &
+					parser%context(), span))
+			end if
+		else
+			call is_ref%push(.false.)
+			arg = parser%parse_expr()
+		end if
+
+		call args%push(arg)
+
+		if (parser%current_kind() /= rparen_token) then
+			comma = parser%match(comma_token)
+		end if
+
+		if (parser%pos == pos0) dummy = parser%next()
+
+	end do
+	call pos_args%push(parser%current_pos() + 1)
+
+	rparen  = parser%match(rparen_token)
+
+	fn_call%kind = fn_call_expr
+	fn_call%identifier = identifier
+	fn_call%module_prefix = module_name
+
+	call resolve_overload(args, fn_call, has_rank)
+	if (has_rank) rank = fn_call%val%array%rank
+
+	! For std:: module, look up function in intrinsics without the prefix
+	if (module_name == "std") then
+		fn = parser%fns%search(fn_call%identifier%text, id_index, io)
+	else
+		! For user modules, look up with full qualified name (future implementation)
+		fn = parser%fns%search(module_name // "::" // fn_call%identifier%text, id_index, io)
+	end if
+
+	if (io /= exit_success) then
+
+		if (parser%ipass == 0) then
+			fn_call%id_index = 0
+			fn_call%kind = fn_call_expr
+			return
+		end if
+
+		span = new_span(identifier%pos, len(identifier%text))
+		call parser%diagnostics%push( &
+			err_undeclare_fn(parser%context(), &
+			span, module_name // "::" // identifier%text))
+
+		return
+
+	end if
+
+	if (fn%is_intr) fn_call%kind = fn_call_intr_expr
+
+	fn_call%val = fn%type
+	if (has_rank) then
+		if (.not. allocated(fn_call%val%array)) allocate(fn_call%val%array)
+		fn_call%val%array%rank = rank
+
+		if (.not. allocated(fn%type%array)) allocate(fn%type%array)
+		fn%type%array%rank = rank
+
+	end if
+
+	if (.not. fn%is_intr) then
+		allocate(fn_call%body)
+		fn_call%body = fn%node%body
+		fn_call%params = fn%node%params
+		fn_call%num_locs = fn%node%num_locs
+	end if
+
+	! Verify argument count (non-variadic)
+	if (fn%variadic_min < 0 .and. size(fn%params) /= args%len_) then
+		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
+		call parser%diagnostics%push( &
+			err_bad_arg_count(parser%context(), &
+			span, identifier%text, size(fn%params), args%len_))
+		return
+
+	else if (args%len_ < size(fn%params) + fn%variadic_min) then
+		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
+		call parser%diagnostics%push( &
+			err_too_few_args(parser%context(), &
+			span, identifier%text, &
+			size(fn%params) + fn%variadic_min, args%len_))
+		return
+
+	else if (fn%variadic_max >= 0 .and. &
+		args%len_ > size(fn%params) + fn%variadic_max) then
+		span = new_span(lparen%pos, rparen%pos - lparen%pos + 1)
+		call parser%diagnostics%push( &
+			err_too_many_args(parser%context(), &
+			span, identifier%text, &
+			size(fn%params) + fn%variadic_max, args%len_))
+		return
+	end if
+
+	fn_call%is_ref = is_ref%v(1: is_ref%len_)
+
+	allocate(param_val%array)
+	do i = 1, args%len_
+
+		if (i <= size(fn%params)) then
+			param_val  = fn%params(i)
+			param_name = fn%param_names%v(i)%s
+		else
+			param_val%type = fn%variadic_type
+			param_name = fn%variadic_name
+		end if
+
+		param_is_ref = .false.
+		if (allocated(fn%node)) param_is_ref = fn%node%is_ref(i)
+
+		if (param_is_ref .neqv. is_ref%v(i)) then
+			span = new_span(pos_args%v(i), pos_args%v(i+1) - pos_args%v(i) - 1)
+			if (param_is_ref) then
+				call parser%diagnostics%push(err_bad_arg_val( &
+					parser%context(), &
+					span, &
+					identifier%text, &
+					i - 1, &
+					param_name &
+				))
+			else
+				call parser%diagnostics%push(err_bad_arg_ref( &
+					parser%context(), &
+					span, &
+					identifier%text, &
+					i - 1, &
+					param_name &
+				))
+			end if
+		end if
+
+		is_ok = .true.
+		is_ok = is_ok .and. types_match(param_val, args%v(i)%val) == TYPE_MATCH
+		is_ok = is_ok .or. (parser%ipass == 0 .and. args%v(i)%val%type == unknown_type)
+
+		if (.not. is_ok) then
+			exp_type = type_name(param_val)
+			act_type = type_name(args%v(i)%val)
+
+			span = new_span(pos_args%v(i), pos_args%v(i+1) - pos_args%v(i) - 1)
+			call parser%diagnostics%push(err_bad_arg_type( &
+				parser%context(), &
+				span, &
+				identifier%text, &
+				i - 1, &
+				param_name, &
+				exp_type, &
+				act_type))
+		end if
+	end do
+
+	fn_call%id_index = id_index
+
+	call syntax_nodes_copy(fn_call%args, args%v( 1: args%len_ ))
+
+end function parse_qualified_fn_call
+
+!===============================================================================
+
 module function parse_fn_declaration(parser) result(decl)
 
 	class(parser_t) :: parser

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -323,7 +323,8 @@ end function parse_fn_call
 
 recursive module function parse_qualified_expr(parser) result(expr)
 
-	! Parse qualified names like `std::println()` or `mod::name`
+	! Parse qualified names like `std::println()`, `mod::name`,
+	! or nested namespaces like `math::vectors::fn()`
 
 	class(parser_t) :: parser
 
@@ -335,19 +336,29 @@ recursive module function parse_qualified_expr(parser) result(expr)
 
 	type(syntax_token_t) :: mod_identifier, double_colon, fn_identifier
 
-	! Get module name
+	! Get first part of module name
 	mod_identifier = parser%match(identifier_token)
 	module_name = mod_identifier%text
 
 	! Consume ::
 	double_colon = parser%match(double_colon_token)
 
-	! Get the function/variable name
+	! Get the next identifier (could be another namespace or the fn/var name)
 	fn_identifier = parser%match(identifier_token)
 	fn_name = fn_identifier%text
 
+	! Handle nested namespaces: math::vectors::fn()
+	! Keep consuming ::identifier pairs while we see more :: tokens
+	do while (parser%current_kind() == double_colon_token)
+		! The current fn_name is actually part of the module path
+		module_name = module_name // "::" // fn_name
+		double_colon = parser%match(double_colon_token)
+		fn_identifier = parser%match(identifier_token)
+		fn_name = fn_identifier%text
+	end do
+
 	if (parser%current_kind() == lparen_token) then
-		! Qualified function call: std::println(...)
+		! Qualified function call: std::println(...) or math::vectors::fn(...)
 		! Create a modified identifier for function lookup
 		fn_identifier%text = fn_name
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -360,9 +360,12 @@ recursive module function parse_qualified_expr(parser) result(expr)
 
 	!********
 
-	character(len = :), allocatable :: module_name, fn_name
+	character(len = :), allocatable :: module_name, fn_name, lookup_name
 
 	type(syntax_token_t) :: mod_identifier, double_colon, fn_identifier
+	type(value_t) :: var_val
+	type(text_span_t) :: span
+	integer :: id_index, iostat
 
 	! Get first part of module name
 	mod_identifier = parser%match(identifier_token)
@@ -389,12 +392,20 @@ recursive module function parse_qualified_expr(parser) result(expr)
 		! Qualified function call: std::println(...) or math::vectors::fn(...)
 		expr = parser%parse_fn_call(module_name, fn_identifier)
 	else
-		! Qualified variable access (future: for user modules)
-		! For now, just report an error since std:: variables don't exist
-		expr%kind = name_expr
-		expr%identifier = fn_identifier
+		! Qualified variable access: mod::var
+		lookup_name = module_name // "::" // fn_name
+		call parser%vars%search(lookup_name, id_index, iostat, var_val)
+
+		if (iostat /= exit_success) then
+			span = new_span(fn_identifier%pos, len(fn_identifier%text))
+			call parser%diagnostics%push( &
+				err_undeclare_var(parser%context(), span, fn_name))
+			return
+		end if
+
+		expr = new_name_expr(fn_identifier, var_val)
+		expr%id_index = id_index
 		expr%module_prefix = module_name
-		! TODO: implement module variable lookup
 	end if
 
 end function parse_qualified_expr

--- a/src/parse_misc.f90
+++ b/src/parse_misc.f90
@@ -383,6 +383,7 @@ module function parse_unit(parser) result(unit)
 	num_fns0 = parser%num_fns    ! includes intrinsic fns
 	num_structs0 = parser%num_structs
 	parser%fn_names = new_string_vector()
+	parser%var_names = new_string_vector()
 
 	do while (parser%current_kind() /= eof_token)
 

--- a/src/tests/test-src/modules/counter.syntran
+++ b/src/tests/test-src/modules/counter.syntran
@@ -1,0 +1,20 @@
+// Module with a variable and functions that use it
+
+let count = 0;
+
+fn get_count(): i32
+{
+	return count;
+}
+
+fn increment(): i32
+{
+	count = count + 1;
+	return count;
+}
+
+fn set_count(val: i32)
+{
+	count = val;
+	return;
+}

--- a/src/tests/test-src/modules/geometry.syntran
+++ b/src/tests/test-src/modules/geometry.syntran
@@ -1,0 +1,18 @@
+// A geometry module that uses the mymath module
+
+use mymath::*;
+
+fn rectangle_area(width: i32, height: i32): i32
+{
+	return mul(width, height);
+}
+
+fn square_area(side: i32): i32
+{
+	return mul(side, side);
+}
+
+fn sum_of_squares(a: i32, b: i32): i32
+{
+	return add(mul(a, a), mul(b, b));
+}

--- a/src/tests/test-src/modules/math/vectors.syntran
+++ b/src/tests/test-src/modules/math/vectors.syntran
@@ -1,0 +1,16 @@
+// Vector math module in a subdirectory
+
+fn dot(a: [i32; :], b: [i32; :]): i32
+{
+	return sum(a * b);
+}
+
+fn magnitude_squared(v: [i32; :]): i32
+{
+	return sum(v * v);
+}
+
+fn add_vectors(a: [i32; :], b: [i32; :]): [i32; :]
+{
+	return a + b;
+}

--- a/src/tests/test-src/modules/math/vectors.syntran
+++ b/src/tests/test-src/modules/math/vectors.syntran
@@ -1,9 +1,9 @@
 // Vector math module in a subdirectory
 
-fn dot(a: [i32; :], b: [i32; :]): i32
+fn vdot(a: [i32; :], b: [i32; :]): i32
 {
 	// Off-by-one from std::dot fn so we can tell which one is getting
-	// called
+	// called.  Named 'vdot' to avoid shadowing the 'dot' intrinsic.
 	return sum(a * b) + 1;
 }
 

--- a/src/tests/test-src/modules/math/vectors.syntran
+++ b/src/tests/test-src/modules/math/vectors.syntran
@@ -2,7 +2,9 @@
 
 fn dot(a: [i32; :], b: [i32; :]): i32
 {
-	return sum(a * b);
+	// Off-by-one from std::dot fn so we can tell which one is getting
+	// called
+	return sum(a * b) + 1;
 }
 
 fn magnitude_squared(v: [i32; :]): i32

--- a/src/tests/test-src/modules/mymath.syntran
+++ b/src/tests/test-src/modules/mymath.syntran
@@ -1,0 +1,11 @@
+// A simple math module
+
+fn add(a: i32, b: i32): i32
+{
+	return a + b;
+}
+
+fn mul(a: i32, b: i32): i32
+{
+	return a * b;
+}

--- a/src/tests/test-src/modules/subdir/deep/test-grandparent-qualified.syntran
+++ b/src/tests/test-src/modules/subdir/deep/test-grandparent-qualified.syntran
@@ -1,0 +1,7 @@
+// Test qualified import from grandparent directory
+use ../../mymath;
+
+let a = mymath::add(10, 20);
+let b = mymath::mul(5, 6);
+
+return a == 30 and b == 30;

--- a/src/tests/test-src/modules/subdir/deep/test-grandparent.syntran
+++ b/src/tests/test-src/modules/subdir/deep/test-grandparent.syntran
@@ -1,0 +1,7 @@
+// Test glob import from grandparent directory
+use ../../mymath::*;
+
+let a = add(10, 20);
+let b = mul(5, 6);
+
+return a == 30 and b == 30;

--- a/src/tests/test-src/modules/subdir/test-parent-import.syntran
+++ b/src/tests/test-src/modules/subdir/test-parent-import.syntran
@@ -1,0 +1,7 @@
+// Test glob import from parent directory
+use ../mymath::*;
+
+let a = add(1, 2);
+let b = mul(3, 4);
+
+return a == 3 and b == 12;

--- a/src/tests/test-src/modules/subdir/test-parent-qualified.syntran
+++ b/src/tests/test-src/modules/subdir/test-parent-qualified.syntran
@@ -1,0 +1,7 @@
+// Test qualified import from parent directory
+use ../mymath;
+
+let a = mymath::add(1, 2);
+let b = mymath::mul(3, 4);
+
+return a == 3 and b == 12;

--- a/src/tests/test-src/modules/test-01.syntran
+++ b/src/tests/test-src/modules/test-01.syntran
@@ -5,7 +5,7 @@ use mymath::*;
 let a = add(2, 3);
 let b = mul(4, 5);
 
-println("add(2, 3) = ", a);
-println("mul(4, 5) = ", b);
+//println("add(2, 3) = ", a);
+//println("mul(4, 5) = ", b);
 
 return a == 5 and b == 20;

--- a/src/tests/test-src/modules/test-01.syntran
+++ b/src/tests/test-src/modules/test-01.syntran
@@ -1,0 +1,11 @@
+// Test module import
+
+use mymath::*;
+
+let a = add(2, 3);
+let b = mul(4, 5);
+
+println("add(2, 3) = ", a);
+println("mul(4, 5) = ", b);
+
+return a == 5 and b == 20;

--- a/src/tests/test-src/modules/test-02.syntran
+++ b/src/tests/test-src/modules/test-02.syntran
@@ -1,0 +1,16 @@
+// Test module with intrinsic function usage
+
+use utils::*;
+
+let a = square(5);
+let b = cube(3);
+let arr = [1, 2, 3, 4, 5];
+let s = sum_array(arr);
+let m = max_val(10, 7);
+
+println("square(5) = ", a);
+println("cube(3) = ", b);
+println("sum_array([1,2,3,4,5]) = ", s);
+println("max_val(10, 7) = ", m);
+
+return a == 25 and b == 27 and s == 15 and m == 10;

--- a/src/tests/test-src/modules/test-02.syntran
+++ b/src/tests/test-src/modules/test-02.syntran
@@ -8,9 +8,9 @@ let arr = [1, 2, 3, 4, 5];
 let s = sum_array(arr);
 let m = max_val(10, 7);
 
-println("square(5) = ", a);
-println("cube(3) = ", b);
-println("sum_array([1,2,3,4,5]) = ", s);
-println("max_val(10, 7) = ", m);
+//println("square(5) = ", a);
+//println("cube(3) = ", b);
+//println("sum_array([1,2,3,4,5]) = ", s);
+//println("max_val(10, 7) = ", m);
 
 return a == 25 and b == 27 and s == 15 and m == 10;

--- a/src/tests/test-src/modules/test-03.syntran
+++ b/src/tests/test-src/modules/test-03.syntran
@@ -8,9 +8,9 @@ let b = mul(4, 5);
 let c = square(6);
 let d = max_val(a, b);
 
-println("add(2, 3) = ", a);
-println("mul(4, 5) = ", b);
-println("square(6) = ", c);
-println("max_val(5, 20) = ", d);
+//println("add(2, 3) = ", a);
+//println("mul(4, 5) = ", b);
+//println("square(6) = ", c);
+//println("max_val(5, 20) = ", d);
 
 return a == 5 and b == 20 and c == 36 and d == 20;

--- a/src/tests/test-src/modules/test-03.syntran
+++ b/src/tests/test-src/modules/test-03.syntran
@@ -1,0 +1,16 @@
+// Test importing multiple modules
+
+use mymath::*;
+use utils::*;
+
+let a = add(2, 3);
+let b = mul(4, 5);
+let c = square(6);
+let d = max_val(a, b);
+
+println("add(2, 3) = ", a);
+println("mul(4, 5) = ", b);
+println("square(6) = ", c);
+println("max_val(5, 20) = ", d);
+
+return a == 5 and b == 20 and c == 36 and d == 20;

--- a/src/tests/test-src/modules/test-04.syntran
+++ b/src/tests/test-src/modules/test-04.syntran
@@ -6,8 +6,8 @@ let a = rectangle_area(4, 5);
 let b = square_area(7);
 let c = sum_of_squares(3, 4);
 
-println("rectangle_area(4, 5) = ", a);
-println("square_area(7) = ", b);
-println("sum_of_squares(3, 4) = ", c);
+//println("rectangle_area(4, 5) = ", a);
+//println("square_area(7) = ", b);
+//println("sum_of_squares(3, 4) = ", c);
 
 return a == 20 and b == 49 and c == 25;

--- a/src/tests/test-src/modules/test-04.syntran
+++ b/src/tests/test-src/modules/test-04.syntran
@@ -1,0 +1,13 @@
+// Test nested module imports (geometry uses mymath)
+
+use geometry::*;
+
+let a = rectangle_area(4, 5);
+let b = square_area(7);
+let c = sum_of_squares(3, 4);
+
+println("rectangle_area(4, 5) = ", a);
+println("square_area(7) = ", b);
+println("sum_of_squares(3, 4) = ", c);
+
+return a == 20 and b == 49 and c == 25;

--- a/src/tests/test-src/modules/test-05.syntran
+++ b/src/tests/test-src/modules/test-05.syntran
@@ -1,0 +1,11 @@
+// Test qualified module import (use module; instead of use module::*)
+
+use mymath;
+
+let a = mymath::add(2, 3);
+let b = mymath::mul(4, 5);
+
+println("mymath::add(2, 3) = ", a);
+println("mymath::mul(4, 5) = ", b);
+
+return a == 5 and b == 20;

--- a/src/tests/test-src/modules/test-05.syntran
+++ b/src/tests/test-src/modules/test-05.syntran
@@ -5,7 +5,7 @@ use mymath;
 let a = mymath::add(2, 3);
 let b = mymath::mul(4, 5);
 
-println("mymath::add(2, 3) = ", a);
-println("mymath::mul(4, 5) = ", b);
+//println("mymath::add(2, 3) = ", a);
+//println("mymath::mul(4, 5) = ", b);
 
 return a == 5 and b == 20;

--- a/src/tests/test-src/modules/test-06.syntran
+++ b/src/tests/test-src/modules/test-06.syntran
@@ -5,14 +5,13 @@ use math/vectors::*;
 let a = [1, 2, 3];
 let b = [4, 5, 6];
 
-let d = dot(a, b) - 1;
-//let d = math::vectors::dot(a, b) - 1;
-
+let d = vdot(a, b);
 let m = magnitude_squared(a);
 let c = add_vectors(a, b);
 
-//println("dot([1,2,3], [4,5,6]) = ", d);
+//println("vdot([1,2,3], [4,5,6]) = ", d);
 //println("magnitude_squared([1,2,3]) = ", m);
 //println("add_vectors result = ", c);
 
-return d == std::dot(a,b) and m == 14 and c[0] == 5 and c[1] == 7 and c[2] == 9;
+// vdot returns sum(a*b) + 1 = 32 + 1 = 33
+return d == 33 and m == 14 and c[0] == 5 and c[1] == 7 and c[2] == 9;

--- a/src/tests/test-src/modules/test-06.syntran
+++ b/src/tests/test-src/modules/test-06.syntran
@@ -1,0 +1,16 @@
+// Test importing a module from a subdirectory
+
+use math/vectors::*;
+
+let a = [1, 2, 3];
+let b = [4, 5, 6];
+
+let d = dot(a, b);
+let m = magnitude_squared(a);
+let c = add_vectors(a, b);
+
+//println("dot([1,2,3], [4,5,6]) = ", d);
+//println("magnitude_squared([1,2,3]) = ", m);
+//println("add_vectors result = ", c);
+
+return d == 32 and m == 14 and c[0] == 5 and c[1] == 7 and c[2] == 9;

--- a/src/tests/test-src/modules/test-06.syntran
+++ b/src/tests/test-src/modules/test-06.syntran
@@ -5,7 +5,9 @@ use math/vectors::*;
 let a = [1, 2, 3];
 let b = [4, 5, 6];
 
-let d = dot(a, b);
+let d = dot(a, b) - 1;
+//let d = math::vectors::dot(a, b) - 1;
+
 let m = magnitude_squared(a);
 let c = add_vectors(a, b);
 
@@ -13,4 +15,4 @@ let c = add_vectors(a, b);
 //println("magnitude_squared([1,2,3]) = ", m);
 //println("add_vectors result = ", c);
 
-return d == 32 and m == 14 and c[0] == 5 and c[1] == 7 and c[2] == 9;
+return d == std::dot(a,b) and m == 14 and c[0] == 5 and c[1] == 7 and c[2] == 9;

--- a/src/tests/test-src/modules/test-07.syntran
+++ b/src/tests/test-src/modules/test-07.syntran
@@ -1,0 +1,17 @@
+// Test subdirectory import with qualified calls
+
+use math/vectors;
+
+let a = [1, 2, 3];
+let b = [4, 5, 6];
+
+let d = math::vectors::vdot(a, b);
+let m = math::vectors::magnitude_squared(a);
+let c = math::vectors::add_vectors(a, b);
+
+//println("math::vectors::vdot([1,2,3], [4,5,6]) = ", d);
+//println("math::vectors::magnitude_squared([1,2,3]) = ", m);
+//println("math::vectors::add_vectors result = ", c);
+
+// vdot returns sum(a*b) + 1 = 32 + 1 = 33
+return d == 33 and m == 14 and c[0] == 5 and c[1] == 7 and c[2] == 9;

--- a/src/tests/test-src/modules/test-cwd-qualified.syntran
+++ b/src/tests/test-src/modules/test-cwd-qualified.syntran
@@ -1,0 +1,7 @@
+// Test qualified current directory import with ./
+use ./mymath;
+
+let a = mymath::add(1, 2);
+let b = mymath::mul(3, 4);
+
+return a == 3 and b == 12;

--- a/src/tests/test-src/modules/test-cwd.syntran
+++ b/src/tests/test-src/modules/test-cwd.syntran
@@ -1,0 +1,7 @@
+// Test current directory import with ./
+use ./mymath::*;
+
+let a = add(1, 2);
+let b = mul(3, 4);
+
+return a == 3 and b == 12;

--- a/src/tests/test-src/modules/test-modvar-01.syntran
+++ b/src/tests/test-src/modules/test-modvar-01.syntran
@@ -1,0 +1,30 @@
+// Test module variables with unqualified import (use module::*)
+
+use counter::*;
+
+// Test initial value
+let ok1 = count == 0;
+
+// Test reading via function
+let ok2 = get_count() == 0;
+
+// Test increment function modifying module variable
+let c1 = increment();
+let ok3 = c1 == 1;
+let ok4 = count == 1;
+
+// Test another increment
+let c2 = increment();
+let ok5 = c2 == 2;
+let ok6 = get_count() == 2;
+
+// Test direct assignment to module variable
+count = 10;
+let ok7 = count == 10;
+let ok8 = get_count() == 10;
+
+// Test set function
+set_count(42);
+let ok9 = count == 42;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6 and ok7 and ok8 and ok9;

--- a/src/tests/test-src/modules/test-modvar-02.syntran
+++ b/src/tests/test-src/modules/test-modvar-02.syntran
@@ -13,9 +13,14 @@ let c1 = counter::increment();
 let ok3 = c1 == 1;
 let ok4 = counter::count == 1;
 
-// Test set function (workaround for qualified assignment)
-counter::set_count(100);
-let ok5 = counter::count == 100;
-let ok6 = counter::get_count() == 100;
+// Test direct qualified assignment
+counter::count = 50;
+let ok5 = counter::count == 50;
+let ok6 = counter::get_count() == 50;
 
-return ok1 and ok2 and ok3 and ok4 and ok5 and ok6;
+// Test set function still works
+counter::set_count(100);
+let ok7 = counter::count == 100;
+let ok8 = counter::get_count() == 100;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6 and ok7 and ok8;

--- a/src/tests/test-src/modules/test-modvar-02.syntran
+++ b/src/tests/test-src/modules/test-modvar-02.syntran
@@ -1,0 +1,21 @@
+// Test module variables with qualified import (use module;)
+
+use counter;
+
+// Test initial value via qualified access
+let ok1 = counter::count == 0;
+
+// Test reading via qualified function
+let ok2 = counter::get_count() == 0;
+
+// Test increment function modifying module variable
+let c1 = counter::increment();
+let ok3 = c1 == 1;
+let ok4 = counter::count == 1;
+
+// Test set function (workaround for qualified assignment)
+counter::set_count(100);
+let ok5 = counter::count == 100;
+let ok6 = counter::get_count() == 100;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6;

--- a/src/tests/test-src/modules/utils.syntran
+++ b/src/tests/test-src/modules/utils.syntran
@@ -1,0 +1,24 @@
+// A utility module that uses intrinsic functions
+
+fn square(x: i32): i32
+{
+	return x * x;
+}
+
+fn cube(x: i32): i32
+{
+	return x * x * x;
+}
+
+fn sum_array(arr: [i32; :]): i32
+{
+	// Uses intrinsic sum function
+	return sum(arr);
+}
+
+fn max_val(a: i32, b: i32): i32
+{
+	if (a > b)
+		return a;
+	return b;
+}

--- a/src/tests/test-src/recursion/test-05.syntran
+++ b/src/tests/test-src/recursion/test-05.syntran
@@ -5,6 +5,18 @@
 // It's based on some fortran code that I wrote eons ago, so some of the
 // variable names and argument conventions are crazy
 
+// TODO: re-write this with an algorithm like I tried for AOC 2025 day 12
+// (packing shapes into a grid)
+//
+// The algorithm here is weird and it feels unnatural.  I wouldn't really be
+// able to explain this algo or write it without references.  On the other
+// hand, the recursive backtrack algo I used for AOC feels more natural and I
+// came up with it from memory and first-principles.  Unfortunately, it didn't
+// work very well because it could only pack two lines from the test input and
+// then the permutations exploded.  If I can get it working here for sudoku,
+// that will be a better test for it.  If successful, maybe break out into a
+// separate syntran unit test
+
 //==============================================================================
 
 // Square sudoku grid size

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4479,6 +4479,9 @@ subroutine unit_test_modules(npass, nfail)
 			interpret_file(path//'test-05.syntran', quiet) == 'true', &
 			interpret_file(path//'test-06.syntran', quiet) == 'true', &
 			interpret_file(path//'test-07.syntran', quiet) == 'true', &
+			interpret_file(path//'subdir/test-parent-import.syntran', quiet) == 'true', &
+			interpret_file(path//'subdir/test-parent-qualified.syntran', quiet) == 'true', &
+			interpret_file(path//'subdir/deep/test-grandparent.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4452,6 +4452,44 @@ end subroutine unit_test_recursion
 
 !===============================================================================
 
+subroutine unit_test_modules(npass, nfail)
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'module scripts'
+
+	! Path to syntran test files from root of repo
+	character(len = *), parameter :: path = 'src/tests/test-src/modules/'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			interpret_file(path//'test-01.syntran', quiet) == 'true', &
+			interpret_file(path//'test-02.syntran', quiet) == 'true', &
+			interpret_file(path//'test-03.syntran', quiet) == 'true', &
+			interpret_file(path//'test-04.syntran', quiet) == 'true', &
+			interpret_file(path//'test-05.syntran', quiet) == 'true', &
+			interpret_file(path//'test-06.syntran', quiet) == 'true', &
+			.false.  & ! so I don't have to bother w/ trailing commas
+		]
+
+	! Trim dummy false element
+	tests = tests(1: size(tests) - 1)
+
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_modules
+
+!===============================================================================
+
 subroutine unit_test_array_bool(npass, nfail)
 
 	! More advanced tests on longer scripts
@@ -4685,6 +4723,7 @@ subroutine unit_tests(iostat)
 	call unit_test_bitwise_2  (npass, nfail)
 	call unit_test_ref        (npass, nfail)
 	call unit_test_recursion  (npass, nfail)
+	call unit_test_modules    (npass, nfail)
 
 	! TODO: add tests that mock interpreting one line at a time (as opposed to
 	! whole files)

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4478,6 +4478,7 @@ subroutine unit_test_modules(npass, nfail)
 			interpret_file(path//'test-04.syntran', quiet) == 'true', &
 			interpret_file(path//'test-05.syntran', quiet) == 'true', &
 			interpret_file(path//'test-06.syntran', quiet) == 'true', &
+			interpret_file(path//'test-07.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4479,9 +4479,12 @@ subroutine unit_test_modules(npass, nfail)
 			interpret_file(path//'test-05.syntran', quiet) == 'true', &
 			interpret_file(path//'test-06.syntran', quiet) == 'true', &
 			interpret_file(path//'test-07.syntran', quiet) == 'true', &
+			interpret_file(path//'test-cwd.syntran', quiet) == 'true', &
+			interpret_file(path//'test-cwd-qualified.syntran', quiet) == 'true', &
 			interpret_file(path//'subdir/test-parent-import.syntran', quiet) == 'true', &
 			interpret_file(path//'subdir/test-parent-qualified.syntran', quiet) == 'true', &
 			interpret_file(path//'subdir/deep/test-grandparent.syntran', quiet) == 'true', &
+			interpret_file(path//'subdir/deep/test-grandparent-qualified.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/types.f90
+++ b/src/types.f90
@@ -159,6 +159,9 @@ module syntran__types_m
 		!type(struct_t), allocatable :: struct
 		character(len = :), allocatable :: struct_name
 
+		! Module prefix for qualified names (e.g., "std" in "std::println")
+		character(len = :), allocatable :: module_prefix
+
 		type(string_vector_t) :: diagnostics
 
 		! Only used to handle comment/whitespace lines for now
@@ -765,6 +768,12 @@ recursive subroutine syntax_node_copy(dst, src)
 		dst%struct_name = src%struct_name
 	else if (allocated(dst%struct_name)) then
 		deallocate(dst%struct_name)
+	end if
+
+	if (allocated(src%module_prefix)) then
+		dst%module_prefix = src%module_prefix
+	else if (allocated(dst%module_prefix)) then
+		deallocate(dst%module_prefix)
 	end if
 
 	dst%expecting       = src%expecting
@@ -1422,6 +1431,9 @@ integer function get_keyword_kind(text) result(kind)
 
 		case ("continue")
 			kind = continue_keyword
+
+		case ("use")
+			kind = use_keyword
 
 		case default
 			kind = identifier_token

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -879,6 +879,45 @@ end function rm_char
 
 !===============================================================================
 
+function replace_all(str_, old, new) result(str_out)
+
+	! Replace all occurrences of substring `old` with `new` in `str_`
+
+	character(len = *), intent(in) :: str_, old, new
+
+	character(len = :), allocatable :: str_out
+
+	!********
+
+	integer :: pos, start
+	type(char_vector_t) :: sb  ! string builder
+
+	if (len(old) == 0) then
+		str_out = str_
+		return
+	end if
+
+	sb = new_char_vector()
+	start = 1
+	pos = index(str_(start:), old)
+	do while (pos > 0)
+		! Push everything before the match
+		call sb%push(str_(start: start + pos - 2))
+		! Push the replacement
+		call sb%push(new)
+		! Move past the matched substring
+		start = start + pos - 1 + len(old)
+		! Find next match
+		pos = index(str_(start:), old)
+	end do
+	! Push the remaining part
+	call sb%push(str_(start:))
+	str_out = sb%trim()
+
+end function replace_all
+
+!===============================================================================
+
 function tabs2spaces(str_) result(str_out)
 
 	! Replace each tab with a *single* space.  This is useful for alignment and


### PR DESCRIPTION
## Summary

- Add `::` token for namespace access (e.g., `std::println()`)
- Add `use` keyword for importing from modules
- All intrinsics accessible via `std::` prefix while remaining globally available (backwards compatible)
- Parse `use std::fn_name;` and `use std::*;` statements
- User-defined modules are experimental
  - Functions from user modules work well
  - Scalar module variables work
  - Array module variables do *not* work
  - Structs untested

## Features

### std built-in module
```rust
// Qualified access to intrinsics
let s = std::str(42);
std::println("hello");

// Import statements (no-op for std since intrinsics are global)
use std::println;
use std::*;
```

### User modules

counter.syntran:
```rust
// Module with a variable and functions that use it
let count = 0;
fn get_count(): i32 {
        return count;
}
fn increment(): i32 {
        count = count + 1;
        return count;
}
fn set_count(val: i32) {
        count = val;
        return;
}
```

main program:
```rust
// Test module variables with qualified import (use module;)
use counter;

// Test initial value via qualified access
let ok1 = counter::count == 0;

// Test reading via qualified function
let ok2 = counter::get_count() == 0;

// Test increment function modifying module variable
let c1 = counter::increment();
let ok3 = c1 == 1;
let ok4 = counter::count == 1;

// Test direct qualified assignment
counter::count = 50;
let ok5 = counter::count == 50;
let ok6 = counter::get_count() == 50;

// Test set function still works
counter::set_count(100);
let ok7 = counter::count == 100;
let ok8 = counter::get_count() == 100;
```

## Files Changed

- `src/consts.f90` - Add `double_colon_token`, `use_keyword`
- `src/lex.f90` - Recognize `::` token
- `src/types.f90` - Add `use` keyword, `module_prefix` field
- `src/parse.f90` - Interface declarations
- `src/parse_expr.f90` - Qualified name detection
- `src/parse_fn.f90` - `parse_qualified_expr()`, `parse_qualified_fn_call()`
- `src/parse_control.f90` - `parse_use_statement()`

## Test plan

- [x] `std::println("hello")` works
- [x] `std::str(42)` works  
- [x] `use std::println;` parses without error
- [x] `use std::*;` parses without error
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)