### PR TITLE
Feature/bytecode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -501,8 +501,6 @@
 				"
 					set -exu \n
 
-					ulimit -s unlimited \n
-
 					if [[ \"${{ env.FC }}\" != \"ifort\" ]] ; then \n
 					if [[ \"${{ matrix.toolchain.version }}\" != \"2023.1\" ]] ; then \n
 						fpm test test --profile debug   --verbose --flag \"-DSYNTRAN_INTEL -fpp\" \n

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -510,7 +510,6 @@
 					fi \n
 
 					fpm test test --profile release --verbose --flag \"-DSYNTRAN_INTEL -fpp -Ofast\" \n
-					fpm test long --profile debug   --verbose --flag \"-DSYNTRAN_INTEL -fpp\" \n
 					fpm test long --profile release --verbose --flag \"-DSYNTRAN_INTEL -fpp -Ofast\" \n
 				"
 			}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -501,6 +501,8 @@
 				"
 					set -exu \n
 
+					ulimit -s unlimited \n
+
 					if [[ \"${{ env.FC }}\" != \"ifort\" ]] ; then \n
 					if [[ \"${{ matrix.toolchain.version }}\" != \"2023.1\" ]] ; then \n
 						fpm test test --profile debug   --verbose --flag \"-DSYNTRAN_INTEL -fpp\" \n

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -510,6 +510,7 @@
 					fi \n
 
 					fpm test test --profile release --verbose --flag \"-DSYNTRAN_INTEL -fpp -Ofast\" \n
+					fpm test long --profile debug   --verbose --flag \"-DSYNTRAN_INTEL -fpp\" \n
 					fpm test long --profile release --verbose --flag \"-DSYNTRAN_INTEL -fpp -Ofast\" \n
 				"
 			}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,9 @@
 
 					# Short tests only.  Long tests are only done in release \n
 					fpm test test --profile debug --link-flag \"$lflags\" \n
+
+					# Also test the legacy AST backend so both paths are exercised \n
+					SYNTRAN_BACKEND=ast fpm test test --profile debug --link-flag \"$lflags\" \n
 				"
 			},
 			{

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(LIB_SRC
 	${SRC_DIR}/eval_fn.f90
 	${SRC_DIR}/vm.f90
 	${SRC_DIR}/vm_exec.f90
+	${SRC_DIR}/vm_intr.f90
 	${SRC_DIR}/intr_fns.f90
 	${SRC_DIR}/intr_fns_array.f90
 	${SRC_DIR}/intr_fns_io.f90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,10 @@ set(SRC_DIR "src")
 set(LIB "${PROJECT}")
 set(LIB_SRC
 	${SRC_DIR}/bool.f90
+	${SRC_DIR}/bytecode.f90
 	${SRC_DIR}/compiler.F90
+	${SRC_DIR}/compile.f90
+	${SRC_DIR}/compile_ctrl.f90
 	${SRC_DIR}/consts.f90
 	${SRC_DIR}/core.f90
 	${SRC_DIR}/errors.f90
@@ -86,6 +89,8 @@ set(LIB_SRC
 	${SRC_DIR}/eval_control.f90
 	${SRC_DIR}/eval_expr.f90
 	${SRC_DIR}/eval_fn.f90
+	${SRC_DIR}/vm.f90
+	${SRC_DIR}/vm_exec.f90
 	${SRC_DIR}/intr_fns.f90
 	${SRC_DIR}/intr_fns_array.f90
 	${SRC_DIR}/intr_fns_io.f90

--- a/src/app.f90
+++ b/src/app.f90
@@ -126,6 +126,7 @@ subroutine set_ansi_colors(is_color_in)
 		fg_bright_magenta  = FG_BRIGHT_MAGENTA_
 		fg_bright_cyan     = FG_BRIGHT_CYAN_
 		fg_bright_white    = FG_BRIGHT_WHITE_
+		fg_bold_yellow     = FG_BOLD_YELLOW_
 		color_reset        = COLOR_RESET_
 	else
 		fg_bold            = ""
@@ -137,6 +138,7 @@ subroutine set_ansi_colors(is_color_in)
 		fg_bright_magenta  = ""
 		fg_bright_cyan     = ""
 		fg_bright_white    = ""
+		fg_bold_yellow     = ""
 		color_reset        = ""
 	end if
 

--- a/src/benchmarks/benchmark.sh
+++ b/src/benchmarks/benchmark.sh
@@ -11,7 +11,11 @@ echo "=============================================================="
 echo "    SYNTRAN:"
 
 for ((i=1; i<=$n; i++)) ; do
+	# Locally-built version
 	time ./build/Release/syntran src/benchmarks/primes-1.syntran
+
+	### Installed version
+	#time syntran src/benchmarks/primes-1.syntran
 done
 
 echo "=============================================================="

--- a/src/benchmarks/primes-1.py
+++ b/src/benchmarks/primes-1.py
@@ -1,5 +1,5 @@
 
-n = 30000
+n = 60000
 #n = 100
 
 prime = 0
@@ -12,6 +12,7 @@ for i in range(0, n):
     for j in range(2, i//2 + 1):
         divisible = j * (i // j) == i
         is_composite = is_composite or divisible
+        if (is_composite): break
 
     if not is_composite:
         prime = i

--- a/src/benchmarks/primes-1.syntran
+++ b/src/benchmarks/primes-1.syntran
@@ -1,35 +1,34 @@
 
+// Get the largest prime number less than n
+let n = 60000;
+
+// Initialize the largest prime found so far
+let prime = 0;
+
+// This check is O(n**2) time, which might be the best we can do
+// without having arrays in the language yet
+
+// If we had while loops, we could loop from n downards and stop as
+// soon as we find the first prime
+for i in [0: n]
 {
-	// Get the largest prime number less than n
-	let n = 30000;
+	// Check if i is composite, i.e. not prime
+	let is_composite = false;
 
-	// Initialize the largest prime found so far
-	let prime = 0;
-
-	// This check is O(n**2) time, which might be the best we can do
-	// without having arrays in the language yet
-
-	// If we had while loops, we could loop from n downards and stop as
-	// soon as we find the first prime
-	for i in [0: n]
+	// Largest possible divisor of i is i/2.  Actually it's sqrt(i)
+	// but I don't have a sqrt fn yet
+	for j in [2: i/2 + 1]
 	{
-		// Check if i is composite, i.e. not prime
-		let is_composite = false;
-
-		// Largest possible divisor of i is i/2.  Actually it's sqrt(i)
-		// but I don't have a sqrt fn yet
-		for j in [2: i/2 + 1]
-		{
-			// Is i divisible by j?
-			let divisible = j * (i / j) == i;  // poor man's modulo == 0
-			is_composite = is_composite or divisible;
-		}
-
-		if not is_composite
-			prime = i;
+		// Is i divisible by j?
+		let divisible = j * (i / j) == i;  // poor man's modulo == 0
+		is_composite = is_composite or divisible;
+		if (is_composite) break;
 	}
 
-	// Final result
-	prime;
+	if not is_composite
+		prime = i;
 }
+
+// Final result
+println(prime);
 

--- a/src/bool.f90
+++ b/src/bool.f90
@@ -118,7 +118,7 @@ subroutine is_eq_value_t(left, right, res, op_text)
 	case        (magic * bool_type + bool_type)
 		res%sca%bool = left%sca%bool .eqv. right%sca%bool
 	case        (magic * str_type + str_type)
-		res%sca%bool = is_str_eq(left%sca%str%s, right%sca%str%s)
+		res%sca%bool = is_str_eq(left%str%s, right%str%s)
 
 	case        (magic * array_type + i32_type)
 
@@ -233,7 +233,7 @@ subroutine is_eq_value_t(left, right, res, op_text)
 			do i8 = 1, res%array%len_
 				res%array%bool(i8) = is_str_eq( &
 					left%array%str(i8)%s, &
-					right%sca%str%s &
+					right%str%s &
 				)
 			end do
 
@@ -351,7 +351,7 @@ subroutine is_eq_value_t(left, right, res, op_text)
 			allocate(res%array%bool( res%array%len_ ))
 			do i8 = 1, res%array%len_
 				res%array%bool(i8) = is_str_eq( &
-					left%sca%str%s, &
+					left%str%s, &
 					right%array%str(i8)%s &
 				)
 			end do

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -13,17 +13,21 @@ module syntran__bytecode_m
 	! enum in consts.f90 (which tops out at 121) to prevent accidental aliasing.
 
 	integer, parameter :: &
-		OP_EVAL_NODE   = 1001, &	! fallback: run one AST node through syntax_eval
-		OP_LOAD_CONST  = 1002, &	! push consts(a) onto the operand stack (deep copy)
-		OP_LOAD_GLOBAL = 1003, &	! push state%vars%vals(a) (deep copy)
-		OP_LOAD_LOCAL  = 1004, &	! push state%locs%vals(a) (deep copy)
-		OP_STORE_GLOBAL= 1005, &	! copy TOS into state%vars%vals(a), keep TOS
-		OP_STORE_LOCAL = 1006, &	! copy TOS into state%locs%vals(a), keep TOS
-		OP_BINOP       = 1007, &	! pop right+left, compute with op-token a, push result
-		OP_UNOP        = 1008, &	! pop operand, compute with op-token a, push result
-		OP_POP         = 1009, &	! discard TOS
-		OP_JUMP          = 1010, &	! unconditional jump: ip = a
-		OP_JUMP_IF_FALSE = 1011  	! pop bool TOS; if false: ip = a, else continue
+		OP_EVAL_NODE        = 1001, &	! fallback: run one AST node through syntax_eval
+		OP_LOAD_CONST       = 1002, &	! push consts(a) onto the operand stack (deep copy)
+		OP_LOAD_GLOBAL      = 1003, &	! push state%vars%vals(a) (deep copy)
+		OP_LOAD_LOCAL       = 1004, &	! push state%locs%vals(a) (deep copy)
+		OP_STORE_GLOBAL     = 1005, &	! copy TOS into state%vars%vals(a), keep TOS
+		OP_STORE_LOCAL      = 1006, &	! copy TOS into state%locs%vals(a), keep TOS
+		OP_BINOP            = 1007, &	! pop right+left, compute with op-token a, push result
+		OP_UNOP             = 1008, &	! pop operand, compute with op-token a, push result
+		OP_POP              = 1009, &	! discard TOS
+		OP_JUMP             = 1010, &	! unconditional jump: ip = a
+		OP_JUMP_IF_FALSE    = 1011, &	! pop bool TOS; if false: ip = a, else continue
+		OP_CALL             = 1012, &	! call user fn: a=fn_id, b=node_pool_idx (fn_call node)
+		OP_RET              = 1013, &	! return from fn: TOS is return value
+		OP_LOAD_REF_GLOBAL  = 1014, &	! move state%vars%vals(a) to stack (by-ref arg, pass 2)
+		OP_LOAD_REF_LOCAL   = 1015 	! move state%locs%vals(a) to stack (by-ref arg, pass 2)
 
 	!********
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -43,6 +43,72 @@ module syntran__bytecode_m
 		OP_STORE_SLICE      = 1027, &	! M8: slice/complex LHS assign: a=node_idx; calls eval_assignment_expr
 		OP_HALT             = 1028  	! M8: top-level return: exit VM loop, TOS is result
 
+	!**** Typed scalar opcodes (Stage 2) -------------------------------------------
+	! Each typed opcode operates in-place on TOS / TOS-1, avoiding value_move and
+	! get_binary_op_kind overhead.  Only same-type scalar combinations are covered;
+	! mixed types and array/string ops fall back to the generic OP_BINOP/UNOP.
+	!
+	! Arithmetic (arith): left=TOS-1, right=TOS; result written to TOS-1, len_--.
+	! Same result type as both operands.
+	integer, parameter :: &
+		OP_ADD_I32 = 1029, OP_ADD_I64 = 1030, OP_ADD_F32 = 1031, OP_ADD_F64 = 1032, &
+		OP_SUB_I32 = 1033, OP_SUB_I64 = 1034, OP_SUB_F32 = 1035, OP_SUB_F64 = 1036, &
+		OP_MUL_I32 = 1037, OP_MUL_I64 = 1038, OP_MUL_F32 = 1039, OP_MUL_F64 = 1040, &
+		OP_DIV_I32 = 1041, OP_DIV_I64 = 1042, OP_DIV_F32 = 1043, OP_DIV_F64 = 1044, &
+		OP_MOD_I32 = 1045, OP_MOD_I64 = 1046, OP_MOD_F32 = 1047, OP_MOD_F64 = 1048
+
+	! Comparisons: result type is bool_type; updates TOS-1%type = bool_type.
+	integer, parameter :: &
+		OP_LT_I32  = 1049, OP_LT_I64  = 1050, OP_LT_F32  = 1051, OP_LT_F64  = 1052, &
+		OP_LE_I32  = 1053, OP_LE_I64  = 1054, OP_LE_F32  = 1055, OP_LE_F64  = 1056, &
+		OP_GT_I32  = 1057, OP_GT_I64  = 1058, OP_GT_F32  = 1059, OP_GT_F64  = 1060, &
+		OP_GE_I32  = 1061, OP_GE_I64  = 1062, OP_GE_F32  = 1063, OP_GE_F64  = 1064, &
+		OP_EQ_I32  = 1065, OP_EQ_I64  = 1066, OP_EQ_F32  = 1067, OP_EQ_F64  = 1068, &
+		OP_EQ_BOOL = 1069, &
+		OP_NE_I32  = 1070, OP_NE_I64  = 1071, OP_NE_F32  = 1072, OP_NE_F64  = 1073, &
+		OP_NE_BOOL = 1074
+
+	! Bool binary: left=TOS-1, right=TOS; result written to TOS-1 (bool), len_--.
+	integer, parameter :: &
+		OP_AND_BOOL = 1075, &
+		OP_OR_BOOL  = 1076
+
+	! Unary: operand=TOS; result written to TOS in-place (no pop).
+	integer, parameter :: &
+		OP_NEG_I32  = 1077, OP_NEG_I64  = 1078, OP_NEG_F32 = 1079, OP_NEG_F64 = 1080, &
+		OP_NOT_BOOL = 1081, &
+		OP_BNOT_I32 = 1082, OP_BNOT_I64 = 1083
+
+	! Typed scalar loads: push a scalar onto the stack without value_copy overhead.
+	!   LOAD_CONST_BOOL:  a = 0 (false) or 1 (true)
+	!   LOAD_CONST_I32:   a = i32 value directly (no const pool)
+	!   LOAD_CONST_I64:   c = i64 value directly (no const pool)
+	!   LOAD_CONST_F32:   a = transfer(f32, 0) — bit pattern as integer
+	!   LOAD_CONST_F64:   c = transfer(f64, 0_8) — bit pattern as integer(8)
+	!   LOAD_LOCAL/GLOBAL_*: a = slot index (same as generic LOAD_LOCAL/GLOBAL)
+	integer, parameter :: &
+		OP_LOAD_CONST_BOOL  = 1084, &
+		OP_LOAD_CONST_I32   = 1085, OP_LOAD_CONST_I64  = 1086, &
+		OP_LOAD_CONST_F32   = 1087, OP_LOAD_CONST_F64  = 1088, &
+		OP_LOAD_LOCAL_BOOL  = 1089, &
+		OP_LOAD_LOCAL_I32   = 1090, OP_LOAD_LOCAL_I64  = 1091, &
+		OP_LOAD_LOCAL_F32   = 1092, OP_LOAD_LOCAL_F64  = 1093, &
+		OP_LOAD_GLOBAL_BOOL = 1094, &
+		OP_LOAD_GLOBAL_I32  = 1095, OP_LOAD_GLOBAL_I64 = 1096, &
+		OP_LOAD_GLOBAL_F32  = 1097, OP_LOAD_GLOBAL_F64 = 1098
+
+	! Typed scalar stores: write TOS into variable slot without assign_ overhead.
+	! Keep TOS (consistent with generic OP_STORE_LOCAL/GLOBAL).
+	! Sets both %type and %sca%*.  Safe because the compiler only emits these when
+	! the static RHS type matches the variable type.
+	integer, parameter :: &
+		OP_STORE_LOCAL_BOOL  = 1099, &
+		OP_STORE_LOCAL_I32   = 1100, OP_STORE_LOCAL_I64  = 1101, &
+		OP_STORE_LOCAL_F32   = 1102, OP_STORE_LOCAL_F64  = 1103, &
+		OP_STORE_GLOBAL_BOOL = 1104, &
+		OP_STORE_GLOBAL_I32  = 1105, OP_STORE_GLOBAL_I64 = 1106, &
+		OP_STORE_GLOBAL_F32  = 1107, OP_STORE_GLOBAL_F64 = 1108
+
 	!**** M6: intrinsic function ids (match order in eval_fn_call_intr / declare_intr_fns)
 
 	! Math
@@ -488,6 +554,200 @@ pure integer function intr_id_from_name(name) result(id)
 	end select
 
 end function intr_id_from_name
+
+!===============================================================================
+
+pure integer function binop_typed_opcode(op_kind, ltype, rtype) result(op)
+
+	! Return the typed scalar opcode for a binary operation on two same-type
+	! scalar operands, or 0 if not specializable (mixed types, arrays, etc.).
+
+	integer, intent(in) :: op_kind, ltype, rtype
+
+	op = 0
+	if (ltype /= rtype) return
+
+	select case (op_kind)
+	case (plus_token)
+		select case (ltype)
+		case (i32_type); op = OP_ADD_I32
+		case (i64_type); op = OP_ADD_I64
+		case (f32_type); op = OP_ADD_F32
+		case (f64_type); op = OP_ADD_F64
+		end select
+	case (minus_token)
+		select case (ltype)
+		case (i32_type); op = OP_SUB_I32
+		case (i64_type); op = OP_SUB_I64
+		case (f32_type); op = OP_SUB_F32
+		case (f64_type); op = OP_SUB_F64
+		end select
+	case (star_token)
+		select case (ltype)
+		case (i32_type); op = OP_MUL_I32
+		case (i64_type); op = OP_MUL_I64
+		case (f32_type); op = OP_MUL_F32
+		case (f64_type); op = OP_MUL_F64
+		end select
+	case (slash_token)
+		select case (ltype)
+		case (i32_type); op = OP_DIV_I32
+		case (i64_type); op = OP_DIV_I64
+		case (f32_type); op = OP_DIV_F32
+		case (f64_type); op = OP_DIV_F64
+		end select
+	case (percent_token)
+		select case (ltype)
+		case (i32_type); op = OP_MOD_I32
+		case (i64_type); op = OP_MOD_I64
+		case (f32_type); op = OP_MOD_F32
+		case (f64_type); op = OP_MOD_F64
+		end select
+	case (less_token)
+		select case (ltype)
+		case (i32_type); op = OP_LT_I32
+		case (i64_type); op = OP_LT_I64
+		case (f32_type); op = OP_LT_F32
+		case (f64_type); op = OP_LT_F64
+		end select
+	case (less_equals_token)
+		select case (ltype)
+		case (i32_type); op = OP_LE_I32
+		case (i64_type); op = OP_LE_I64
+		case (f32_type); op = OP_LE_F32
+		case (f64_type); op = OP_LE_F64
+		end select
+	case (greater_token)
+		select case (ltype)
+		case (i32_type); op = OP_GT_I32
+		case (i64_type); op = OP_GT_I64
+		case (f32_type); op = OP_GT_F32
+		case (f64_type); op = OP_GT_F64
+		end select
+	case (greater_equals_token)
+		select case (ltype)
+		case (i32_type); op = OP_GE_I32
+		case (i64_type); op = OP_GE_I64
+		case (f32_type); op = OP_GE_F32
+		case (f64_type); op = OP_GE_F64
+		end select
+	case (eequals_token)
+		select case (ltype)
+		case (i32_type); op = OP_EQ_I32
+		case (i64_type); op = OP_EQ_I64
+		case (f32_type); op = OP_EQ_F32
+		case (f64_type); op = OP_EQ_F64
+		case (bool_type); op = OP_EQ_BOOL
+		end select
+	case (bang_equals_token)
+		select case (ltype)
+		case (i32_type); op = OP_NE_I32
+		case (i64_type); op = OP_NE_I64
+		case (f32_type); op = OP_NE_F32
+		case (f64_type); op = OP_NE_F64
+		case (bool_type); op = OP_NE_BOOL
+		end select
+	case (and_keyword)
+		if (ltype == bool_type) op = OP_AND_BOOL
+	case (or_keyword)
+		if (ltype == bool_type) op = OP_OR_BOOL
+	end select
+
+end function binop_typed_opcode
+
+!===============================================================================
+
+pure integer function unop_typed_opcode(op_kind, type_) result(op)
+
+	! Return the typed scalar opcode for a unary operation, or 0 if not
+	! specializable.
+
+	integer, intent(in) :: op_kind, type_
+
+	op = 0
+	select case (op_kind)
+	case (minus_token)
+		select case (type_)
+		case (i32_type); op = OP_NEG_I32
+		case (i64_type); op = OP_NEG_I64
+		case (f32_type); op = OP_NEG_F32
+		case (f64_type); op = OP_NEG_F64
+		end select
+	case (not_keyword)
+		if (type_ == bool_type) op = OP_NOT_BOOL
+	case (bang_token)
+		select case (type_)
+		case (i32_type); op = OP_BNOT_I32
+		case (i64_type); op = OP_BNOT_I64
+		end select
+	end select
+
+end function unop_typed_opcode
+
+!===============================================================================
+
+pure integer function typed_load_op(type_, is_const, is_local) result(op)
+
+	! Return the typed scalar load opcode, or 0 for non-scalar types.
+
+	integer, intent(in) :: type_
+	logical, intent(in) :: is_const, is_local
+
+	op = 0
+	select case (type_)
+	case (bool_type)
+		if (is_const) then; op = OP_LOAD_CONST_BOOL
+		else if (is_local) then; op = OP_LOAD_LOCAL_BOOL
+		else; op = OP_LOAD_GLOBAL_BOOL; end if
+	case (i32_type)
+		if (is_const) then; op = OP_LOAD_CONST_I32
+		else if (is_local) then; op = OP_LOAD_LOCAL_I32
+		else; op = OP_LOAD_GLOBAL_I32; end if
+	case (i64_type)
+		if (is_const) then; op = OP_LOAD_CONST_I64
+		else if (is_local) then; op = OP_LOAD_LOCAL_I64
+		else; op = OP_LOAD_GLOBAL_I64; end if
+	case (f32_type)
+		if (is_const) then; op = OP_LOAD_CONST_F32
+		else if (is_local) then; op = OP_LOAD_LOCAL_F32
+		else; op = OP_LOAD_GLOBAL_F32; end if
+	case (f64_type)
+		if (is_const) then; op = OP_LOAD_CONST_F64
+		else if (is_local) then; op = OP_LOAD_LOCAL_F64
+		else; op = OP_LOAD_GLOBAL_F64; end if
+	end select
+
+end function typed_load_op
+
+!===============================================================================
+
+pure integer function typed_store_op(type_, is_local) result(op)
+
+	! Return the typed scalar store opcode, or 0 for non-scalar types.
+
+	integer, intent(in) :: type_
+	logical, intent(in) :: is_local
+
+	op = 0
+	select case (type_)
+	case (bool_type)
+		if (is_local) then; op = OP_STORE_LOCAL_BOOL
+		else; op = OP_STORE_GLOBAL_BOOL; end if
+	case (i32_type)
+		if (is_local) then; op = OP_STORE_LOCAL_I32
+		else; op = OP_STORE_GLOBAL_I32; end if
+	case (i64_type)
+		if (is_local) then; op = OP_STORE_LOCAL_I64
+		else; op = OP_STORE_GLOBAL_I64; end if
+	case (f32_type)
+		if (is_local) then; op = OP_STORE_LOCAL_F32
+		else; op = OP_STORE_GLOBAL_F32; end if
+	case (f64_type)
+		if (is_local) then; op = OP_STORE_LOCAL_F64
+		else; op = OP_STORE_GLOBAL_F64; end if
+	end select
+
+end function typed_store_op
 
 !===============================================================================
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -13,7 +13,7 @@ module syntran__bytecode_m
 	! enum in consts.f90 (which tops out at 121) to prevent accidental aliasing.
 
 	integer, parameter :: &
-		OP_EVAL_NODE        = 1001, &	! fallback: run one AST node through syntax_eval
+		OP_EVAL_NODE        = 1001, &	! debug fallback: run one AST node through syntax_eval (no compiler emit)
 		OP_LOAD_CONST       = 1002, &	! push consts(a) onto the operand stack (deep copy)
 		OP_LOAD_GLOBAL      = 1003, &	! push state%vars%vals(a) (deep copy)
 		OP_LOAD_LOCAL       = 1004, &	! push state%locs%vals(a) (deep copy)
@@ -34,8 +34,14 @@ module syntran__bytecode_m
 		OP_MAKE_STRUCT      = 1019, &	! M5: struct instance: a=node_idx (for struct_name+nmembers), members on stack
 		OP_LOAD_MEMBER      = 1020, &	! M5: dot_expr read: a=node_idx; uses get_val
 		OP_STORE_MEMBER     = 1021, &	! M5: dot member write: a=node_idx, b=op_kind; TOS=RHS; uses get_val+set_val
-		OP_CALL_INTR        = 1022  	! M6: intrinsic call; native: a=intr_id b=argc (args on stack);
-		                            	!   fallback: a=intr_id b=-1 c=node_pool_idx (no args on stack)
+		OP_CALL_INTR        = 1022, &	! M6: intrinsic call; native: a=intr_id b=argc (args on stack);
+		                            	!   readln/close: a=intr_id b=1 c=(id_index*2+is_loc) for slot writeback
+		OP_FOR_SETUP        = 1023, &	! M8: for-loop setup: a=node_idx; pushes iter onto for_iter stack
+		OP_FOR_NEXT         = 1024, &	! M8: for-loop advance: a=L_pop; exhausted->jump (no pop), else write loop var
+		OP_FOR_POP          = 1025, &	! M8: for-loop exit: pop for_iter stack (emitted at all loop exits)
+		OP_NEW_ARRAY        = 1026, &	! M8: array construction: a=node_idx; calls eval_array_expr, pushes result
+		OP_STORE_SLICE      = 1027, &	! M8: slice/complex LHS assign: a=node_idx; calls eval_assignment_expr
+		OP_HALT             = 1028  	! M8: top-level return: exit VM loop, TOS is result
 
 	!**** M6: intrinsic function ids (match order in eval_fn_call_intr / declare_intr_fns)
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -389,8 +389,9 @@ end function new_compiler_state
 function add_const(prog, val) result(idx)
 
 	! Add a value to the constant pool and return its 1-based index.
-	! Uses the copy-to-tmp-and-back growth pattern required for types with
-	! allocatable members (same rationale as push_value in value.f90).
+	! Grows the pool using a single copy into tmp + move_alloc (one deep-copy
+	! pass instead of two).  move_alloc is safe here: it transfers the outer
+	! array descriptor; the elements' allocatable members stay in place.
 
 	type(program_t), intent(inout) :: prog
 	type(value_t), intent(in) :: val
@@ -415,11 +416,7 @@ function add_const(prog, val) result(idx)
 		do i = 1, prog%nconsts - 1
 			tmp(i) = prog%consts(i)
 		end do
-		deallocate(prog%consts)
-		allocate(prog%consts(new_cap))
-		do i = 1, prog%nconsts - 1
-			prog%consts(i) = tmp(i)
-		end do
+		call move_alloc(tmp, prog%consts)
 	end if
 
 	prog%consts(idx) = val
@@ -488,8 +485,9 @@ function add_node(prog, node) result(idx)
 
 	! Store an AST node in the program's node pool and return its index.
 	!
-	! Growth uses the copy-to-tmp-and-back pattern required for types with
-	! allocatable members (same rationale as push_value in value.f90).
+	! Grows the pool using a single copy into tmp + move_alloc (one deep-copy
+	! pass instead of two).  move_alloc is safe here: it transfers the outer
+	! array descriptor; the elements' allocatable members stay in place.
 
 	type(program_t), intent(inout) :: prog
 	type(syntax_node_t), intent(in) :: node
@@ -514,11 +512,7 @@ function add_node(prog, node) result(idx)
 		do i = 1, prog%nnodes - 1
 			tmp(i) = prog%nodes(i)
 		end do
-		deallocate(prog%nodes)
-		allocate(prog%nodes(new_cap))
-		do i = 1, prog%nnodes - 1
-			prog%nodes(i) = tmp(i)
-		end do
+		call move_alloc(tmp, prog%nodes)
 	end if
 
 	prog%nodes(idx) = node
@@ -527,15 +521,15 @@ end function add_node
 
 !===============================================================================
 
-subroutine patch_jump(prog, ip, target)
+subroutine patch_jump(prog, ip, tgt)
 
 	! Backpatch the jump target (field `a`) of a previously emitted
 	! OP_JUMP or OP_JUMP_IF_FALSE instruction at position ip.
 
 	type(program_t), intent(inout) :: prog
-	integer, intent(in) :: ip, target
+	integer, intent(in) :: ip, tgt
 
-	prog%code(ip)%a = target
+	prog%code(ip)%a = tgt
 
 end subroutine patch_jump
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -21,7 +21,9 @@ module syntran__bytecode_m
 		OP_STORE_LOCAL = 1006, &	! copy TOS into state%locs%vals(a), keep TOS
 		OP_BINOP       = 1007, &	! pop right+left, compute with op-token a, push result
 		OP_UNOP        = 1008, &	! pop operand, compute with op-token a, push result
-		OP_POP         = 1009   	! discard TOS
+		OP_POP         = 1009, &	! discard TOS
+		OP_JUMP          = 1010, &	! unconditional jump: ip = a
+		OP_JUMP_IF_FALSE = 1011  	! pop bool TOS; if false: ip = a, else continue
 
 	!********
 
@@ -214,6 +216,20 @@ function add_node(prog, node) result(idx)
 	prog%nodes(idx) = node
 
 end function add_node
+
+!===============================================================================
+
+subroutine patch_jump(prog, ip, target)
+
+	! Backpatch the jump target (field `a`) of a previously emitted
+	! OP_JUMP or OP_JUMP_IF_FALSE instruction at position ip.
+
+	type(program_t), intent(inout) :: prog
+	integer, intent(in) :: ip, target
+
+	prog%code(ip)%a = target
+
+end subroutine patch_jump
 
 !===============================================================================
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -109,6 +109,40 @@ module syntran__bytecode_m
 		OP_STORE_GLOBAL_I32  = 1105, OP_STORE_GLOBAL_I64 = 1106, &
 		OP_STORE_GLOBAL_F32  = 1107, OP_STORE_GLOBAL_F64 = 1108
 
+	!**** Typed scalar opcodes (Stage 3) -------------------------------------------
+
+	! Power: same as arithmetic opcodes — left=TOS-1, right=TOS; result=TOS-1, len_--.
+	! Semantics match math_bin_pow.f90 same-type scalar cases.
+	integer, parameter :: &
+		OP_POW_I32 = 1109, OP_POW_I64 = 1110, &
+		OP_POW_F32 = 1111, OP_POW_F64 = 1112
+
+	! Mixed i32/i64 scalar arithmetic: result type is i64.
+	! Naming: OP_<OP>_<LTYPE>_<RTYPE>.  TOS-1 type updated to i64_type.
+	integer, parameter :: &
+		OP_ADD_I32_I64 = 1113, OP_ADD_I64_I32 = 1114, &
+		OP_SUB_I32_I64 = 1115, OP_SUB_I64_I32 = 1116, &
+		OP_MUL_I32_I64 = 1117, OP_MUL_I64_I32 = 1118, &
+		OP_DIV_I32_I64 = 1119, OP_DIV_I64_I32 = 1120, &
+		OP_MOD_I32_I64 = 1121, OP_MOD_I64_I32 = 1122
+
+	! Mixed i32/i64 scalar comparisons: result type is bool.
+	! TOS-1 type updated to bool_type, len_--.
+	integer, parameter :: &
+		OP_LT_I32_I64  = 1123, OP_LT_I64_I32  = 1124, &
+		OP_LE_I32_I64  = 1125, OP_LE_I64_I32  = 1126, &
+		OP_GT_I32_I64  = 1127, OP_GT_I64_I32  = 1128, &
+		OP_GE_I32_I64  = 1129, OP_GE_I64_I32  = 1130, &
+		OP_EQ_I32_I64  = 1131, OP_EQ_I64_I32  = 1132, &
+		OP_NE_I32_I64  = 1133, OP_NE_I64_I32  = 1134
+
+	! Same-type array binop: a = op_kind (token), b = element type.
+	! Dispatches to do_array_binop_typed for i32/i64/f32/f64 arrays.
+	! Arithmetic: result type is array of same elem type.
+	! Comparisons: result type is bool array.
+	integer, parameter :: &
+		OP_ARR_BINOP = 1135
+
 	!**** M6: intrinsic function ids (match order in eval_fn_call_intr / declare_intr_fns)
 
 	! Math
@@ -565,92 +599,142 @@ pure integer function binop_typed_opcode(op_kind, ltype, rtype) result(op)
 	integer, intent(in) :: op_kind, ltype, rtype
 
 	op = 0
-	if (ltype /= rtype) return
+
+	! --- Fast path: same-type scalars ---
+	if (ltype == rtype) then
+		select case (op_kind)
+		case (plus_token)
+			select case (ltype)
+			case (i32_type); op = OP_ADD_I32
+			case (i64_type); op = OP_ADD_I64
+			case (f32_type); op = OP_ADD_F32
+			case (f64_type); op = OP_ADD_F64
+			end select
+		case (minus_token)
+			select case (ltype)
+			case (i32_type); op = OP_SUB_I32
+			case (i64_type); op = OP_SUB_I64
+			case (f32_type); op = OP_SUB_F32
+			case (f64_type); op = OP_SUB_F64
+			end select
+		case (star_token)
+			select case (ltype)
+			case (i32_type); op = OP_MUL_I32
+			case (i64_type); op = OP_MUL_I64
+			case (f32_type); op = OP_MUL_F32
+			case (f64_type); op = OP_MUL_F64
+			end select
+		case (slash_token)
+			select case (ltype)
+			case (i32_type); op = OP_DIV_I32
+			case (i64_type); op = OP_DIV_I64
+			case (f32_type); op = OP_DIV_F32
+			case (f64_type); op = OP_DIV_F64
+			end select
+		case (percent_token)
+			select case (ltype)
+			case (i32_type); op = OP_MOD_I32
+			case (i64_type); op = OP_MOD_I64
+			case (f32_type); op = OP_MOD_F32
+			case (f64_type); op = OP_MOD_F64
+			end select
+		case (sstar_token)
+			select case (ltype)
+			case (i32_type); op = OP_POW_I32
+			case (i64_type); op = OP_POW_I64
+			case (f32_type); op = OP_POW_F32
+			case (f64_type); op = OP_POW_F64
+			end select
+		case (less_token)
+			select case (ltype)
+			case (i32_type); op = OP_LT_I32
+			case (i64_type); op = OP_LT_I64
+			case (f32_type); op = OP_LT_F32
+			case (f64_type); op = OP_LT_F64
+			end select
+		case (less_equals_token)
+			select case (ltype)
+			case (i32_type); op = OP_LE_I32
+			case (i64_type); op = OP_LE_I64
+			case (f32_type); op = OP_LE_F32
+			case (f64_type); op = OP_LE_F64
+			end select
+		case (greater_token)
+			select case (ltype)
+			case (i32_type); op = OP_GT_I32
+			case (i64_type); op = OP_GT_I64
+			case (f32_type); op = OP_GT_F32
+			case (f64_type); op = OP_GT_F64
+			end select
+		case (greater_equals_token)
+			select case (ltype)
+			case (i32_type); op = OP_GE_I32
+			case (i64_type); op = OP_GE_I64
+			case (f32_type); op = OP_GE_F32
+			case (f64_type); op = OP_GE_F64
+			end select
+		case (eequals_token)
+			select case (ltype)
+			case (i32_type); op = OP_EQ_I32
+			case (i64_type); op = OP_EQ_I64
+			case (f32_type); op = OP_EQ_F32
+			case (f64_type); op = OP_EQ_F64
+			case (bool_type); op = OP_EQ_BOOL
+			end select
+		case (bang_equals_token)
+			select case (ltype)
+			case (i32_type); op = OP_NE_I32
+			case (i64_type); op = OP_NE_I64
+			case (f32_type); op = OP_NE_F32
+			case (f64_type); op = OP_NE_F64
+			case (bool_type); op = OP_NE_BOOL
+			end select
+		case (and_keyword)
+			if (ltype == bool_type) op = OP_AND_BOOL
+		case (or_keyword)
+			if (ltype == bool_type) op = OP_OR_BOOL
+		end select
+		return
+	end if
+
+	! --- Mixed i32/i64: result is i64 (arithmetic) or bool (comparisons) ---
+	if (.not. ((ltype == i32_type .and. rtype == i64_type) .or. &
+	           (ltype == i64_type .and. rtype == i32_type))) return
 
 	select case (op_kind)
 	case (plus_token)
-		select case (ltype)
-		case (i32_type); op = OP_ADD_I32
-		case (i64_type); op = OP_ADD_I64
-		case (f32_type); op = OP_ADD_F32
-		case (f64_type); op = OP_ADD_F64
-		end select
+		if (ltype == i32_type) then; op = OP_ADD_I32_I64
+		else;                         op = OP_ADD_I64_I32; end if
 	case (minus_token)
-		select case (ltype)
-		case (i32_type); op = OP_SUB_I32
-		case (i64_type); op = OP_SUB_I64
-		case (f32_type); op = OP_SUB_F32
-		case (f64_type); op = OP_SUB_F64
-		end select
+		if (ltype == i32_type) then; op = OP_SUB_I32_I64
+		else;                         op = OP_SUB_I64_I32; end if
 	case (star_token)
-		select case (ltype)
-		case (i32_type); op = OP_MUL_I32
-		case (i64_type); op = OP_MUL_I64
-		case (f32_type); op = OP_MUL_F32
-		case (f64_type); op = OP_MUL_F64
-		end select
+		if (ltype == i32_type) then; op = OP_MUL_I32_I64
+		else;                         op = OP_MUL_I64_I32; end if
 	case (slash_token)
-		select case (ltype)
-		case (i32_type); op = OP_DIV_I32
-		case (i64_type); op = OP_DIV_I64
-		case (f32_type); op = OP_DIV_F32
-		case (f64_type); op = OP_DIV_F64
-		end select
+		if (ltype == i32_type) then; op = OP_DIV_I32_I64
+		else;                         op = OP_DIV_I64_I32; end if
 	case (percent_token)
-		select case (ltype)
-		case (i32_type); op = OP_MOD_I32
-		case (i64_type); op = OP_MOD_I64
-		case (f32_type); op = OP_MOD_F32
-		case (f64_type); op = OP_MOD_F64
-		end select
+		if (ltype == i32_type) then; op = OP_MOD_I32_I64
+		else;                         op = OP_MOD_I64_I32; end if
 	case (less_token)
-		select case (ltype)
-		case (i32_type); op = OP_LT_I32
-		case (i64_type); op = OP_LT_I64
-		case (f32_type); op = OP_LT_F32
-		case (f64_type); op = OP_LT_F64
-		end select
+		if (ltype == i32_type) then; op = OP_LT_I32_I64
+		else;                         op = OP_LT_I64_I32; end if
 	case (less_equals_token)
-		select case (ltype)
-		case (i32_type); op = OP_LE_I32
-		case (i64_type); op = OP_LE_I64
-		case (f32_type); op = OP_LE_F32
-		case (f64_type); op = OP_LE_F64
-		end select
+		if (ltype == i32_type) then; op = OP_LE_I32_I64
+		else;                         op = OP_LE_I64_I32; end if
 	case (greater_token)
-		select case (ltype)
-		case (i32_type); op = OP_GT_I32
-		case (i64_type); op = OP_GT_I64
-		case (f32_type); op = OP_GT_F32
-		case (f64_type); op = OP_GT_F64
-		end select
+		if (ltype == i32_type) then; op = OP_GT_I32_I64
+		else;                         op = OP_GT_I64_I32; end if
 	case (greater_equals_token)
-		select case (ltype)
-		case (i32_type); op = OP_GE_I32
-		case (i64_type); op = OP_GE_I64
-		case (f32_type); op = OP_GE_F32
-		case (f64_type); op = OP_GE_F64
-		end select
+		if (ltype == i32_type) then; op = OP_GE_I32_I64
+		else;                         op = OP_GE_I64_I32; end if
 	case (eequals_token)
-		select case (ltype)
-		case (i32_type); op = OP_EQ_I32
-		case (i64_type); op = OP_EQ_I64
-		case (f32_type); op = OP_EQ_F32
-		case (f64_type); op = OP_EQ_F64
-		case (bool_type); op = OP_EQ_BOOL
-		end select
+		if (ltype == i32_type) then; op = OP_EQ_I32_I64
+		else;                         op = OP_EQ_I64_I32; end if
 	case (bang_equals_token)
-		select case (ltype)
-		case (i32_type); op = OP_NE_I32
-		case (i64_type); op = OP_NE_I64
-		case (f32_type); op = OP_NE_F32
-		case (f64_type); op = OP_NE_F64
-		case (bool_type); op = OP_NE_BOOL
-		end select
-	case (and_keyword)
-		if (ltype == bool_type) op = OP_AND_BOOL
-	case (or_keyword)
-		if (ltype == bool_type) op = OP_OR_BOOL
+		if (ltype == i32_type) then; op = OP_NE_I32_I64
+		else;                         op = OP_NE_I64_I32; end if
 	end select
 
 end function binop_typed_opcode
@@ -683,6 +767,35 @@ pure integer function unop_typed_opcode(op_kind, type_) result(op)
 	end select
 
 end function unop_typed_opcode
+
+!===============================================================================
+
+pure integer function arr_binop_typed_opcode(op_kind, elem_type) result(op)
+
+	! Return OP_ARR_BINOP when op_kind is a supported binary operation on
+	! same-type numeric arrays (i32/i64/f32/f64), or 0 to fall back to OP_BINOP.
+	! The caller is responsible for checking that both operands are array_type
+	! and that their element types are equal.
+
+	integer, intent(in) :: op_kind, elem_type
+
+	op = 0
+
+	! Only numeric element types
+	select case (elem_type)
+	case (i32_type, i64_type, f32_type, f64_type); continue
+	case default; return
+	end select
+
+	! Only the operators handled by do_array_binop_typed in the VM
+	select case (op_kind)
+	case (plus_token, minus_token, star_token, slash_token, percent_token, &
+	      less_token, less_equals_token, greater_token, greater_equals_token, &
+	      eequals_token, bang_equals_token)
+		op = OP_ARR_BINOP
+	end select
+
+end function arr_binop_typed_opcode
 
 !===============================================================================
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -13,7 +13,15 @@ module syntran__bytecode_m
 	! enum in consts.f90 (which tops out at 121) to prevent accidental aliasing.
 
 	integer, parameter :: &
-		OP_EVAL_NODE = 1001	! fallback: run one AST node through syntax_eval
+		OP_EVAL_NODE   = 1001, &	! fallback: run one AST node through syntax_eval
+		OP_LOAD_CONST  = 1002, &	! push consts(a) onto the operand stack (deep copy)
+		OP_LOAD_GLOBAL = 1003, &	! push state%vars%vals(a) (deep copy)
+		OP_LOAD_LOCAL  = 1004, &	! push state%locs%vals(a) (deep copy)
+		OP_STORE_GLOBAL= 1005, &	! copy TOS into state%vars%vals(a), keep TOS
+		OP_STORE_LOCAL = 1006, &	! copy TOS into state%locs%vals(a), keep TOS
+		OP_BINOP       = 1007, &	! pop right+left, compute with op-token a, push result
+		OP_UNOP        = 1008, &	! pop operand, compute with op-token a, push result
+		OP_POP         = 1009   	! discard TOS
 
 	!********
 
@@ -65,6 +73,48 @@ module syntran__bytecode_m
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+function add_const(prog, val) result(idx)
+
+	! Add a value to the constant pool and return its 1-based index.
+	! Uses the copy-to-tmp-and-back growth pattern required for types with
+	! allocatable members (same rationale as push_value in value.f90).
+
+	type(program_t), intent(inout) :: prog
+	type(value_t), intent(in) :: val
+	integer :: idx
+
+	!*******
+
+	type(value_t), allocatable :: tmp(:)
+	integer :: i, new_cap
+
+	integer, parameter :: INIT_CONST_CAP = 16
+
+	prog%nconsts = prog%nconsts + 1
+	idx = prog%nconsts
+
+	if (.not. allocated(prog%consts)) then
+		allocate(prog%consts(INIT_CONST_CAP))
+
+	else if (prog%nconsts > size(prog%consts)) then
+		new_cap = 2 * prog%nconsts
+		allocate(tmp(new_cap))
+		do i = 1, prog%nconsts - 1
+			tmp(i) = prog%consts(i)
+		end do
+		deallocate(prog%consts)
+		allocate(prog%consts(new_cap))
+		do i = 1, prog%nconsts - 1
+			prog%consts(i) = tmp(i)
+		end do
+	end if
+
+	prog%consts(idx) = val
+
+end function add_const
 
 !===============================================================================
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -143,6 +143,36 @@ module syntran__bytecode_m
 	integer, parameter :: &
 		OP_ARR_BINOP = 1135
 
+	!**** M9: native scalar array indexing ----------------------------------------
+	!
+	! OP_INDEX_NAT: fast array element read without syntax_eval per subscript.
+	!   Compiler emits one typed compile_node per subscript (pushing each index
+	!   onto the operand stack), then emits this opcode.
+	!   Instruction fields:
+	!     a = id_index (slot index of the array variable)
+	!     b = nsub     (number of subscripts = array rank for this access)
+	!     c = is_local (0 = global, 1 = local)
+	!   Stack before:  [sub_1][sub_2]...[sub_nsub]
+	!   Stack after:   [element_value]
+	!   Only emitted when the result type is a numeric/bool scalar (guard in
+	!   index_native_ok).  String, struct, and slice accesses fall back to
+	!   OP_INDEX / OP_SLICE.
+	!
+	! OP_STORE_IDX_NAT: fast array element write (plain '=' only).
+	!   Compiler emits one compile_node per subscript then the RHS.
+	!   Instruction fields:
+	!     a = id_index
+	!     b = nsub
+	!     c = is_local (0 = global, 1 = local)
+	!   Stack before:  [sub_1]...[sub_nsub][rhs]
+	!   Stack after:   [rhs]   (leaves the stored value on top, matching OP_STORE_IDX)
+	!   Only emitted when rhs is a numeric/bool scalar and op is '='
+	!   (guard in store_idx_native_ok).  String/struct writes and compound ops
+	!   (a[i]+=x) fall back to OP_STORE_IDX.
+	integer, parameter :: &
+		OP_INDEX_NAT     = 1136, &
+		OP_STORE_IDX_NAT = 1137
+
 	!**** M6: intrinsic function ids (match order in eval_fn_call_intr / declare_intr_fns)
 
 	! Math
@@ -799,6 +829,56 @@ end function arr_binop_typed_opcode
 
 !===============================================================================
 
+pure logical function index_native_ok(node) result(ok)
+
+	! Return .true. when a name_expr node with all-scalar subscripts can be
+	! lowered to OP_INDEX_NAT (fast inline element read) instead of OP_INDEX.
+	! Requires:
+	!   - subscripts are allocated and all scalar_sub
+	!   - result element type is a numeric/bool scalar (not str, struct, array)
+
+	type(syntax_node_t), intent(in) :: node
+
+	ok = .false.
+	if (.not. allocated(node%lsubscripts)) return
+	if (.not. all(node%lsubscripts%sub_kind == scalar_sub)) return
+
+	select case (node%val%type)
+	case (bool_type, i32_type, i64_type, f32_type, f64_type)
+		ok = .true.
+	end select
+
+end function index_native_ok
+
+!===============================================================================
+
+pure logical function store_idx_native_ok(node) result(ok)
+
+	! Return .true. when an assignment_expr node with all-scalar subscripts and
+	! a plain '=' op can be lowered to OP_STORE_IDX_NAT (fast inline element
+	! write) instead of OP_STORE_IDX.
+	! Requires:
+	!   - subscripts are allocated and all scalar_sub   (caller guarantees this)
+	!   - op is plain '=' (not +=, -=, etc.)
+	!   - RHS element type is a numeric/bool scalar
+
+	type(syntax_node_t), intent(in) :: node
+
+	ok = .false.
+	if (.not. allocated(node%lsubscripts)) return
+	if (.not. all(node%lsubscripts%sub_kind == scalar_sub)) return
+	if (node%op%kind /= equals_token) return
+	if (.not. allocated(node%right)) return
+
+	select case (node%right%val%type)
+	case (bool_type, i32_type, i64_type, f32_type, f64_type)
+		ok = .true.
+	end select
+
+end function store_idx_native_ok
+
+!===============================================================================
+
 pure integer function typed_load_op(type_, is_const, is_local) result(op)
 
 	! Return the typed scalar load opcode, or 0 for non-scalar types.
@@ -861,6 +941,28 @@ pure integer function typed_store_op(type_, is_local) result(op)
 	end select
 
 end function typed_store_op
+
+!===============================================================================
+
+pure integer function compound_to_arith_token(op_kind) result(tok)
+
+	! Map a compound-assignment operator token to its arithmetic counterpart,
+	! or 0 if the compound op is not a standard arithmetic op.
+	! Used to select the typed binop opcode for native compound scalar assignment.
+
+	integer, intent(in) :: op_kind
+
+	select case (op_kind)
+	case (plus_equals_token);    tok = plus_token
+	case (minus_equals_token);   tok = minus_token
+	case (star_equals_token);    tok = star_token
+	case (slash_equals_token);   tok = slash_token
+	case (percent_equals_token); tok = percent_token
+	case (sstar_equals_token);   tok = sstar_token
+	case default;                tok = 0
+	end select
+
+end function compound_to_arith_token
 
 !===============================================================================
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -1,0 +1,172 @@
+
+!===============================================================================
+
+module syntran__bytecode_m
+
+	use syntran__types_m
+
+	implicit none
+
+	!********
+
+	! Opcode enum.  Uses a separate numbering space from the token/type/node-kind
+	! enum in consts.f90 (which tops out at 121) to prevent accidental aliasing.
+
+	integer, parameter :: &
+		OP_EVAL_NODE = 1001	! fallback: run one AST node through syntax_eval
+
+	!********
+
+	! A single bytecode instruction.  Kept as a plain POD record (no allocatable
+	! members) so that arrays of instr_t can be grown with plain array assignment
+	! or move_alloc without triggering the deep-copy machinery.
+	!
+	! Fields:
+	!   op  - opcode
+	!   a,b - integer operands (slot index, const index, jump target, etc.)
+	!   c   - wide integer operand (e.g. element count)
+
+	type instr_t
+		integer :: op
+		integer :: a = 0, b = 0
+		integer(kind = 8) :: c = 0
+	end type instr_t
+
+	!********
+
+	! A compiled program.  All function bodies and the top-level code are
+	! concatenated into a single flat code(:) array; per-function entry offsets
+	! are stored in fn_entry(:).
+	!
+	! The constant pool consts(:) holds literal values referenced by LOAD_CONST.
+	!
+	! The node pool nodes(:) holds AST subtrees referenced by OP_EVAL_NODE.
+	! This is only used for the M0 fallback and will be removed once all node
+	! kinds have been lowered to real opcodes.
+
+	type program_t
+
+		type(instr_t), allocatable :: code(:)
+		integer :: len_ = 0, cap = 0
+
+		type(value_t), allocatable :: consts(:)
+		integer :: nconsts = 0
+
+		! AST node pool for the OP_EVAL_NODE fallback
+		type(syntax_node_t), allocatable :: nodes(:)
+		integer :: nnodes = 0
+
+		integer, allocatable :: fn_entry(:)
+		integer, allocatable :: fn_num_locs(:)
+		integer :: entry_main = 1
+
+	end type program_t
+
+!===============================================================================
+
+contains
+
+!===============================================================================
+
+function new_program() result(prog)
+
+	type(program_t) :: prog
+
+	!*******
+
+	integer, parameter :: INIT_CAP = 16
+
+	prog%cap     = INIT_CAP
+	prog%len_    = 0
+	prog%nconsts = 0
+	prog%nnodes  = 0
+	prog%entry_main = 1
+
+	allocate(prog%code(INIT_CAP))
+
+end function new_program
+
+!===============================================================================
+
+subroutine emit(prog, op, a, b, c)
+
+	! Append one instruction to prog%code, growing the array if needed.
+	! instr_t has no allocatable members so a simple array-section copy + move_alloc
+	! is safe.
+
+	type(program_t), intent(inout) :: prog
+	integer, intent(in) :: op
+	integer, intent(in), optional :: a, b
+	integer(kind = 8), intent(in), optional :: c
+
+	!*******
+
+	type(instr_t), allocatable :: tmp(:)
+
+	prog%len_ = prog%len_ + 1
+
+	if (prog%len_ > prog%cap) then
+		prog%cap = 2 * prog%len_
+		allocate(tmp(prog%cap))
+		tmp(1 : prog%len_ - 1) = prog%code(1 : prog%len_ - 1)
+		call move_alloc(tmp, prog%code)
+	end if
+
+	prog%code(prog%len_)%op = op
+	prog%code(prog%len_)%a  = 0
+	prog%code(prog%len_)%b  = 0
+	prog%code(prog%len_)%c  = 0_8
+	if (present(a)) prog%code(prog%len_)%a = a
+	if (present(b)) prog%code(prog%len_)%b = b
+	if (present(c)) prog%code(prog%len_)%c = c
+
+end subroutine emit
+
+!===============================================================================
+
+function add_node(prog, node) result(idx)
+
+	! Store an AST node in the program's node pool and return its index.
+	!
+	! Growth uses the copy-to-tmp-and-back pattern required for types with
+	! allocatable members (same rationale as push_value in value.f90).
+
+	type(program_t), intent(inout) :: prog
+	type(syntax_node_t), intent(in) :: node
+	integer :: idx
+
+	!*******
+
+	type(syntax_node_t), allocatable :: tmp(:)
+	integer :: i, new_cap
+
+	integer, parameter :: INIT_NODE_CAP = 8
+
+	prog%nnodes = prog%nnodes + 1
+	idx = prog%nnodes
+
+	if (.not. allocated(prog%nodes)) then
+		allocate(prog%nodes(INIT_NODE_CAP))
+
+	else if (prog%nnodes > size(prog%nodes)) then
+		new_cap = 2 * prog%nnodes
+		allocate(tmp(new_cap))
+		do i = 1, prog%nnodes - 1
+			tmp(i) = prog%nodes(i)
+		end do
+		deallocate(prog%nodes)
+		allocate(prog%nodes(new_cap))
+		do i = 1, prog%nnodes - 1
+			prog%nodes(i) = tmp(i)
+		end do
+	end if
+
+	prog%nodes(idx) = node
+
+end function add_node
+
+!===============================================================================
+
+end module syntran__bytecode_m
+
+!===============================================================================

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -30,7 +30,10 @@ module syntran__bytecode_m
 		OP_LOAD_REF_LOCAL   = 1015, &	! move state%locs%vals(a) to stack (by-ref arg, pass 2)
 		OP_INDEX            = 1016, &	! scalar subscript read: a=node_idx (name_expr w/ scalar subs)
 		OP_SLICE            = 1017, &	! non-scalar subscript/slice read: a=node_idx
-		OP_STORE_IDX        = 1018 	! scalar subscript write: a=node_idx, b=op_kind; TOS=RHS
+		OP_STORE_IDX        = 1018, &	! scalar subscript write: a=node_idx, b=op_kind; TOS=RHS
+		OP_MAKE_STRUCT      = 1019, &	! M5: struct instance: a=node_idx (for struct_name+nmembers), members on stack
+		OP_LOAD_MEMBER      = 1020, &	! M5: dot_expr read: a=node_idx; uses get_val
+		OP_STORE_MEMBER     = 1021  	! M5: dot member write: a=node_idx, b=op_kind; TOS=RHS; uses get_val+set_val
 
 	!********
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -33,7 +33,98 @@ module syntran__bytecode_m
 		OP_STORE_IDX        = 1018, &	! scalar subscript write: a=node_idx, b=op_kind; TOS=RHS
 		OP_MAKE_STRUCT      = 1019, &	! M5: struct instance: a=node_idx (for struct_name+nmembers), members on stack
 		OP_LOAD_MEMBER      = 1020, &	! M5: dot_expr read: a=node_idx; uses get_val
-		OP_STORE_MEMBER     = 1021  	! M5: dot member write: a=node_idx, b=op_kind; TOS=RHS; uses get_val+set_val
+		OP_STORE_MEMBER     = 1021, &	! M5: dot member write: a=node_idx, b=op_kind; TOS=RHS; uses get_val+set_val
+		OP_CALL_INTR        = 1022  	! M6: intrinsic call; native: a=intr_id b=argc (args on stack);
+		                            	!   fallback: a=intr_id b=-1 c=node_pool_idx (no args on stack)
+
+	!**** M6: intrinsic function ids (match order in eval_fn_call_intr / declare_intr_fns)
+
+	! Math
+	integer, parameter :: &
+		INTR_EXP_F32      =  1, INTR_EXP_F64      =  2, &
+		INTR_EXP_F32_ARR  =  3, INTR_EXP_F64_ARR  =  4, &
+		INTR_LOG_F32      =  5, INTR_LOG_F64      =  6, &
+		INTR_LOG_F32_ARR  =  7, INTR_LOG_F64_ARR  =  8, &
+		INTR_LOG10_F32    =  9, INTR_LOG10_F64    = 10, &
+		INTR_LOG10_F32_ARR= 11, INTR_LOG10_F64_ARR= 12, &
+		INTR_LOG2_F32     = 13, INTR_LOG2_F64     = 14, &
+		INTR_LOG2_F32_ARR = 15, INTR_LOG2_F64_ARR = 16, &
+		INTR_SQRT_F32     = 17, INTR_SQRT_F64     = 18, &
+		INTR_SQRT_F32_ARR = 19, INTR_SQRT_F64_ARR = 20, &
+		INTR_ABS_F32      = 21, INTR_ABS_F64      = 22, &
+		INTR_ABS_F32_ARR  = 23, INTR_ABS_F64_ARR  = 24, &
+		INTR_ABS_I32      = 25, INTR_ABS_I64      = 26, &
+		INTR_ABS_I32_ARR  = 27, INTR_ABS_I64_ARR  = 28
+
+	! Trig
+	integer, parameter :: &
+		INTR_COS_F32      = 29, INTR_COS_F64      = 30, &
+		INTR_COS_F32_ARR  = 31, INTR_COS_F64_ARR  = 32, &
+		INTR_SIN_F32      = 33, INTR_SIN_F64      = 34, &
+		INTR_SIN_F32_ARR  = 35, INTR_SIN_F64_ARR  = 36, &
+		INTR_TAN_F32      = 37, INTR_TAN_F64      = 38, &
+		INTR_TAN_F32_ARR  = 39, INTR_TAN_F64_ARR  = 40, &
+		INTR_COSD_F32     = 41, INTR_COSD_F64     = 42, &
+		INTR_COSD_F32_ARR = 43, INTR_COSD_F64_ARR = 44, &
+		INTR_SIND_F32     = 45, INTR_SIND_F64     = 46, &
+		INTR_SIND_F32_ARR = 47, INTR_SIND_F64_ARR = 48, &
+		INTR_TAND_F32     = 49, INTR_TAND_F64     = 50, &
+		INTR_TAND_F32_ARR = 51, INTR_TAND_F64_ARR = 52, &
+		INTR_ACOS_F32     = 53, INTR_ACOS_F64     = 54, &
+		INTR_ACOS_F32_ARR = 55, INTR_ACOS_F64_ARR = 56, &
+		INTR_ASIN_F32     = 57, INTR_ASIN_F64     = 58, &
+		INTR_ASIN_F32_ARR = 59, INTR_ASIN_F64_ARR = 60, &
+		INTR_ATAN_F32     = 61, INTR_ATAN_F64     = 62, &
+		INTR_ATAN_F32_ARR = 63, INTR_ATAN_F64_ARR = 64, &
+		INTR_ACOSD_F32    = 65, INTR_ACOSD_F64    = 66, &
+		INTR_ACOSD_F32_ARR= 67, INTR_ACOSD_F64_ARR= 68, &
+		INTR_ASIND_F32    = 69, INTR_ASIND_F64    = 70, &
+		INTR_ASIND_F32_ARR= 71, INTR_ASIND_F64_ARR= 72, &
+		INTR_ATAND_F32    = 73, INTR_ATAND_F64    = 74, &
+		INTR_ATAND_F32_ARR= 75, INTR_ATAND_F64_ARR= 76
+
+	! Minmax
+	integer, parameter :: &
+		INTR_MIN_I32      = 77, INTR_MIN_I64      = 78, &
+		INTR_MIN_F32      = 79, INTR_MIN_F64      = 80, &
+		INTR_MAX_I32      = 81, INTR_MAX_I64      = 82, &
+		INTR_MAX_F32      = 83, INTR_MAX_F64      = 84
+
+	! String / conversion
+	integer, parameter :: &
+		INTR_PRINTLN      = 85, INTR_STR          = 86, &
+		INTR_LEN          = 87, INTR_REPEAT       = 88, &
+		INTR_PARSE_I32    = 89, INTR_PARSE_I64    = 90, &
+		INTR_PARSE_F32    = 91, INTR_PARSE_F64    = 92, &
+		INTR_CHAR         = 93, &
+		INTR_I32_SCA      = 94, INTR_I32_ARR      = 95, &
+		INTR_I64_SCA      = 96, INTR_I64_ARR      = 97
+
+	! I/O
+	integer, parameter :: &
+		INTR_OPEN         = 98, &
+		INTR_READLN       = 99,  &  ! CALL_INTR_NODE fallback: needs writeback
+		INTR_WRITELN      = 100, &
+		INTR_EOF          = 101, &
+		INTR_CLOSE        = 102     ! CALL_INTR_NODE fallback: needs writeback
+
+	! Misc + reduction
+	integer, parameter :: &
+		INTR_EXIT         = 103, &
+		INTR_SIZE         = 104, INTR_COUNT        = 105, &
+		INTR_MINVAL_I32   = 106, INTR_MINVAL_I64   = 107, &
+		INTR_MINVAL_F32   = 108, INTR_MINVAL_F64   = 109, &
+		INTR_MAXVAL_I32   = 110, INTR_MAXVAL_I64   = 111, &
+		INTR_MAXVAL_F32   = 112, INTR_MAXVAL_F64   = 113, &
+		INTR_SUM_I32      = 114, INTR_SUM_I64      = 115, &
+		INTR_SUM_F32      = 116, INTR_SUM_F64      = 117, &
+		INTR_PRODUCT_I32  = 118, INTR_PRODUCT_I64  = 119, &
+		INTR_PRODUCT_F32  = 120, INTR_PRODUCT_F64  = 121, &
+		INTR_NORM2_F32    = 122, INTR_NORM2_F64    = 123, &
+		INTR_DOT_F32      = 124, INTR_DOT_F64      = 125, &
+		INTR_DOT_I32      = 126, INTR_DOT_I64      = 127, &
+		INTR_ALL          = 128, INTR_ANY          = 129, &
+		INTR_ARGS         = 130
 
 	!********
 
@@ -240,6 +331,157 @@ subroutine patch_jump(prog, ip, target)
 	prog%code(ip)%a = target
 
 end subroutine patch_jump
+
+!===============================================================================
+
+pure integer function intr_id_from_name(name) result(id)
+
+	! Map a mangled intrinsic function name to its INTR_* enum id.
+	! Returns 0 for unknown names (should not happen after successful parsing).
+
+	character(len = *), intent(in) :: name
+
+	select case (name)
+	! Math
+	case ("0exp_f32");       id = INTR_EXP_F32
+	case ("0exp_f64");       id = INTR_EXP_F64
+	case ("0exp_f32_arr");   id = INTR_EXP_F32_ARR
+	case ("0exp_f64_arr");   id = INTR_EXP_F64_ARR
+	case ("0log_f32");       id = INTR_LOG_F32
+	case ("0log_f64");       id = INTR_LOG_F64
+	case ("0log_f32_arr");   id = INTR_LOG_F32_ARR
+	case ("0log_f64_arr");   id = INTR_LOG_F64_ARR
+	case ("0log10_f32");     id = INTR_LOG10_F32
+	case ("0log10_f64");     id = INTR_LOG10_F64
+	case ("0log10_f32_arr"); id = INTR_LOG10_F32_ARR
+	case ("0log10_f64_arr"); id = INTR_LOG10_F64_ARR
+	case ("0log2_f32");      id = INTR_LOG2_F32
+	case ("0log2_f64");      id = INTR_LOG2_F64
+	case ("0log2_f32_arr");  id = INTR_LOG2_F32_ARR
+	case ("0log2_f64_arr");  id = INTR_LOG2_F64_ARR
+	case ("0sqrt_f32");      id = INTR_SQRT_F32
+	case ("0sqrt_f64");      id = INTR_SQRT_F64
+	case ("0sqrt_f32_arr");  id = INTR_SQRT_F32_ARR
+	case ("0sqrt_f64_arr");  id = INTR_SQRT_F64_ARR
+	case ("0abs_f32");       id = INTR_ABS_F32
+	case ("0abs_f64");       id = INTR_ABS_F64
+	case ("0abs_f32_arr");   id = INTR_ABS_F32_ARR
+	case ("0abs_f64_arr");   id = INTR_ABS_F64_ARR
+	case ("0abs_i32");       id = INTR_ABS_I32
+	case ("0abs_i64");       id = INTR_ABS_I64
+	case ("0abs_i32_arr");   id = INTR_ABS_I32_ARR
+	case ("0abs_i64_arr");   id = INTR_ABS_I64_ARR
+	! Trig
+	case ("0cos_f32");       id = INTR_COS_F32
+	case ("0cos_f64");       id = INTR_COS_F64
+	case ("0cos_f32_arr");   id = INTR_COS_F32_ARR
+	case ("0cos_f64_arr");   id = INTR_COS_F64_ARR
+	case ("0sin_f32");       id = INTR_SIN_F32
+	case ("0sin_f64");       id = INTR_SIN_F64
+	case ("0sin_f32_arr");   id = INTR_SIN_F32_ARR
+	case ("0sin_f64_arr");   id = INTR_SIN_F64_ARR
+	case ("0tan_f32");       id = INTR_TAN_F32
+	case ("0tan_f64");       id = INTR_TAN_F64
+	case ("0tan_f32_arr");   id = INTR_TAN_F32_ARR
+	case ("0tan_f64_arr");   id = INTR_TAN_F64_ARR
+	case ("0cosd_f32");      id = INTR_COSD_F32
+	case ("0cosd_f64");      id = INTR_COSD_F64
+	case ("0cosd_f32_arr");  id = INTR_COSD_F32_ARR
+	case ("0cosd_f64_arr");  id = INTR_COSD_F64_ARR
+	case ("0sind_f32");      id = INTR_SIND_F32
+	case ("0sind_f64");      id = INTR_SIND_F64
+	case ("0sind_f32_arr");  id = INTR_SIND_F32_ARR
+	case ("0sind_f64_arr");  id = INTR_SIND_F64_ARR
+	case ("0tand_f32");      id = INTR_TAND_F32
+	case ("0tand_f64");      id = INTR_TAND_F64
+	case ("0tand_f32_arr");  id = INTR_TAND_F32_ARR
+	case ("0tand_f64_arr");  id = INTR_TAND_F64_ARR
+	case ("0acos_f32");      id = INTR_ACOS_F32
+	case ("0acos_f64");      id = INTR_ACOS_F64
+	case ("0acos_f32_arr");  id = INTR_ACOS_F32_ARR
+	case ("0acos_f64_arr");  id = INTR_ACOS_F64_ARR
+	case ("0asin_f32");      id = INTR_ASIN_F32
+	case ("0asin_f64");      id = INTR_ASIN_F64
+	case ("0asin_f32_arr");  id = INTR_ASIN_F32_ARR
+	case ("0asin_f64_arr");  id = INTR_ASIN_F64_ARR
+	case ("0atan_f32");      id = INTR_ATAN_F32
+	case ("0atan_f64");      id = INTR_ATAN_F64
+	case ("0atan_f32_arr");  id = INTR_ATAN_F32_ARR
+	case ("0atan_f64_arr");  id = INTR_ATAN_F64_ARR
+	case ("0acosd_f32");     id = INTR_ACOSD_F32
+	case ("0acosd_f64");     id = INTR_ACOSD_F64
+	case ("0acosd_f32_arr"); id = INTR_ACOSD_F32_ARR
+	case ("0acosd_f64_arr"); id = INTR_ACOSD_F64_ARR
+	case ("0asind_f32");     id = INTR_ASIND_F32
+	case ("0asind_f64");     id = INTR_ASIND_F64
+	case ("0asind_f32_arr"); id = INTR_ASIND_F32_ARR
+	case ("0asind_f64_arr"); id = INTR_ASIND_F64_ARR
+	case ("0atand_f32");     id = INTR_ATAND_F32
+	case ("0atand_f64");     id = INTR_ATAND_F64
+	case ("0atand_f32_arr"); id = INTR_ATAND_F32_ARR
+	case ("0atand_f64_arr"); id = INTR_ATAND_F64_ARR
+	! Minmax
+	case ("0min_i32");       id = INTR_MIN_I32
+	case ("0min_i64");       id = INTR_MIN_I64
+	case ("0min_f32");       id = INTR_MIN_F32
+	case ("0min_f64");       id = INTR_MIN_F64
+	case ("0max_i32");       id = INTR_MAX_I32
+	case ("0max_i64");       id = INTR_MAX_I64
+	case ("0max_f32");       id = INTR_MAX_F32
+	case ("0max_f64");       id = INTR_MAX_F64
+	! String / conversion
+	case ("println");        id = INTR_PRINTLN
+	case ("str");            id = INTR_STR
+	case ("len");            id = INTR_LEN
+	case ("repeat");         id = INTR_REPEAT
+	case ("parse_i32");      id = INTR_PARSE_I32
+	case ("parse_i64");      id = INTR_PARSE_I64
+	case ("parse_f32");      id = INTR_PARSE_F32
+	case ("parse_f64");      id = INTR_PARSE_F64
+	case ("char");           id = INTR_CHAR
+	case ("0i32_sca");       id = INTR_I32_SCA
+	case ("0i32_arr");       id = INTR_I32_ARR
+	case ("0i64_sca");       id = INTR_I64_SCA
+	case ("0i64_arr");       id = INTR_I64_ARR
+	! I/O
+	case ("open");           id = INTR_OPEN
+	case ("readln");         id = INTR_READLN
+	case ("writeln");        id = INTR_WRITELN
+	case ("eof");            id = INTR_EOF
+	case ("close");          id = INTR_CLOSE
+	! Misc + reduction
+	case ("exit");           id = INTR_EXIT
+	case ("size");           id = INTR_SIZE
+	case ("count");          id = INTR_COUNT
+	case ("0minval_i32");    id = INTR_MINVAL_I32
+	case ("0minval_i64");    id = INTR_MINVAL_I64
+	case ("0minval_f32");    id = INTR_MINVAL_F32
+	case ("0minval_f64");    id = INTR_MINVAL_F64
+	case ("0maxval_i32");    id = INTR_MAXVAL_I32
+	case ("0maxval_i64");    id = INTR_MAXVAL_I64
+	case ("0maxval_f32");    id = INTR_MAXVAL_F32
+	case ("0maxval_f64");    id = INTR_MAXVAL_F64
+	case ("0sum_i32");       id = INTR_SUM_I32
+	case ("0sum_i64");       id = INTR_SUM_I64
+	case ("0sum_f32");       id = INTR_SUM_F32
+	case ("0sum_f64");       id = INTR_SUM_F64
+	case ("0product_i32");   id = INTR_PRODUCT_I32
+	case ("0product_i64");   id = INTR_PRODUCT_I64
+	case ("0product_f32");   id = INTR_PRODUCT_F32
+	case ("0product_f64");   id = INTR_PRODUCT_F64
+	case ("0norm2_f32");     id = INTR_NORM2_F32
+	case ("0norm2_f64");     id = INTR_NORM2_F64
+	case ("0dot_f32");       id = INTR_DOT_F32
+	case ("0dot_f64");       id = INTR_DOT_F64
+	case ("0dot_i32");       id = INTR_DOT_I32
+	case ("0dot_i64");       id = INTR_DOT_I64
+	case ("all");            id = INTR_ALL
+	case ("any");            id = INTR_ANY
+	case ("args");           id = INTR_ARGS
+	case default;            id = 0
+	end select
+
+end function intr_id_from_name
 
 !===============================================================================
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -27,7 +27,10 @@ module syntran__bytecode_m
 		OP_CALL             = 1012, &	! call user fn: a=fn_id, b=node_pool_idx (fn_call node)
 		OP_RET              = 1013, &	! return from fn: TOS is return value
 		OP_LOAD_REF_GLOBAL  = 1014, &	! move state%vars%vals(a) to stack (by-ref arg, pass 2)
-		OP_LOAD_REF_LOCAL   = 1015 	! move state%locs%vals(a) to stack (by-ref arg, pass 2)
+		OP_LOAD_REF_LOCAL   = 1015, &	! move state%locs%vals(a) to stack (by-ref arg, pass 2)
+		OP_INDEX            = 1016, &	! scalar subscript read: a=node_idx (name_expr w/ scalar subs)
+		OP_SLICE            = 1017, &	! non-scalar subscript/slice read: a=node_idx
+		OP_STORE_IDX        = 1018 	! scalar subscript write: a=node_idx, b=op_kind; TOS=RHS
 
 	!********
 

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -13,7 +13,6 @@ module syntran__bytecode_m
 	! enum in consts.f90 (which tops out at 121) to prevent accidental aliasing.
 
 	integer, parameter :: &
-		OP_EVAL_NODE        = 1001, &	! debug fallback: run one AST node through syntax_eval (no compiler emit)
 		OP_LOAD_CONST       = 1002, &	! push consts(a) onto the operand stack (deep copy)
 		OP_LOAD_GLOBAL      = 1003, &	! push state%vars%vals(a) (deep copy)
 		OP_LOAD_LOCAL       = 1004, &	! push state%locs%vals(a) (deep copy)
@@ -287,9 +286,10 @@ module syntran__bytecode_m
 	!
 	! The constant pool consts(:) holds literal values referenced by LOAD_CONST.
 	!
-	! The node pool nodes(:) holds AST subtrees referenced by OP_EVAL_NODE.
-	! This is only used for the M0 fallback and will be removed once all node
-	! kinds have been lowered to real opcodes.
+	! The node pool nodes(:) holds AST subtrees referenced by opcodes that still
+	! delegate partial evaluation to the AST layer: OP_INDEX, OP_SLICE,
+	! OP_STORE_IDX, OP_MAKE_STRUCT, OP_LOAD_MEMBER, OP_STORE_MEMBER,
+	! OP_FOR_SETUP, OP_NEW_ARRAY, OP_STORE_SLICE, and OP_CALL.
 
 	type program_t
 
@@ -299,7 +299,7 @@ module syntran__bytecode_m
 		type(value_t), allocatable :: consts(:)
 		integer :: nconsts = 0
 
-		! AST node pool for the OP_EVAL_NODE fallback
+		! AST node pool for opcodes that delegate to the AST layer
 		type(syntax_node_t), allocatable :: nodes(:)
 		integer :: nnodes = 0
 
@@ -309,9 +309,80 @@ module syntran__bytecode_m
 
 	end type program_t
 
+	!********
+
+	! Per-compilation state threaded through the recursive compiler.
+	! Using a derived type (rather than module variables) makes the compiler
+	! reentrant: each compile_tree() call constructs its own compiler_state_t
+	! and passes it explicitly through compile_node/compile_module_fns.
+
+	type compiler_state_t
+
+		! --- loop break/continue backpatching ---
+		!
+		! loop_depth is incremented when entering a natively-compiled while/for
+		! loop and decremented on exit.  continue_target(d) is the instruction
+		! index to jump to for a `continue` inside loop depth d.  break fixups
+		! inside loops are collected and backpatched after the loop body.
+		!
+		! All arrays are growable (no hard limit) for parity with the AST walker.
+		! INIT_LOOP_DEPTH / INIT_BREAK_FIXUPS are starting capacities only;
+		! arrays double on demand.
+
+		integer :: loop_depth = 0
+		integer, allocatable :: continue_target(:)
+
+		integer, allocatable :: break_fixup_ips(:)
+		integer, allocatable :: break_fixup_depths(:)
+		integer :: nbreak_fixups = 0
+
+		! --- Block-level break context ---
+		!
+		! In Syntran, `break` can exit a plain block statement (not just loops).
+		! When loop_depth == 0 and this is the outermost natively-compiled block,
+		! `break` records a fixup that gets patched to the block's end.
+
+		logical :: in_block_break_ctx = .false.
+		integer, allocatable :: block_break_ips(:)
+		integer :: nblock_break_fixups = 0
+
+		! Set to true while compiling a user function body; used to distinguish
+		! a function-level return_statement (emit OP_RET) from a top-level one
+		! (emit OP_HALT).
+		logical :: in_fn_body = .false.
+
+	end type compiler_state_t
+
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+function new_compiler_state() result(cs)
+
+	! Construct a freshly-initialised compiler_state_t for one compile_tree()
+	! call.  All growable arrays are allocated at their initial capacities.
+
+	type(compiler_state_t) :: cs
+
+	!*******
+
+	integer, parameter :: INIT_LOOP_DEPTH   = 64
+	integer, parameter :: INIT_BREAK_FIXUPS = 256
+
+	cs%loop_depth          = 0
+	cs%nbreak_fixups       = 0
+	cs%in_block_break_ctx  = .false.
+	cs%nblock_break_fixups = 0
+	cs%in_fn_body          = .false.
+
+	allocate(cs%continue_target(INIT_LOOP_DEPTH))
+	allocate(cs%break_fixup_ips(INIT_BREAK_FIXUPS))
+	allocate(cs%break_fixup_depths(INIT_BREAK_FIXUPS))
+	allocate(cs%block_break_ips(INIT_BREAK_FIXUPS))
+
+end function new_compiler_state
 
 !===============================================================================
 

--- a/src/compile.f90
+++ b/src/compile.f90
@@ -1,0 +1,34 @@
+
+!===============================================================================
+
+module syntran__compile_m
+
+	! Bytecode compiler: lowers an AST (syntax_node_t) into a program_t.
+	!
+	! Module + submodule layout mirrors eval.f90 + eval_*.f90.
+	! Submodules:
+	!   compile_ctrl.f90  - compile_tree entry point and control flow
+
+	use syntran__bytecode_m
+	use syntran__eval_m
+
+	implicit none
+
+!===============================================================================
+
+	interface
+
+		! Implemented in compile_ctrl.f90
+
+		module subroutine compile_tree(tree, prog)
+			type(syntax_node_t), intent(in) :: tree
+			type(program_t), intent(out) :: prog
+		end subroutine
+
+	end interface
+
+!===============================================================================
+
+end module syntran__compile_m
+
+!===============================================================================

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -11,11 +11,13 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	!     Everything else still falls back to OP_EVAL_NODE.
 	! M2: adds block_statement, if_statement, while_statement,
 	!     break_statement, continue_statement via JUMP/JUMP_IF_FALSE opcodes.
-	!     for_statement still falls back to OP_EVAL_NODE.
-	! M6: fn_call_intr_expr emits OP_CALL_INTR with integer intr_id dispatch
-	!     (readln/close use CALL_INTR_NODE fallback for variable-slot writeback).
+	! M6: fn_call_intr_expr emits OP_CALL_INTR with integer intr_id dispatch.
 	! M7: use_statement: module fn bodies compiled into prog before entry_main;
 	!     module init code emitted inline at the use_statement site.
+	! M8: for_statement (native FOR_SETUP/FOR_NEXT), array_expr (OP_NEW_ARRAY),
+	!     slice/complex LHS assign (OP_STORE_SLICE), top-level return (OP_HALT),
+	!     readln/close native dispatch with slot writeback; OP_EVAL_NODE fallback
+	!     removed from compiler (kept as debug opcode in the VM handler).
 
 	implicit none
 
@@ -259,9 +261,9 @@ recursive subroutine compile_node(prog, node)
 				idx = add_node(prog, node)
 				call emit(prog, OP_STORE_IDX, a = idx, b = node%op%kind)
 			else
-				! Slice LHS or compound assignment without subscripts — fall back
+				! Slice LHS or subscript-less compound: delegate to eval_assignment_expr
 				idx = add_node(prog, node)
-				call emit(prog, OP_EVAL_NODE, a = idx)
+				call emit(prog, OP_STORE_SLICE, a = idx)
 			end if
 		end if
 
@@ -444,9 +446,9 @@ recursive subroutine compile_node(prog, node)
 			call emit(prog, OP_JUMP, a = 0)
 
 		else
-			! No breakable context (top-level break): fall back to AST walker
-			idx = add_node(prog, node)
-			call emit(prog, OP_EVAL_NODE, a = idx)
+			! No breakable context: top-level break is a no-op in translation_unit
+			const_idx = add_const(prog, unknown_val())
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
 		end if
 
 	! ---- continue --------------------------------------------------------------
@@ -454,8 +456,9 @@ recursive subroutine compile_node(prog, node)
 		if (loop_depth > 0) then
 			call emit(prog, OP_JUMP, a = continue_target(loop_depth))
 		else
-			idx = add_node(prog, node)
-			call emit(prog, OP_EVAL_NODE, a = idx)
+			! No loop context: top-level continue is a no-op in translation_unit
+			const_idx = add_const(prog, unknown_val())
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
 		end if
 
 	! ---- top-level translation unit -------------------------------------------
@@ -512,6 +515,56 @@ recursive subroutine compile_node(prog, node)
 			const_idx = add_const(prog, unknown_val())
 			call emit(prog, OP_LOAD_CONST, a = const_idx)
 		end if
+
+	! ---- for statement --------------------------------------------------------
+	! M8: for_statement lowering:
+	!
+	!   OP_FOR_SETUP a=node_idx    ! eval bounds once, push onto for-iter stack
+	!   L_top:
+	!   OP_FOR_NEXT  a=L_pop       ! counter++; if exhausted: jump L_pop; else write loop var
+	!   [body]
+	!   OP_POP                     ! discard body result before next iteration
+	!   OP_JUMP a=L_top
+	!   L_pop:
+	!   OP_FOR_POP                 ! pop for-iter stack (all exits: exhaustion + break)
+	!   LOAD_CONST unknown_type    ! for-statement result
+	!
+	! break    -> JUMP L_pop (backpatched; FOR_POP then LOAD_CONST execute)
+	! continue -> JUMP L_top (continue_target; FOR_NEXT re-evaluates)
+	case (for_statement)
+		idx = add_node(prog, node)
+		call emit(prog, OP_FOR_SETUP, a = idx)
+
+		loop_depth = loop_depth + 1
+		l_top = prog%len_ + 1
+		continue_target(loop_depth) = l_top
+
+		! FOR_NEXT — patched to L_pop below
+		jf_ip = prog%len_ + 1
+		call emit(prog, OP_FOR_NEXT, a = 0)
+
+		! Compile body; its result is discarded before the back edge
+		call compile_node(prog, node%body)
+		call emit(prog, OP_POP)
+		call emit(prog, OP_JUMP, a = l_top)
+
+		! L_pop: backpatch FOR_NEXT and all break fixups here, then pop + result
+		l_end = prog%len_ + 1
+		call patch_jump(prog, jf_ip, l_end)
+		call backpatch_breaks(prog, loop_depth, l_end)
+		loop_depth = loop_depth - 1
+		call emit(prog, OP_FOR_POP)
+
+		! Push unknown_type as the for-statement's result value
+		const_idx = add_const(prog, unknown_val())
+		call emit(prog, OP_LOAD_CONST, a = const_idx)
+
+	! ---- array expression construction ----------------------------------------
+	! M8: Store the array_expr node in the pool and emit OP_NEW_ARRAY.
+	! The VM handler calls eval_array_expr to build the value.
+	case (array_expr)
+		idx = add_node(prog, node)
+		call emit(prog, OP_NEW_ARRAY, a = idx)
 
 	! ---- struct instance construction -----------------------------------------
 	! M5: Compile each member-initialiser expression in order, then emit
@@ -571,9 +624,10 @@ recursive subroutine compile_node(prog, node)
 		end if
 
 		if (.not. first) then
-			! Not a locally-compiled fn: fall back to the AST walker.
-			idx = add_node(prog, node)
-			call emit(prog, OP_EVAL_NODE, a = idx)
+			! fn_entry not yet populated — compile_module_fns should have covered all
+			! reachable fns; reaching here means a compiler bug.
+			write(*,*) 'compile: fn_call_expr: fn_entry not found for id', node%id_index
+			call internal_error()
 		else
 			! Locally-compiled fn: two-pass arg push + OP_CALL.
 			! Store the call node so OP_CALL/OP_RET can access params/is_ref.
@@ -601,19 +655,22 @@ recursive subroutine compile_node(prog, node)
 		end if
 
 	! ---- intrinsic function call -----------------------------------------------
-	! M6: emit OP_CALL_INTR.  For most intrinsics, push all args first then emit
-	! with b=argc for native dispatch in vm_call_intr.  For intrinsics that need
-	! writeback to a variable slot (readln, close), store the node in the pool
-	! and use the CALL_INTR_NODE fallback (b=-1, c=node_pool_idx).
+	! M6/M8: emit OP_CALL_INTR.  For most intrinsics: push all args, then emit
+	! with b=argc for native dispatch in vm_call_intr.
+	! For readln/close (slot writeback needed): push the arg, encode the file
+	! variable's slot in c = (id_index*2 + is_loc), dispatch inline in vm_exec.
 	case (fn_call_intr_expr)
 		block
 			integer :: intr_id_, nargs_
+			integer(kind = 8) :: slot_c
 			intr_id_ = intr_id_from_name(node%identifier%text)
 			select case (intr_id_)
 			case (INTR_READLN, INTR_CLOSE)
-				! Writeback required: store node and fall back to eval_fn_call_intr.
-				idx = add_node(prog, node)
-				call emit(prog, OP_CALL_INTR, a = intr_id_, b = -1, c = int(idx, 8))
+				! Push the file argument, encode its slot for writeback in c.
+				call compile_node(prog, node%args(1))
+				slot_c = int(node%args(1)%id_index, 8) * 2 + &
+				         merge(1_8, 0_8, node%args(1)%is_loc)
+				call emit(prog, OP_CALL_INTR, a = intr_id_, b = 1, c = slot_c)
 			case default
 				! Native dispatch: push all args, then emit OP_CALL_INTR.
 				nargs_ = 0
@@ -629,28 +686,26 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- return statement ------------------------------------------------------
 	! Inside a compiled function body: push return value (or unknown sentinel for
-	! void) then emit OP_RET.  At top level: fall back to OP_EVAL_NODE (which
-	! sets state%returned so the VM exits its main loop).
+	! void) then emit OP_RET.  At top level: push return value then OP_HALT.
 	case (return_statement)
+		if (node%right%val%type == void_type) then
+			! Void return: push unknown_type as a dummy return slot.
+			const_idx = add_const(prog, unknown_val())
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
+		else
+			call compile_node(prog, node%right)
+		end if
 		if (in_fn_body) then
-			if (node%right%val%type == void_type) then
-				! Void return: push unknown_type as a dummy return slot.
-				const_idx = add_const(prog, unknown_val())
-				call emit(prog, OP_LOAD_CONST, a = const_idx)
-			else
-				call compile_node(prog, node%right)
-			end if
 			call emit(prog, OP_RET)
 		else
-			! Top-level return: fall back to OP_EVAL_NODE which sets state%returned.
-			idx = add_node(prog, node)
-			call emit(prog, OP_EVAL_NODE, a = idx)
+			! Top-level return: OP_HALT exits the VM loop; TOS is the result.
+			call emit(prog, OP_HALT)
 		end if
 
-	! ---- fallback: delegate to the AST walker ---------------------------------
+	! ---- no unhandled node kinds should reach here ----------------------------
 	case default
-		idx = add_node(prog, node)
-		call emit(prog, OP_EVAL_NODE, a = idx)
+		write(*,*) 'compile: unhandled node kind ', node%kind
+		call internal_error()
 
 	end select
 

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -432,33 +432,49 @@ recursive subroutine compile_node(prog, node)
 		! Nothing to emit: fn bodies are pre-compiled by the translation_unit handler.
 
 	! ---- user-defined function call -------------------------------------------
-	! Two-pass arg push to avoid by-ref aliasing (mirrors eval_fn_call):
-	!   Pass 1: compile all by-value args (push evaluated values).
-	!   Pass 2: emit OP_LOAD_REF_* for each by-ref arg (moves value from slot).
-	! Then emit OP_CALL with the fn id and a node-pool index carrying ref metadata.
+	! Only emit OP_CALL for functions compiled into this program_t (i.e. locally
+	! declared functions whose fn_entry is known).  Module-imported functions and
+	! any call whose fn_id lies outside the compiled range fall back to OP_EVAL_NODE
+	! so the AST walker handles them via eval_fn_call.
 	case (fn_call_expr)
-		! Store the call node so OP_CALL/OP_RET can access params/is_ref.
-		idx = add_node(prog, node)
-
-		! Pass 1: push by-value args onto stack.
-		if (allocated(node%is_ref)) then
-			do i = 1, size(node%is_ref)
-				if (.not. node%is_ref(i)) call compile_node(prog, node%args(i))
-			end do
-
-			! Pass 2: move by-ref args from their variable slots onto stack.
-			do i = 1, size(node%is_ref)
-				if (node%is_ref(i)) then
-					if (node%args(i)%is_loc) then
-						call emit(prog, OP_LOAD_REF_LOCAL,  a = node%args(i)%id_index)
-					else
-						call emit(prog, OP_LOAD_REF_GLOBAL, a = node%args(i)%id_index)
-					end if
-				end if
-			end do
+		! Fortran .or./.and. are NOT short-circuit; use nested ifs to avoid
+		! an out-of-bounds access on prog%fn_entry(node%id_index).
+		first = .false.   ! reuse `first` as a "use_native" scratch bool
+		if (allocated(prog%fn_entry)) then
+			if (node%id_index <= size(prog%fn_entry)) then
+				if (prog%fn_entry(node%id_index) /= 0) first = .true.
+			end if
 		end if
 
-		call emit(prog, OP_CALL, a = node%id_index, b = idx)
+		if (.not. first) then
+			! Not a locally-compiled fn: fall back to the AST walker.
+			idx = add_node(prog, node)
+			call emit(prog, OP_EVAL_NODE, a = idx)
+		else
+			! Locally-compiled fn: two-pass arg push + OP_CALL.
+			! Store the call node so OP_CALL/OP_RET can access params/is_ref.
+			idx = add_node(prog, node)
+
+			! Pass 1: push by-value args onto stack.
+			if (allocated(node%is_ref)) then
+				do i = 1, size(node%is_ref)
+					if (.not. node%is_ref(i)) call compile_node(prog, node%args(i))
+				end do
+
+				! Pass 2: move by-ref args from their variable slots onto stack.
+				do i = 1, size(node%is_ref)
+					if (node%is_ref(i)) then
+						if (node%args(i)%is_loc) then
+							call emit(prog, OP_LOAD_REF_LOCAL,  a = node%args(i)%id_index)
+						else
+							call emit(prog, OP_LOAD_REF_GLOBAL, a = node%args(i)%id_index)
+						end if
+					end if
+				end do
+			end if
+
+			call emit(prog, OP_CALL, a = node%id_index, b = idx)
+		end if
 
 	! ---- intrinsic function call -----------------------------------------------
 	! Delegate the entire call to the AST walker via OP_EVAL_NODE.  The walker

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -244,7 +244,8 @@ recursive subroutine compile_node(prog, node)
 	case (binary_expr)
 		call compile_node(prog, node%left )
 		call compile_node(prog, node%right)
-		! Same-type scalar: emit typed opcode (no value_move / get_binary_op_kind).
+		! Same-type scalar or mixed i32/i64: emit typed opcode.
+		! Same-type numeric arrays: emit OP_ARR_BINOP (a=op_kind, b=elem_type).
 		! Otherwise emit generic OP_BINOP with pre-computed result type in instr%b
 		! so the VM can skip get_binary_op_kind at runtime.
 		typed_op = binop_typed_opcode(node%op%kind, &
@@ -252,7 +253,24 @@ recursive subroutine compile_node(prog, node)
 		if (typed_op /= 0) then
 			call emit(prog, typed_op)
 		else
-			call emit(prog, OP_BINOP, a = node%op%kind, b = node%val%type)
+			! Check for same-type numeric array ⊕ array.  Use nested ifs so the
+			! %array%type access is guarded by the allocated() checks — gfortran
+			! at -O0 does not short-circuit .and. chains in else-if conditions.
+			if (node%left%val%type == array_type .and. &
+			    node%right%val%type == array_type) then
+				if (allocated(node%left%val%array) .and. &
+				    allocated(node%right%val%array)) then
+					if (node%left%val%array%type == node%right%val%array%type) then
+						typed_op = arr_binop_typed_opcode(node%op%kind, &
+							node%left%val%array%type)
+						if (typed_op /= 0) &
+							call emit(prog, typed_op, &
+								a = node%op%kind, b = node%left%val%array%type)
+					end if
+				end if
+			end if
+			if (typed_op == 0) &
+				call emit(prog, OP_BINOP, a = node%op%kind, b = node%val%type)
 		end if
 
 	case (unary_expr)

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -104,6 +104,12 @@ recursive subroutine compile_module_fns(prog, module_node)
 	! nested use_statement members so that transitively-imported module fns are
 	! also compiled.  Skips any fn whose fn_entry is already non-zero to guard
 	! against diamond-dependency double-compilation.
+	!
+	! Two-sub-pass design so that forward references within the module resolve:
+	!   Sub-pass A: register (ensure_fn_entry) ALL fns in this module first.
+	!   Sub-pass B: compile each body; any call to a forward-declared sibling
+	!               finds the id registered (in range) even if fn_entry == 0,
+	!               and OP_CALL is emitted safely (entry will be filled before VM runs).
 
 	type(program_t),     intent(inout) :: prog
 	type(syntax_node_t), intent(in)    :: module_node   ! translation_unit
@@ -120,11 +126,16 @@ recursive subroutine compile_module_fns(prog, module_node)
 		call compile_module_fns(prog, module_node%members(i)%member)
 	end do
 
-	! Compile each fn_declaration body (guarded against double-compilation).
+	! Sub-pass A: register all local fn ids before compiling any body.
+	do i = 1, size(module_node%members)
+		if (module_node%members(i)%kind /= fn_declaration) cycle
+		call ensure_fn_entry(prog, module_node%members(i)%id_index)
+	end do
+
+	! Sub-pass B: compile each fn_declaration body.
 	do i = 1, size(module_node%members)
 		if (module_node%members(i)%kind /= fn_declaration) cycle
 		fn_id = module_node%members(i)%id_index
-		call ensure_fn_entry(prog, fn_id)
 		if (prog%fn_entry(fn_id) /= 0) cycle   ! already compiled (diamond dep)
 		prog%fn_num_locs(fn_id) = module_node%members(i)%num_locs
 		prog%fn_entry(fn_id)    = prog%len_ + 1
@@ -614,19 +625,21 @@ recursive subroutine compile_node(prog, node)
 	! any call whose fn_id lies outside the compiled range fall back to OP_EVAL_NODE
 	! so the AST walker handles them via eval_fn_call.
 	case (fn_call_expr)
-		! Fortran .or./.and. are NOT short-circuit; use nested ifs to avoid
-		! an out-of-bounds access on prog%fn_entry(node%id_index).
-		first = .false.   ! reuse `first` as a "use_native" scratch bool
+		! Check registration only: fn_entry[id] may be 0 for a forward reference
+		! (the fn is declared after this call site in the source).  That is fine —
+		! fn_entry[id] will be non-zero by the time the VM executes because all
+		! fn bodies are compiled before execution begins.  What matters at compile
+		! time is whether the fn_id was registered (id is in range of fn_entry).
+		! Fortran .or./.and. are NOT short-circuit; use nested ifs.
+		first = .false.   ! reuse `first` as "fn_id is registered"
 		if (allocated(prog%fn_entry)) then
-			if (node%id_index <= size(prog%fn_entry)) then
-				if (prog%fn_entry(node%id_index) /= 0) first = .true.
-			end if
+			if (node%id_index <= size(prog%fn_entry)) first = .true.
 		end if
 
 		if (.not. first) then
-			! fn_entry not yet populated — compile_module_fns should have covered all
-			! reachable fns; reaching here means a compiler bug.
-			write(*,*) 'compile: fn_call_expr: fn_entry not found for id', node%id_index
+			! fn_id not registered — neither the translation_unit pre-pass nor
+			! compile_module_fns saw this fn.  Compiler bug.
+			write(*,*) 'compile: fn_call_expr: fn_entry not registered for id', node%id_index
 			call internal_error()
 		else
 			! Locally-compiled fn: two-pass arg push + OP_CALL.

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -9,12 +9,76 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	! M1: natively compiles literal_expr, simple name_expr, binary_expr,
 	!     unary_expr, let_expr, simple assignment_expr, and translation_unit.
 	!     Everything else still falls back to OP_EVAL_NODE.
+	! M2: adds block_statement, if_statement, while_statement,
+	!     break_statement, continue_statement via JUMP/JUMP_IF_FALSE opcodes.
+	!     for_statement still falls back to OP_EVAL_NODE.
 
 	implicit none
+
+	! --- Loop context for break/continue backpatching ---
+	!
+	! loop_depth is incremented when entering a natively-compiled while/for loop
+	! and decremented on exit.  continue_target(d) is the instruction index to
+	! jump to for a `continue` inside loop depth d.  break fixups inside loops
+	! are collected and backpatched after the loop body is fully compiled.
+
+	integer, parameter :: MAX_LOOP_DEPTH   = 64
+	integer, parameter :: MAX_BREAK_FIXUPS = 4096
+
+	integer :: loop_depth = 0
+	integer :: continue_target(MAX_LOOP_DEPTH) = 0
+
+	integer :: break_fixup_ips(MAX_BREAK_FIXUPS)    = 0
+	integer :: break_fixup_depths(MAX_BREAK_FIXUPS)  = 0
+	integer :: nbreak_fixups = 0
+
+	! --- Block-level break context ---
+	!
+	! In Syntran, `break` can exit a plain block statement (not just loops).
+	! The AST walker propagates state%breaked through all enclosing blocks until
+	! it reaches a for/while loop or the translation unit.
+	!
+	! In the VM, we replicate this by tracking whether we are inside the
+	! outermost natively-compiled block (with no enclosing native loop).  If so,
+	! `break` records a fixup that gets patched to the block's end when the
+	! outermost block finishes compilation.  Inner blocks nested inside the
+	! outermost block share the same target, so one JUMP exits all of them.
+
+	logical :: in_block_break_ctx = .false.
+	integer :: block_break_ips(MAX_BREAK_FIXUPS) = 0
+	integer :: nblock_break_fixups = 0
 
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+subroutine backpatch_breaks(prog, depth, target)
+
+	! Patch all pending loop-break fixups at the given loop depth to target,
+	! then remove them from the fixup list.
+
+	type(program_t), intent(inout) :: prog
+	integer, intent(in) :: depth, target
+
+	!*******
+
+	integer :: i, j
+
+	j = 0
+	do i = 1, nbreak_fixups
+		if (break_fixup_depths(i) == depth) then
+			call patch_jump(prog, break_fixup_ips(i), target)
+		else
+			j = j + 1
+			break_fixup_ips(j)    = break_fixup_ips(i)
+			break_fixup_depths(j) = break_fixup_depths(i)
+		end if
+	end do
+	nbreak_fixups = j
+
+end subroutine backpatch_breaks
 
 !===============================================================================
 
@@ -23,6 +87,10 @@ recursive subroutine compile_node(prog, node)
 	! Lower one AST node to opcodes.  The contract is that this subroutine
 	! always leaves exactly one value on the operand stack after the emitted
 	! opcodes execute — even for the OP_EVAL_NODE fallback.
+	!
+	! Exception: break_statement and continue_statement emit an unconditional
+	! JUMP so the instructions after them are unreachable.  Stack discipline is
+	! only required on live paths.
 
 	type(program_t), intent(inout) :: prog
 	type(syntax_node_t), intent(in) :: node
@@ -30,7 +98,9 @@ recursive subroutine compile_node(prog, node)
 	!*******
 
 	integer :: idx, i, const_idx
-	logical :: first
+	integer :: jf_ip, j_ip, l_top, l_else, l_end, l_pad
+	integer :: nblock_saved
+	logical :: first, entering_ctx
 
 	select case (node%kind)
 
@@ -91,6 +161,199 @@ recursive subroutine compile_node(prog, node)
 			call emit(prog, OP_EVAL_NODE, a = idx)
 		end if
 
+	! ---- block statement -------------------------------------------------------
+	!
+	! Compiles all members sequentially; the last one leaves its result on the
+	! stack.  When loop_depth == 0 and this is the outermost natively-compiled
+	! block, `break` inside emits a JUMP that is patched to a pad at the block's
+	! end.  The pad pushes unknown_type so the stack is D+1 on both the normal
+	! and break-taken paths.
+	!
+	! Normal path:   [body, last result on stack] JUMP L_skip_pad
+	!                L_pad: LOAD_CONST unknown    <- not reached on normal path
+	!                L_skip_pad:
+	!
+	! Break path:    [body...] JUMP L_pad         <- from break_statement
+	!                [unreachable body tail]
+	!                JUMP L_skip_pad
+	!                L_pad: LOAD_CONST unknown
+	!                L_skip_pad:
+	case (block_statement)
+		! Enter the outermost block-break context if not already in one and
+		! there is no enclosing native while/for loop.
+		if (loop_depth == 0 .and. .not. in_block_break_ctx) then
+			in_block_break_ctx = .true.
+			entering_ctx = .true.
+			nblock_saved = nblock_break_fixups
+		else
+			entering_ctx = .false.
+			nblock_saved = 0		! unused, but avoids uninitialized warning
+		end if
+
+		! Compile members: pop between them, leave last result on stack
+		first = .true.
+		do i = 1, size(node%members)
+			if (.not. first) call emit(prog, OP_POP)
+			first = .false.
+			call compile_node(prog, node%members(i))
+		end do
+		! Empty block: push unknown_type sentinel
+		if (first) then
+			const_idx = add_const(prog, unknown_val())
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
+		end if
+
+		! After the outermost block body: emit the break-taken sentinel pad
+		! if any block-level break fixups were collected.
+		if (entering_ctx) then
+			if (nblock_break_fixups > nblock_saved) then
+				! Normal path: skip the pad
+				j_ip = prog%len_ + 1
+				call emit(prog, OP_JUMP, a = 0)
+
+				! Break path: push unknown_type as the block's result
+				l_pad = prog%len_ + 1
+				do i = nblock_saved + 1, nblock_break_fixups
+					call patch_jump(prog, block_break_ips(i), l_pad)
+				end do
+				const_idx = add_const(prog, unknown_val())
+				call emit(prog, OP_LOAD_CONST, a = const_idx)
+
+				! Both paths converge here
+				l_end = prog%len_ + 1
+				call patch_jump(prog, j_ip, l_end)
+			end if
+
+			! Restore the block-break context for the enclosing scope
+			nblock_break_fixups = nblock_saved
+			in_block_break_ctx  = .false.
+		end if
+
+	! ---- if statement ----------------------------------------------------------
+	! Bytecode pattern (no else):
+	!   [condition]
+	!   JUMP_IF_FALSE L_else
+	!   [if-clause]          -> leaves result on stack
+	!   JUMP L_end
+	!   L_else: LOAD_CONST unknown_type
+	!   L_end:
+	!
+	! Pattern (with else):
+	!   [condition]
+	!   JUMP_IF_FALSE L_else
+	!   [if-clause]          -> leaves result on stack
+	!   JUMP L_end
+	!   L_else: [else-clause] -> leaves result on stack
+	!   L_end:
+	case (if_statement)
+		! Compile condition; leaves bool on stack
+		call compile_node(prog, node%condition)
+
+		! JUMP_IF_FALSE — target patched below
+		jf_ip = prog%len_ + 1
+		call emit(prog, OP_JUMP_IF_FALSE, a = 0)
+
+		! Compile the if-clause
+		call compile_node(prog, node%if_clause)
+
+		if (allocated(node%else_clause)) then
+			! JUMP past else — target patched below
+			j_ip = prog%len_ + 1
+			call emit(prog, OP_JUMP, a = 0)
+
+			l_else = prog%len_ + 1
+			call patch_jump(prog, jf_ip, l_else)
+
+			! Compile the else-clause (may itself be another if_statement)
+			call compile_node(prog, node%else_clause)
+
+			l_end = prog%len_ + 1
+			call patch_jump(prog, j_ip, l_end)
+		else
+			! No else: jump past the unknown_type push
+			j_ip = prog%len_ + 1
+			call emit(prog, OP_JUMP, a = 0)
+
+			l_else = prog%len_ + 1
+			call patch_jump(prog, jf_ip, l_else)
+
+			! Condition was false and no else: push unknown_type
+			const_idx = add_const(prog, unknown_val())
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
+
+			l_end = prog%len_ + 1
+			call patch_jump(prog, j_ip, l_end)
+		end if
+
+	! ---- while statement -------------------------------------------------------
+	! Bytecode pattern:
+	!   L_top: [condition]
+	!          JUMP_IF_FALSE L_end
+	!          [body]         -> result discarded with POP
+	!          POP
+	!          JUMP L_top
+	!   L_end: LOAD_CONST unknown_type  (while-statement result)
+	!
+	! break  -> JUMP L_end  (backpatched after loop)
+	! continue -> JUMP L_top (target known when continue is emitted)
+	case (while_statement)
+		loop_depth = loop_depth + 1
+		l_top = prog%len_ + 1
+		continue_target(loop_depth) = l_top
+
+		! Compile condition
+		call compile_node(prog, node%condition)
+
+		! JUMP_IF_FALSE — patched to L_end below
+		jf_ip = prog%len_ + 1
+		call emit(prog, OP_JUMP_IF_FALSE, a = 0)
+
+		! Compile body; its result is discarded before looping
+		call compile_node(prog, node%body)
+		call emit(prog, OP_POP)
+		call emit(prog, OP_JUMP, a = l_top)
+
+		! L_end: backpatch the conditional exit and all break fixups
+		l_end = prog%len_ + 1
+		call patch_jump(prog, jf_ip, l_end)
+		call backpatch_breaks(prog, loop_depth, l_end)
+		loop_depth = loop_depth - 1
+
+		! Push unknown_type as the while-statement's result value
+		const_idx = add_const(prog, unknown_val())
+		call emit(prog, OP_LOAD_CONST, a = const_idx)
+
+	! ---- break -----------------------------------------------------------------
+	case (break_statement)
+		if (loop_depth > 0) then
+			! Inside a native while/for: jump to the loop's end (backpatched)
+			nbreak_fixups = nbreak_fixups + 1
+			break_fixup_ips(nbreak_fixups)    = prog%len_ + 1
+			break_fixup_depths(nbreak_fixups) = loop_depth
+			call emit(prog, OP_JUMP, a = 0)
+
+		else if (in_block_break_ctx) then
+			! Inside the outermost native block (no enclosing loop): jump to
+			! the block's end pad (backpatched when the block finishes)
+			nblock_break_fixups = nblock_break_fixups + 1
+			block_break_ips(nblock_break_fixups) = prog%len_ + 1
+			call emit(prog, OP_JUMP, a = 0)
+
+		else
+			! No breakable context (top-level break): fall back to AST walker
+			idx = add_node(prog, node)
+			call emit(prog, OP_EVAL_NODE, a = idx)
+		end if
+
+	! ---- continue --------------------------------------------------------------
+	case (continue_statement)
+		if (loop_depth > 0) then
+			call emit(prog, OP_JUMP, a = continue_target(loop_depth))
+		else
+			idx = add_node(prog, node)
+			call emit(prog, OP_EVAL_NODE, a = idx)
+		end if
+
 	! ---- top-level translation unit -------------------------------------------
 	case (translation_unit)
 		! Fn and struct declarations are registered at parse time; skip them here.
@@ -137,6 +400,12 @@ module subroutine compile_tree(tree, prog)
 
 	type(syntax_node_t), intent(in) :: tree
 	type(program_t), intent(out) :: prog
+
+	! Reset all compiler state for each fresh compilation
+	loop_depth          = 0
+	nbreak_fixups       = 0
+	in_block_break_ctx  = .false.
+	nblock_break_fixups = 0
 
 	prog = new_program()
 	call compile_node(prog, tree)

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -5,10 +5,8 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 
 	! Bytecode compiler: AST -> bytecode lowering.
 	!
-	! M0: single OP_EVAL_NODE fallback for any unsupported node.
 	! M1: natively compiles literal_expr, simple name_expr, binary_expr,
 	!     unary_expr, let_expr, simple assignment_expr, and translation_unit.
-	!     Everything else still falls back to OP_EVAL_NODE.
 	! M2: adds block_statement, if_statement, while_statement,
 	!     break_statement, continue_statement via JUMP/JUMP_IF_FALSE opcodes.
 	! M6: fn_call_intr_expr emits OP_CALL_INTR with integer intr_id dispatch.
@@ -16,51 +14,11 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	!     module init code emitted inline at the use_statement site.
 	! M8: for_statement (native FOR_SETUP/FOR_NEXT), array_expr (OP_NEW_ARRAY),
 	!     slice/complex LHS assign (OP_STORE_SLICE), top-level return (OP_HALT),
-	!     readln/close native dispatch with slot writeback; OP_EVAL_NODE fallback
-	!     removed from compiler (kept as debug opcode in the VM handler).
+	!     readln/close native dispatch with slot writeback.
+	! All node kinds are now natively compiled; the case default traps unhandled
+	! nodes via internal_error().
 
 	implicit none
-
-	! --- Loop context for break/continue backpatching ---
-	!
-	! loop_depth is incremented when entering a natively-compiled while/for loop
-	! and decremented on exit.  continue_target(d) is the instruction index to
-	! jump to for a `continue` inside loop depth d.  break fixups inside loops
-	! are collected and backpatched after the loop body is fully compiled.
-	!
-	! All arrays are growable (no hard limit) for parity with the AST walker.
-	! INIT_* constants are starting capacities only; arrays double on demand.
-
-	integer, parameter :: INIT_LOOP_DEPTH   = 64
-	integer, parameter :: INIT_BREAK_FIXUPS = 256
-
-	integer :: loop_depth = 0
-	integer, allocatable :: continue_target(:)
-
-	integer, allocatable :: break_fixup_ips(:)
-	integer, allocatable :: break_fixup_depths(:)
-	integer :: nbreak_fixups = 0
-
-	! --- Block-level break context ---
-	!
-	! In Syntran, `break` can exit a plain block statement (not just loops).
-	! The AST walker propagates state%breaked through all enclosing blocks until
-	! it reaches a for/while loop or the translation unit.
-	!
-	! In the VM, we replicate this by tracking whether we are inside the
-	! outermost natively-compiled block (with no enclosing native loop).  If so,
-	! `break` records a fixup that gets patched to the block's end when the
-	! outermost block finishes compilation.  Inner blocks nested inside the
-	! outermost block share the same target, so one JUMP exits all of them.
-
-	logical :: in_block_break_ctx = .false.
-	integer, allocatable :: block_break_ips(:)
-	integer :: nblock_break_fixups = 0
-
-	! Set to true while compiling a user function body; used to distinguish
-	! a function-level return_statement (emit OP_RET) from a top-level one
-	! (fall back to OP_EVAL_NODE).
-	logical :: in_fn_body = .false.
 
 !===============================================================================
 
@@ -118,7 +76,7 @@ end subroutine ensure_fn_entry
 
 !===============================================================================
 
-recursive subroutine compile_module_fns(prog, module_node)
+recursive subroutine compile_module_fns(prog, cs, module_node)
 
 	! Compile all fn bodies from a module's translation_unit node into prog,
 	! recording their entry points in prog%fn_entry.  Recursively handles any
@@ -132,8 +90,9 @@ recursive subroutine compile_module_fns(prog, module_node)
 	!               finds the id registered (in range) even if fn_entry == 0,
 	!               and OP_CALL is emitted safely (entry will be filled before VM runs).
 
-	type(program_t),     intent(inout) :: prog
-	type(syntax_node_t), intent(in)    :: module_node   ! translation_unit
+	type(program_t),        intent(inout) :: prog
+	type(compiler_state_t), intent(inout) :: cs
+	type(syntax_node_t),    intent(in)    :: module_node   ! translation_unit
 
 	!*******
 
@@ -144,7 +103,7 @@ recursive subroutine compile_module_fns(prog, module_node)
 	do i = 1, size(module_node%members)
 		if (module_node%members(i)%kind /= use_statement) cycle
 		if (.not. allocated(module_node%members(i)%member)) cycle
-		call compile_module_fns(prog, module_node%members(i)%member)
+		call compile_module_fns(prog, cs, module_node%members(i)%member)
 	end do
 
 	! Sub-pass A: register all local fn ids before compiling any body.
@@ -160,55 +119,57 @@ recursive subroutine compile_module_fns(prog, module_node)
 		if (prog%fn_entry(fn_id) /= 0) cycle   ! already compiled (diamond dep)
 		prog%fn_num_locs(fn_id) = module_node%members(i)%num_locs
 		prog%fn_entry(fn_id)    = prog%len_ + 1
-		in_fn_body = .true.
-		call compile_node(prog, module_node%members(i)%body)
-		in_fn_body = .false.
+		cs%in_fn_body = .true.
+		call compile_node(prog, cs, module_node%members(i)%body)
+		cs%in_fn_body = .false.
 	end do
 
 end subroutine compile_module_fns
 
 !===============================================================================
 
-subroutine backpatch_breaks(prog, depth, target)
+subroutine backpatch_breaks(prog, cs, depth, target)
 
 	! Patch all pending loop-break fixups at the given loop depth to target,
 	! then remove them from the fixup list.
 
-	type(program_t), intent(inout) :: prog
-	integer, intent(in) :: depth, target
+	type(program_t),        intent(inout) :: prog
+	type(compiler_state_t), intent(inout) :: cs
+	integer,                intent(in)    :: depth, target
 
 	!*******
 
 	integer :: i, j
 
 	j = 0
-	do i = 1, nbreak_fixups
-		if (break_fixup_depths(i) == depth) then
-			call patch_jump(prog, break_fixup_ips(i), target)
+	do i = 1, cs%nbreak_fixups
+		if (cs%break_fixup_depths(i) == depth) then
+			call patch_jump(prog, cs%break_fixup_ips(i), target)
 		else
 			j = j + 1
-			break_fixup_ips(j)    = break_fixup_ips(i)
-			break_fixup_depths(j) = break_fixup_depths(i)
+			cs%break_fixup_ips(j)    = cs%break_fixup_ips(i)
+			cs%break_fixup_depths(j) = cs%break_fixup_depths(i)
 		end if
 	end do
-	nbreak_fixups = j
+	cs%nbreak_fixups = j
 
 end subroutine backpatch_breaks
 
 !===============================================================================
 
-recursive subroutine compile_node(prog, node)
+recursive subroutine compile_node(prog, cs, node)
 
 	! Lower one AST node to opcodes.  The contract is that this subroutine
 	! always leaves exactly one value on the operand stack after the emitted
-	! opcodes execute — even for the OP_EVAL_NODE fallback.
+	! opcodes execute.
 	!
 	! Exception: break_statement and continue_statement emit an unconditional
 	! JUMP so the instructions after them are unreachable.  Stack discipline is
 	! only required on live paths.
 
-	type(program_t), intent(inout) :: prog
-	type(syntax_node_t), intent(in) :: node
+	type(program_t),        intent(inout) :: prog
+	type(compiler_state_t), intent(inout) :: cs
+	type(syntax_node_t),    intent(in)    :: node
 
 	!*******
 
@@ -250,7 +211,7 @@ recursive subroutine compile_node(prog, node)
 			! Fallback B: any range/step/all subscript → OP_SLICE.
 			if (index_native_ok(node)) then
 				do i = 1, size(node%lsubscripts)
-					call compile_node(prog, node%lsubscripts(i))
+					call compile_node(prog, cs, node%lsubscripts(i))
 				end do
 				call emit(prog, OP_INDEX_NAT, &
 					a = node%id_index, &
@@ -277,8 +238,8 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- arithmetic / comparison / logic / bitwise ----------------------------
 	case (binary_expr)
-		call compile_node(prog, node%left )
-		call compile_node(prog, node%right)
+		call compile_node(prog, cs, node%left )
+		call compile_node(prog, cs, node%right)
 		! Same-type scalar or mixed i32/i64: emit typed opcode.
 		! Same-type numeric arrays: emit OP_ARR_BINOP (a=op_kind, b=elem_type).
 		! Otherwise emit generic OP_BINOP with pre-computed result type in instr%b
@@ -309,7 +270,7 @@ recursive subroutine compile_node(prog, node)
 		end if
 
 	case (unary_expr)
-		call compile_node(prog, node%right)
+		call compile_node(prog, cs, node%right)
 		typed_op = unop_typed_opcode(node%op%kind, node%right%val%type)
 		if (typed_op /= 0) then
 			call emit(prog, typed_op)
@@ -319,7 +280,7 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- variable declarations ------------------------------------------------
 	case (let_expr)
-		call compile_node(prog, node%right)
+		call compile_node(prog, cs, node%right)
 		! Scalar type: emit typed store (avoids assign_ overhead).
 		typed_op = typed_store_op(node%val%type, node%is_loc)
 		if (typed_op /= 0) then
@@ -334,14 +295,14 @@ recursive subroutine compile_node(prog, node)
 	case (assignment_expr)
 		if (allocated(node%member)) then
 			! M5: dot member assignment: a.b = expr  or  a.b += expr
-			call compile_node(prog, node%right)
+			call compile_node(prog, cs, node%right)
 			idx = add_node(prog, node)
 			call emit(prog, OP_STORE_MEMBER, a = idx, b = node%op%kind)
 
 		else if (.not. allocated(node%lsubscripts) .and. &
 		         node%op%kind == equals_token) then
 			! Simple plain assignment: a = expr
-			call compile_node(prog, node%right)
+			call compile_node(prog, cs, node%right)
 			! Scalar type (LHS and RHS agree — parser guarantees): typed store.
 			typed_op = 0
 			if (node%val%type == node%right%val%type) &
@@ -373,7 +334,7 @@ recursive subroutine compile_node(prog, node)
 			if (binop_op_ /= 0) then
 				! Load current value, compile RHS, apply op, store result.
 				call emit(prog, typed_op, a = node%id_index)
-				call compile_node(prog, node%right)
+				call compile_node(prog, cs, node%right)
 				call emit(prog, binop_op_)
 				typed_op = typed_store_op(node%val%type, node%is_loc)
 				call emit(prog, typed_op, a = node%id_index)
@@ -399,16 +360,16 @@ recursive subroutine compile_node(prog, node)
 				! Fallback: compound ops, str/struct elements → OP_STORE_IDX.
 				if (store_idx_native_ok(node)) then
 					do i = 1, size(node%lsubscripts)
-						call compile_node(prog, node%lsubscripts(i))
+						call compile_node(prog, cs, node%lsubscripts(i))
 					end do
-					call compile_node(prog, node%right)
+					call compile_node(prog, cs, node%right)
 					call emit(prog, OP_STORE_IDX_NAT, &
 						a = node%id_index, &
 						b = int(size(node%lsubscripts)), &
 						c = merge(1_8, 0_8, node%is_loc))
 				else
 					! Fallback: compound ops, str chars, struct elements, casts
-					call compile_node(prog, node%right)
+					call compile_node(prog, cs, node%right)
 					idx = add_node(prog, node)
 					call emit(prog, OP_STORE_IDX, a = idx, b = node%op%kind)
 				end if
@@ -439,10 +400,10 @@ recursive subroutine compile_node(prog, node)
 	case (block_statement)
 		! Enter the outermost block-break context if not already in one and
 		! there is no enclosing native while/for loop.
-		if (loop_depth == 0 .and. .not. in_block_break_ctx) then
-			in_block_break_ctx = .true.
+		if (cs%loop_depth == 0 .and. .not. cs%in_block_break_ctx) then
+			cs%in_block_break_ctx = .true.
 			entering_ctx = .true.
-			nblock_saved = nblock_break_fixups
+			nblock_saved = cs%nblock_break_fixups
 		else
 			entering_ctx = .false.
 			nblock_saved = 0		! unused, but avoids uninitialized warning
@@ -453,7 +414,7 @@ recursive subroutine compile_node(prog, node)
 		do i = 1, size(node%members)
 			if (.not. first) call emit(prog, OP_POP)
 			first = .false.
-			call compile_node(prog, node%members(i))
+			call compile_node(prog, cs, node%members(i))
 		end do
 		! Empty block: push unknown_type sentinel
 		if (first) then
@@ -464,15 +425,15 @@ recursive subroutine compile_node(prog, node)
 		! After the outermost block body: emit the break-taken sentinel pad
 		! if any block-level break fixups were collected.
 		if (entering_ctx) then
-			if (nblock_break_fixups > nblock_saved) then
+			if (cs%nblock_break_fixups > nblock_saved) then
 				! Normal path: skip the pad
 				j_ip = prog%len_ + 1
 				call emit(prog, OP_JUMP, a = 0)
 
 				! Break path: push unknown_type as the block's result
 				l_pad = prog%len_ + 1
-				do i = nblock_saved + 1, nblock_break_fixups
-					call patch_jump(prog, block_break_ips(i), l_pad)
+				do i = nblock_saved + 1, cs%nblock_break_fixups
+					call patch_jump(prog, cs%block_break_ips(i), l_pad)
 				end do
 				const_idx = add_const(prog, unknown_val())
 				call emit(prog, OP_LOAD_CONST, a = const_idx)
@@ -483,8 +444,8 @@ recursive subroutine compile_node(prog, node)
 			end if
 
 			! Restore the block-break context for the enclosing scope
-			nblock_break_fixups = nblock_saved
-			in_block_break_ctx  = .false.
+			cs%nblock_break_fixups = nblock_saved
+			cs%in_block_break_ctx  = .false.
 		end if
 
 	! ---- if statement ----------------------------------------------------------
@@ -505,14 +466,14 @@ recursive subroutine compile_node(prog, node)
 	!   L_end:
 	case (if_statement)
 		! Compile condition; leaves bool on stack
-		call compile_node(prog, node%condition)
+		call compile_node(prog, cs, node%condition)
 
 		! JUMP_IF_FALSE — target patched below
 		jf_ip = prog%len_ + 1
 		call emit(prog, OP_JUMP_IF_FALSE, a = 0)
 
 		! Compile the if-clause
-		call compile_node(prog, node%if_clause)
+		call compile_node(prog, cs, node%if_clause)
 
 		if (allocated(node%else_clause)) then
 			! JUMP past else — target patched below
@@ -523,7 +484,7 @@ recursive subroutine compile_node(prog, node)
 			call patch_jump(prog, jf_ip, l_else)
 
 			! Compile the else-clause (may itself be another if_statement)
-			call compile_node(prog, node%else_clause)
+			call compile_node(prog, cs, node%else_clause)
 
 			l_end = prog%len_ + 1
 			call patch_jump(prog, j_ip, l_end)
@@ -555,28 +516,28 @@ recursive subroutine compile_node(prog, node)
 	! break  -> JUMP L_end  (backpatched after loop)
 	! continue -> JUMP L_top (target known when continue is emitted)
 	case (while_statement)
-		if (loop_depth + 1 > size(continue_target)) call grow_int(continue_target)
-		loop_depth = loop_depth + 1
+		if (cs%loop_depth + 1 > size(cs%continue_target)) call grow_int(cs%continue_target)
+		cs%loop_depth = cs%loop_depth + 1
 		l_top = prog%len_ + 1
-		continue_target(loop_depth) = l_top
+		cs%continue_target(cs%loop_depth) = l_top
 
 		! Compile condition
-		call compile_node(prog, node%condition)
+		call compile_node(prog, cs, node%condition)
 
 		! JUMP_IF_FALSE — patched to L_end below
 		jf_ip = prog%len_ + 1
 		call emit(prog, OP_JUMP_IF_FALSE, a = 0)
 
 		! Compile body; its result is discarded before looping
-		call compile_node(prog, node%body)
+		call compile_node(prog, cs, node%body)
 		call emit(prog, OP_POP)
 		call emit(prog, OP_JUMP, a = l_top)
 
 		! L_end: backpatch the conditional exit and all break fixups
 		l_end = prog%len_ + 1
 		call patch_jump(prog, jf_ip, l_end)
-		call backpatch_breaks(prog, loop_depth, l_end)
-		loop_depth = loop_depth - 1
+		call backpatch_breaks(prog, cs, cs%loop_depth, l_end)
+		cs%loop_depth = cs%loop_depth - 1
 
 		! Push unknown_type as the while-statement's result value
 		const_idx = add_const(prog, unknown_val())
@@ -584,24 +545,24 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- break -----------------------------------------------------------------
 	case (break_statement)
-		if (loop_depth > 0) then
+		if (cs%loop_depth > 0) then
 			! Inside a native while/for: jump to the loop's end (backpatched)
-			if (nbreak_fixups + 1 > size(break_fixup_ips)) then
-				call grow_int(break_fixup_ips)
-				call grow_int(break_fixup_depths)
+			if (cs%nbreak_fixups + 1 > size(cs%break_fixup_ips)) then
+				call grow_int(cs%break_fixup_ips)
+				call grow_int(cs%break_fixup_depths)
 			end if
-			nbreak_fixups = nbreak_fixups + 1
-			break_fixup_ips(nbreak_fixups)    = prog%len_ + 1
-			break_fixup_depths(nbreak_fixups) = loop_depth
+			cs%nbreak_fixups = cs%nbreak_fixups + 1
+			cs%break_fixup_ips(cs%nbreak_fixups)    = prog%len_ + 1
+			cs%break_fixup_depths(cs%nbreak_fixups) = cs%loop_depth
 			call emit(prog, OP_JUMP, a = 0)
 
-		else if (in_block_break_ctx) then
+		else if (cs%in_block_break_ctx) then
 			! Inside the outermost native block (no enclosing loop): jump to
 			! the block's end pad (backpatched when the block finishes)
-			if (nblock_break_fixups + 1 > size(block_break_ips)) &
-				call grow_int(block_break_ips)
-			nblock_break_fixups = nblock_break_fixups + 1
-			block_break_ips(nblock_break_fixups) = prog%len_ + 1
+			if (cs%nblock_break_fixups + 1 > size(cs%block_break_ips)) &
+				call grow_int(cs%block_break_ips)
+			cs%nblock_break_fixups = cs%nblock_break_fixups + 1
+			cs%block_break_ips(cs%nblock_break_fixups) = prog%len_ + 1
 			call emit(prog, OP_JUMP, a = 0)
 
 		else
@@ -612,8 +573,8 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- continue --------------------------------------------------------------
 	case (continue_statement)
-		if (loop_depth > 0) then
-			call emit(prog, OP_JUMP, a = continue_target(loop_depth))
+		if (cs%loop_depth > 0) then
+			call emit(prog, OP_JUMP, a = cs%continue_target(cs%loop_depth))
 		else
 			! No loop context: top-level continue is a no-op in translation_unit
 			const_idx = add_const(prog, unknown_val())
@@ -637,7 +598,7 @@ recursive subroutine compile_node(prog, node)
 		do i = 1, size(node%members)
 			if (node%members(i)%kind /= use_statement) cycle
 			if (.not. allocated(node%members(i)%member)) cycle
-			call compile_module_fns(prog, node%members(i)%member)
+			call compile_module_fns(prog, cs, node%members(i)%member)
 		end do
 
 		! Pass 1: compile each locally-declared fn body.
@@ -647,9 +608,9 @@ recursive subroutine compile_node(prog, node)
 			prog%fn_num_locs(l_top) = node%members(i)%num_locs
 			prog%fn_entry(l_top)    = prog%len_ + 1
 
-			in_fn_body = .true.
-			call compile_node(prog, node%members(i)%body)
-			in_fn_body = .false.
+			cs%in_fn_body = .true.
+			call compile_node(prog, cs, node%members(i)%body)
+			cs%in_fn_body = .false.
 		end do
 
 		! Top-level statements start here.
@@ -664,7 +625,7 @@ recursive subroutine compile_node(prog, node)
 			if (node%members(i)%kind == struct_declaration) cycle
 			if (.not. first) call emit(prog, OP_POP)
 			first = .false.
-			call compile_node(prog, node%members(i))
+			call compile_node(prog, cs, node%members(i))
 		end do
 
 		! If all members were fn/struct declarations, nothing was emitted and
@@ -694,25 +655,25 @@ recursive subroutine compile_node(prog, node)
 		idx = add_node(prog, node)
 		call emit(prog, OP_FOR_SETUP, a = idx)
 
-		if (loop_depth + 1 > size(continue_target)) call grow_int(continue_target)
-		loop_depth = loop_depth + 1
+		if (cs%loop_depth + 1 > size(cs%continue_target)) call grow_int(cs%continue_target)
+		cs%loop_depth = cs%loop_depth + 1
 		l_top = prog%len_ + 1
-		continue_target(loop_depth) = l_top
+		cs%continue_target(cs%loop_depth) = l_top
 
 		! FOR_NEXT — patched to L_pop below
 		jf_ip = prog%len_ + 1
 		call emit(prog, OP_FOR_NEXT, a = 0)
 
 		! Compile body; its result is discarded before the back edge
-		call compile_node(prog, node%body)
+		call compile_node(prog, cs, node%body)
 		call emit(prog, OP_POP)
 		call emit(prog, OP_JUMP, a = l_top)
 
 		! L_pop: backpatch FOR_NEXT and all break fixups here, then pop + result
 		l_end = prog%len_ + 1
 		call patch_jump(prog, jf_ip, l_end)
-		call backpatch_breaks(prog, loop_depth, l_end)
-		loop_depth = loop_depth - 1
+		call backpatch_breaks(prog, cs, cs%loop_depth, l_end)
+		cs%loop_depth = cs%loop_depth - 1
 		call emit(prog, OP_FOR_POP)
 
 		! Push unknown_type as the for-statement's result value
@@ -732,7 +693,7 @@ recursive subroutine compile_node(prog, node)
 	! struct_name and nmembers; the member expressions themselves are bytecode.
 	case (struct_instance_expr)
 		do i = 1, size(node%members)
-			call compile_node(prog, node%members(i))
+			call compile_node(prog, cs, node%members(i))
 		end do
 		idx = add_node(prog, node)
 		call emit(prog, OP_MAKE_STRUCT, a = idx)
@@ -761,7 +722,7 @@ recursive subroutine compile_node(prog, node)
 			do i = 1, size(node%member%members)
 				if (node%member%members(i)%kind == fn_declaration    ) cycle
 				if (node%member%members(i)%kind == struct_declaration) cycle
-				call compile_node(prog, node%member%members(i))
+				call compile_node(prog, cs, node%member%members(i))
 				call emit(prog, OP_POP)
 			end do
 		end if
@@ -798,7 +759,7 @@ recursive subroutine compile_node(prog, node)
 			! Pass 1: push by-value args onto stack.
 			if (allocated(node%is_ref)) then
 				do i = 1, size(node%is_ref)
-					if (.not. node%is_ref(i)) call compile_node(prog, node%args(i))
+					if (.not. node%is_ref(i)) call compile_node(prog, cs, node%args(i))
 				end do
 
 				! Pass 2: move by-ref args from their variable slots onto stack.
@@ -829,7 +790,24 @@ recursive subroutine compile_node(prog, node)
 			select case (intr_id_)
 			case (INTR_READLN, INTR_CLOSE)
 				! Push the file argument, encode its slot for writeback in c.
-				call compile_node(prog, node%args(1))
+				! Guard: the file arg must be a plain variable (no subscripts, no
+				! member access).  If the grammar ever permits readln(arr[i]) or
+				! a struct-member file, the slot encoding would be wrong; fail
+				! loudly here rather than silently writing to the wrong slot.
+				if (node%args(1)%kind /= name_expr) then
+					write(*,*) 'compile: readln/close: file argument must be a ' // &
+						'plain variable (subscripted/member file not supported)'
+					call internal_error()
+				end if
+				if (allocated(node%args(1)%lsubscripts)) then
+					write(*,*) 'compile: readln/close: subscripted file argument not supported'
+					call internal_error()
+				end if
+				if (allocated(node%args(1)%member)) then
+					write(*,*) 'compile: readln/close: member file argument not supported'
+					call internal_error()
+				end if
+				call compile_node(prog, cs, node%args(1))
 				slot_c = int(node%args(1)%id_index, 8) * 2 + &
 				         merge(1_8, 0_8, node%args(1)%is_loc)
 				call emit(prog, OP_CALL_INTR, a = intr_id_, b = 1, c = slot_c)
@@ -838,7 +816,7 @@ recursive subroutine compile_node(prog, node)
 				nargs_ = 0
 				if (allocated(node%args)) then
 					do i = 1, size(node%args)
-						call compile_node(prog, node%args(i))
+						call compile_node(prog, cs, node%args(i))
 					end do
 					nargs_ = size(node%args)
 				end if
@@ -855,9 +833,9 @@ recursive subroutine compile_node(prog, node)
 			const_idx = add_const(prog, unknown_val())
 			call emit(prog, OP_LOAD_CONST, a = const_idx)
 		else
-			call compile_node(prog, node%right)
+			call compile_node(prog, cs, node%right)
 		end if
-		if (in_fn_body) then
+		if (cs%in_fn_body) then
 			call emit(prog, OP_RET)
 		else
 			! Top-level return: OP_HALT exits the VM loop; TOS is the result.
@@ -888,26 +866,15 @@ module subroutine compile_tree(tree, prog)
 	type(syntax_node_t), intent(in) :: tree
 	type(program_t), intent(out) :: prog
 
+	!*******
+
+	type(compiler_state_t) :: cs
+
 	!print *, 'starting compile_tree()'
 
-	! Reset all compiler state for each fresh compilation.
-	! Growable arrays are allocated here (or reallocated to initial cap if already
-	! allocated from a previous compile_tree call on the same module instance).
-	loop_depth          = 0
-	nbreak_fixups       = 0
-	in_block_break_ctx  = .false.
-	nblock_break_fixups = 0
-	in_fn_body          = .false.
-
-	if (.not. allocated(continue_target)) allocate(continue_target(INIT_LOOP_DEPTH))
-	if (.not. allocated(break_fixup_ips)) then
-		allocate(break_fixup_ips(INIT_BREAK_FIXUPS))
-		allocate(break_fixup_depths(INIT_BREAK_FIXUPS))
-	end if
-	if (.not. allocated(block_break_ips)) allocate(block_break_ips(INIT_BREAK_FIXUPS))
-
+	cs = new_compiler_state()
 	prog = new_program()
-	call compile_node(prog, tree)
+	call compile_node(prog, cs, tree)
 
 end subroutine compile_tree
 

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -12,6 +12,8 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	! M2: adds block_statement, if_statement, while_statement,
 	!     break_statement, continue_statement via JUMP/JUMP_IF_FALSE opcodes.
 	!     for_statement still falls back to OP_EVAL_NODE.
+	! M6: fn_call_intr_expr emits OP_CALL_INTR with integer intr_id dispatch
+	!     (readln/close use CALL_INTR_NODE fallback for variable-slot writeback).
 
 	implicit none
 
@@ -518,12 +520,31 @@ recursive subroutine compile_node(prog, node)
 		end if
 
 	! ---- intrinsic function call -----------------------------------------------
-	! Delegate the entire call to the AST walker via OP_EVAL_NODE.  The walker
-	! evaluates args using the current state (which has the callee's locs when
-	! inside a compiled frame).  Migration to native integer dispatch is M6.
+	! M6: emit OP_CALL_INTR.  For most intrinsics, push all args first then emit
+	! with b=argc for native dispatch in vm_call_intr.  For intrinsics that need
+	! writeback to a variable slot (readln, close), store the node in the pool
+	! and use the CALL_INTR_NODE fallback (b=-1, c=node_pool_idx).
 	case (fn_call_intr_expr)
-		idx = add_node(prog, node)
-		call emit(prog, OP_EVAL_NODE, a = idx)
+		block
+			integer :: intr_id_, nargs_
+			intr_id_ = intr_id_from_name(node%identifier%text)
+			select case (intr_id_)
+			case (INTR_READLN, INTR_CLOSE)
+				! Writeback required: store node and fall back to eval_fn_call_intr.
+				idx = add_node(prog, node)
+				call emit(prog, OP_CALL_INTR, a = intr_id_, b = -1, c = int(idx, 8))
+			case default
+				! Native dispatch: push all args, then emit OP_CALL_INTR.
+				nargs_ = 0
+				if (allocated(node%args)) then
+					do i = 1, size(node%args)
+						call compile_node(prog, node%args(i))
+					end do
+					nargs_ = size(node%args)
+				end if
+				call emit(prog, OP_CALL_INTR, a = intr_id_, b = nargs_)
+			end select
+		end block
 
 	! ---- return statement ------------------------------------------------------
 	! Inside a compiled function body: push return value (or unknown sentinel for

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -14,6 +14,8 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	!     for_statement still falls back to OP_EVAL_NODE.
 	! M6: fn_call_intr_expr emits OP_CALL_INTR with integer intr_id dispatch
 	!     (readln/close use CALL_INTR_NODE fallback for variable-slot writeback).
+	! M7: use_statement: module fn bodies compiled into prog before entry_main;
+	!     module init code emitted inline at the use_statement site.
 
 	implicit none
 
@@ -58,6 +60,78 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+subroutine ensure_fn_entry(prog, fn_id)
+
+	! Grow prog%fn_entry / prog%fn_num_locs so that index fn_id is valid.
+	! New slots are zeroed.  No-op if the tables are already large enough.
+
+	type(program_t), intent(inout) :: prog
+	integer, intent(in) :: fn_id
+
+	!*******
+
+	integer, allocatable :: tmp_entry(:), tmp_locs(:)
+
+	if (.not. allocated(prog%fn_entry)) then
+		allocate(prog%fn_entry(fn_id))
+		allocate(prog%fn_num_locs(fn_id))
+		prog%fn_entry    = 0
+		prog%fn_num_locs = 0
+	else if (fn_id > size(prog%fn_entry)) then
+		call move_alloc(prog%fn_entry,    tmp_entry)
+		call move_alloc(prog%fn_num_locs, tmp_locs)
+		allocate(prog%fn_entry(fn_id))
+		allocate(prog%fn_num_locs(fn_id))
+		prog%fn_entry    = 0
+		prog%fn_num_locs = 0
+		prog%fn_entry(1: size(tmp_entry))    = tmp_entry
+		prog%fn_num_locs(1: size(tmp_locs))  = tmp_locs
+	end if
+
+end subroutine ensure_fn_entry
+
+!===============================================================================
+
+recursive subroutine compile_module_fns(prog, module_node)
+
+	! Compile all fn bodies from a module's translation_unit node into prog,
+	! recording their entry points in prog%fn_entry.  Recursively handles any
+	! nested use_statement members so that transitively-imported module fns are
+	! also compiled.  Skips any fn whose fn_entry is already non-zero to guard
+	! against diamond-dependency double-compilation.
+
+	type(program_t),     intent(inout) :: prog
+	type(syntax_node_t), intent(in)    :: module_node   ! translation_unit
+
+	!*******
+
+	integer :: i, fn_id
+
+	! Recurse into nested use_statements first so that their fns are available
+	! to any bodies compiled below that call them.
+	do i = 1, size(module_node%members)
+		if (module_node%members(i)%kind /= use_statement) cycle
+		if (.not. allocated(module_node%members(i)%member)) cycle
+		call compile_module_fns(prog, module_node%members(i)%member)
+	end do
+
+	! Compile each fn_declaration body (guarded against double-compilation).
+	do i = 1, size(module_node%members)
+		if (module_node%members(i)%kind /= fn_declaration) cycle
+		fn_id = module_node%members(i)%id_index
+		call ensure_fn_entry(prog, fn_id)
+		if (prog%fn_entry(fn_id) /= 0) cycle   ! already compiled (diamond dep)
+		prog%fn_num_locs(fn_id) = module_node%members(i)%num_locs
+		prog%fn_entry(fn_id)    = prog%len_ + 1
+		in_fn_body = .true.
+		call compile_node(prog, module_node%members(i)%body)
+		in_fn_body = .false.
+	end do
+
+end subroutine compile_module_fns
 
 !===============================================================================
 
@@ -386,36 +460,25 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- top-level translation unit -------------------------------------------
 	case (translation_unit)
-		! M3: compile all user fn bodies first into prog%code so that fn_entry
-		! offsets are known before any call-site OP_CALL is emitted.  The VM
-		! starts at prog%entry_main which is set after all fn bodies.
+		! All fn bodies (local + transitively-imported modules) are compiled
+		! before entry_main so that call-site OP_CALL can reference fn_entry.
+		! The VM starts at prog%entry_main.
 
-		! Pass 0: determine max fn id to size the entry/num_locs tables.
+		! Pass 0: grow fn_entry / fn_num_locs for locally-declared fns.
 		do i = 1, size(node%members)
 			if (node%members(i)%kind /= fn_declaration) cycle
-			const_idx = node%members(i)%id_index   ! reusing const_idx as scratch
-			if (.not. allocated(prog%fn_entry)) then
-				allocate(prog%fn_entry(const_idx))
-				allocate(prog%fn_num_locs(const_idx))
-				prog%fn_entry    = 0
-				prog%fn_num_locs = 0
-			else if (const_idx > size(prog%fn_entry)) then
-				! Grow tables (rare: fns are declared in order by the parser).
-				block
-					integer, allocatable :: tmp_entry(:), tmp_locs(:)
-					call move_alloc(prog%fn_entry,    tmp_entry)
-					call move_alloc(prog%fn_num_locs, tmp_locs)
-					allocate(prog%fn_entry(const_idx))
-					allocate(prog%fn_num_locs(const_idx))
-					prog%fn_entry    = 0
-					prog%fn_num_locs = 0
-					prog%fn_entry(1: size(tmp_entry))    = tmp_entry
-					prog%fn_num_locs(1: size(tmp_locs))  = tmp_locs
-				end block
-			end if
+			call ensure_fn_entry(prog, node%members(i)%id_index)
 		end do
 
-		! Pass 1: compile each fn declaration body.
+		! M7 pre-pass: compile fn bodies from all transitively-imported modules.
+		! Must run before Pass 1 (local fns) so that cross-module calls resolve.
+		do i = 1, size(node%members)
+			if (node%members(i)%kind /= use_statement) cycle
+			if (.not. allocated(node%members(i)%member)) cycle
+			call compile_module_fns(prog, node%members(i)%member)
+		end do
+
+		! Pass 1: compile each locally-declared fn body.
 		do i = 1, size(node%members)
 			if (node%members(i)%kind /= fn_declaration) cycle
 			l_top = node%members(i)%id_index   ! fn_id (reuse l_top as scratch)
@@ -473,6 +536,24 @@ recursive subroutine compile_node(prog, node)
 	! case before the top-level statements.
 	case (fn_declaration)
 		! Nothing to emit: fn bodies are pre-compiled by the translation_unit handler.
+
+	! ---- use_statement (M7) ---------------------------------------------------
+	! Module fn bodies were already compiled into prog%fn_entry by the
+	! translate_unit pre-pass (compile_module_fns).  Here we only emit the
+	! module's top-level initialisation code (e.g. `let count = 0;`).
+	! Each init statement leaves one value on the stack; we discard all of them
+	! with OP_POP, then push unknown_type as the use_statement's own result.
+	case (use_statement)
+		if (allocated(node%member)) then
+			do i = 1, size(node%member%members)
+				if (node%member%members(i)%kind == fn_declaration    ) cycle
+				if (node%member%members(i)%kind == struct_declaration) cycle
+				call compile_node(prog, node%member%members(i))
+				call emit(prog, OP_POP)
+			end do
+		end if
+		const_idx = add_const(prog, unknown_val())
+		call emit(prog, OP_LOAD_CONST, a = const_idx)
 
 	! ---- user-defined function call -------------------------------------------
 	! Only emit OP_CALL for functions compiled into this program_t (i.e. locally

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -117,9 +117,13 @@ recursive subroutine compile_node(prog, node)
 	! ---- variable reads --------------------------------------------------------
 	case (name_expr)
 		if (allocated(node%lsubscripts)) then
-			! Subscripted access — fall back to the AST walker for now
+			! Subscripted access: all-scalar → OP_INDEX, any range/step/all → OP_SLICE
 			idx = add_node(prog, node)
-			call emit(prog, OP_EVAL_NODE, a = idx)
+			if (all(node%lsubscripts%sub_kind == scalar_sub)) then
+				call emit(prog, OP_INDEX, a = idx)
+			else
+				call emit(prog, OP_SLICE, a = idx)
+			end if
 		else
 			if (node%is_loc) then
 				call emit(prog, OP_LOAD_LOCAL, a = node%id_index)
@@ -147,12 +151,13 @@ recursive subroutine compile_node(prog, node)
 			call emit(prog, OP_STORE_GLOBAL, a = node%id_index)
 		end if
 
-	! ---- simple scalar assignment (no subscripts, no dot members, plain =) ----
+	! ---- assignment (no dot members): scalar, compound, or subscript ----------
 	case (assignment_expr)
-		if (.not. allocated(node%member)      .and. &
+		if (.not. allocated(node%member) .and. &
 		    .not. allocated(node%lsubscripts) .and. &
 		    node%op%kind == equals_token) then
 
+			! Simple plain assignment: a = expr
 			call compile_node(prog, node%right)
 			if (node%is_loc) then
 				call emit(prog, OP_STORE_LOCAL,  a = node%id_index)
@@ -161,9 +166,25 @@ recursive subroutine compile_node(prog, node)
 			end if
 
 		else
-			! Compound assignment or subscript / dot LHS — fall back
-			idx = add_node(prog, node)
-			call emit(prog, OP_EVAL_NODE, a = idx)
+			! Fortran .and. is NOT short-circuit; use nested ifs to guard the
+			! all(lsubscripts%sub_kind) access from unallocated lsubscripts.
+			first = .false.   ! reuse `first` as "use native subscript store"
+			if (.not. allocated(node%member)) then
+				if (allocated(node%lsubscripts)) then
+					if (all(node%lsubscripts%sub_kind == scalar_sub)) first = .true.
+				end if
+			end if
+
+			if (first) then
+				! Scalar subscript write (any op): a[i] = x  or  a[i] += x
+				call compile_node(prog, node%right)
+				idx = add_node(prog, node)
+				call emit(prog, OP_STORE_IDX, a = idx, b = node%op%kind)
+			else
+				! Dot member, slice LHS, or compound without subscripts — fall back
+				idx = add_node(prog, node)
+				call emit(prog, OP_EVAL_NODE, a = idx)
+			end if
 		end if
 
 	! ---- block statement -------------------------------------------------------

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -48,6 +48,11 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	integer :: block_break_ips(MAX_BREAK_FIXUPS) = 0
 	integer :: nblock_break_fixups = 0
 
+	! Set to true while compiling a user function body; used to distinguish
+	! a function-level return_statement (emit OP_RET) from a top-level one
+	! (fall back to OP_EVAL_NODE).
+	logical :: in_fn_body = .false.
+
 !===============================================================================
 
 contains
@@ -356,10 +361,53 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- top-level translation unit -------------------------------------------
 	case (translation_unit)
-		! Fn and struct declarations are registered at parse time; skip them here.
-		! Each statement contributes to the result: the last one leaves its value
-		! on the stack; preceding ones are discarded with OP_POP.
-		! This matches eval_translation_unit which takes the last member's result.
+		! M3: compile all user fn bodies first into prog%code so that fn_entry
+		! offsets are known before any call-site OP_CALL is emitted.  The VM
+		! starts at prog%entry_main which is set after all fn bodies.
+
+		! Pass 0: determine max fn id to size the entry/num_locs tables.
+		do i = 1, size(node%members)
+			if (node%members(i)%kind /= fn_declaration) cycle
+			const_idx = node%members(i)%id_index   ! reusing const_idx as scratch
+			if (.not. allocated(prog%fn_entry)) then
+				allocate(prog%fn_entry(const_idx))
+				allocate(prog%fn_num_locs(const_idx))
+				prog%fn_entry    = 0
+				prog%fn_num_locs = 0
+			else if (const_idx > size(prog%fn_entry)) then
+				! Grow tables (rare: fns are declared in order by the parser).
+				block
+					integer, allocatable :: tmp_entry(:), tmp_locs(:)
+					call move_alloc(prog%fn_entry,    tmp_entry)
+					call move_alloc(prog%fn_num_locs, tmp_locs)
+					allocate(prog%fn_entry(const_idx))
+					allocate(prog%fn_num_locs(const_idx))
+					prog%fn_entry    = 0
+					prog%fn_num_locs = 0
+					prog%fn_entry(1: size(tmp_entry))    = tmp_entry
+					prog%fn_num_locs(1: size(tmp_locs))  = tmp_locs
+				end block
+			end if
+		end do
+
+		! Pass 1: compile each fn declaration body.
+		do i = 1, size(node%members)
+			if (node%members(i)%kind /= fn_declaration) cycle
+			l_top = node%members(i)%id_index   ! fn_id (reuse l_top as scratch)
+			prog%fn_num_locs(l_top) = node%members(i)%num_locs
+			prog%fn_entry(l_top)    = prog%len_ + 1
+
+			in_fn_body = .true.
+			call compile_node(prog, node%members(i)%body)
+			in_fn_body = .false.
+		end do
+
+		! Top-level statements start here.
+		prog%entry_main = prog%len_ + 1
+
+		! Pass 2: compile top-level (non-fn, non-struct) statements.
+		! Each contributes to the result: the last one leaves its value on the
+		! stack; preceding ones are discarded with OP_POP.
 		first = .true.
 		do i = 1, size(node%members)
 			if (node%members(i)%kind == fn_declaration    ) cycle
@@ -375,6 +423,69 @@ recursive subroutine compile_node(prog, node)
 		if (first) then
 			const_idx = add_const(prog, unknown_val())
 			call emit(prog, OP_LOAD_CONST, a = const_idx)
+		end if
+
+	! ---- fn_declaration: bodies are compiled separately in translation_unit -----
+	! Skip silently here; compilation of the body happens in the translation_unit
+	! case before the top-level statements.
+	case (fn_declaration)
+		! Nothing to emit: fn bodies are pre-compiled by the translation_unit handler.
+
+	! ---- user-defined function call -------------------------------------------
+	! Two-pass arg push to avoid by-ref aliasing (mirrors eval_fn_call):
+	!   Pass 1: compile all by-value args (push evaluated values).
+	!   Pass 2: emit OP_LOAD_REF_* for each by-ref arg (moves value from slot).
+	! Then emit OP_CALL with the fn id and a node-pool index carrying ref metadata.
+	case (fn_call_expr)
+		! Store the call node so OP_CALL/OP_RET can access params/is_ref.
+		idx = add_node(prog, node)
+
+		! Pass 1: push by-value args onto stack.
+		if (allocated(node%is_ref)) then
+			do i = 1, size(node%is_ref)
+				if (.not. node%is_ref(i)) call compile_node(prog, node%args(i))
+			end do
+
+			! Pass 2: move by-ref args from their variable slots onto stack.
+			do i = 1, size(node%is_ref)
+				if (node%is_ref(i)) then
+					if (node%args(i)%is_loc) then
+						call emit(prog, OP_LOAD_REF_LOCAL,  a = node%args(i)%id_index)
+					else
+						call emit(prog, OP_LOAD_REF_GLOBAL, a = node%args(i)%id_index)
+					end if
+				end if
+			end do
+		end if
+
+		call emit(prog, OP_CALL, a = node%id_index, b = idx)
+
+	! ---- intrinsic function call -----------------------------------------------
+	! Delegate the entire call to the AST walker via OP_EVAL_NODE.  The walker
+	! evaluates args using the current state (which has the callee's locs when
+	! inside a compiled frame).  Migration to native integer dispatch is M6.
+	case (fn_call_intr_expr)
+		idx = add_node(prog, node)
+		call emit(prog, OP_EVAL_NODE, a = idx)
+
+	! ---- return statement ------------------------------------------------------
+	! Inside a compiled function body: push return value (or unknown sentinel for
+	! void) then emit OP_RET.  At top level: fall back to OP_EVAL_NODE (which
+	! sets state%returned so the VM exits its main loop).
+	case (return_statement)
+		if (in_fn_body) then
+			if (node%right%val%type == void_type) then
+				! Void return: push unknown_type as a dummy return slot.
+				const_idx = add_const(prog, unknown_val())
+				call emit(prog, OP_LOAD_CONST, a = const_idx)
+			else
+				call compile_node(prog, node%right)
+			end if
+			call emit(prog, OP_RET)
+		else
+			! Top-level return: fall back to OP_EVAL_NODE which sets state%returned.
+			idx = add_node(prog, node)
+			call emit(prog, OP_EVAL_NODE, a = idx)
 		end if
 
 	! ---- fallback: delegate to the AST walker ---------------------------------
@@ -406,6 +517,7 @@ module subroutine compile_tree(tree, prog)
 	nbreak_fixups       = 0
 	in_block_break_ctx  = .false.
 	nblock_break_fixups = 0
+	in_fn_body          = .false.
 
 	prog = new_program()
 	call compile_node(prog, tree)

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -221,11 +221,25 @@ recursive subroutine compile_node(prog, node)
 	! ---- variable reads --------------------------------------------------------
 	case (name_expr)
 		if (allocated(node%lsubscripts)) then
-			! Subscripted access: all-scalar → OP_INDEX, any range/step/all → OP_SLICE
-			idx = add_node(prog, node)
-			if (all(node%lsubscripts%sub_kind == scalar_sub)) then
+			! Subscripted access.
+			! Fast path: all-scalar subscripts + numeric result → OP_INDEX_NAT.
+			!   Compile each subscript expression onto the operand stack so the VM
+			!   can compute the linear index inline without calling syntax_eval.
+			! Fallback A: all-scalar but non-numeric (str char, struct) → OP_INDEX.
+			! Fallback B: any range/step/all subscript → OP_SLICE.
+			if (index_native_ok(node)) then
+				do i = 1, size(node%lsubscripts)
+					call compile_node(prog, node%lsubscripts(i))
+				end do
+				call emit(prog, OP_INDEX_NAT, &
+					a = node%id_index, &
+					b = int(size(node%lsubscripts)), &
+					c = merge(1_8, 0_8, node%is_loc))
+			else if (all(node%lsubscripts%sub_kind == scalar_sub)) then
+				idx = add_node(prog, node)
 				call emit(prog, OP_INDEX, a = idx)
 			else
+				idx = add_node(prog, node)
 				call emit(prog, OP_SLICE, a = idx)
 			end if
 		else
@@ -319,6 +333,36 @@ recursive subroutine compile_node(prog, node)
 				call emit(prog, OP_STORE_GLOBAL, a = node%id_index)
 			end if
 
+		else if (.not. allocated(node%lsubscripts) .and. &
+		         .not. allocated(node%member) .and. &
+		         compound_to_arith_token(node%op%kind) /= 0) then
+			! Compound scalar assignment: a += expr, a -= expr, etc.
+			! Native: load a, compile RHS, emit typed binop, store a.
+			! Guard: a must be a numeric scalar with typed load/store/binop available.
+			! Requires same LHS and RHS type so the binop result type == LHS type.
+			block
+			integer :: arith_tok_, binop_op_
+			arith_tok_ = compound_to_arith_token(node%op%kind)
+			typed_op = typed_load_op(node%val%type, .false., node%is_loc)
+			binop_op_ = 0
+			if (typed_op /= 0 .and. allocated(node%right)) then
+				if (node%val%type == node%right%val%type) &
+					binop_op_ = binop_typed_opcode(arith_tok_, node%val%type, node%right%val%type)
+			end if
+			if (binop_op_ /= 0) then
+				! Load current value, compile RHS, apply op, store result.
+				call emit(prog, typed_op, a = node%id_index)
+				call compile_node(prog, node%right)
+				call emit(prog, binop_op_)
+				typed_op = typed_store_op(node%val%type, node%is_loc)
+				call emit(prog, typed_op, a = node%id_index)
+			else
+				! Fallback: AST-walker handles mixed types, bitwise ops, etc.
+				idx = add_node(prog, node)
+				call emit(prog, OP_STORE_SLICE, a = idx)
+			end if
+			end block
+
 		else
 			! Fortran .and. is NOT short-circuit; use nested ifs to guard the
 			! all(lsubscripts%sub_kind) access from unallocated lsubscripts.
@@ -328,10 +372,25 @@ recursive subroutine compile_node(prog, node)
 			end if
 
 			if (first) then
-				! Scalar subscript write (any op): a[i] = x  or  a[i] += x
-				call compile_node(prog, node%right)
-				idx = add_node(prog, node)
-				call emit(prog, OP_STORE_IDX, a = idx, b = node%op%kind)
+				! Scalar subscript write.
+				! Fast path: plain '=' with numeric RHS → OP_STORE_IDX_NAT.
+				!   Compile subscripts then RHS; VM writes element inline.
+				! Fallback: compound ops, str/struct elements → OP_STORE_IDX.
+				if (store_idx_native_ok(node)) then
+					do i = 1, size(node%lsubscripts)
+						call compile_node(prog, node%lsubscripts(i))
+					end do
+					call compile_node(prog, node%right)
+					call emit(prog, OP_STORE_IDX_NAT, &
+						a = node%id_index, &
+						b = int(size(node%lsubscripts)), &
+						c = merge(1_8, 0_8, node%is_loc))
+				else
+					! Fallback: compound ops, str chars, struct elements, casts
+					call compile_node(prog, node%right)
+					idx = add_node(prog, node)
+					call emit(prog, OP_STORE_IDX, a = idx, b = node%op%kind)
+				end if
 			else
 				! Slice LHS or subscript-less compound: delegate to eval_assignment_expr
 				idx = add_node(prog, node)

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -151,12 +151,16 @@ recursive subroutine compile_node(prog, node)
 			call emit(prog, OP_STORE_GLOBAL, a = node%id_index)
 		end if
 
-	! ---- assignment (no dot members): scalar, compound, or subscript ----------
+	! ---- assignment: dot member, scalar subscript, simple, or compound -------
 	case (assignment_expr)
-		if (.not. allocated(node%member) .and. &
-		    .not. allocated(node%lsubscripts) .and. &
-		    node%op%kind == equals_token) then
+		if (allocated(node%member)) then
+			! M5: dot member assignment: a.b = expr  or  a.b += expr
+			call compile_node(prog, node%right)
+			idx = add_node(prog, node)
+			call emit(prog, OP_STORE_MEMBER, a = idx, b = node%op%kind)
 
+		else if (.not. allocated(node%lsubscripts) .and. &
+		         node%op%kind == equals_token) then
 			! Simple plain assignment: a = expr
 			call compile_node(prog, node%right)
 			if (node%is_loc) then
@@ -169,10 +173,8 @@ recursive subroutine compile_node(prog, node)
 			! Fortran .and. is NOT short-circuit; use nested ifs to guard the
 			! all(lsubscripts%sub_kind) access from unallocated lsubscripts.
 			first = .false.   ! reuse `first` as "use native subscript store"
-			if (.not. allocated(node%member)) then
-				if (allocated(node%lsubscripts)) then
-					if (all(node%lsubscripts%sub_kind == scalar_sub)) first = .true.
-				end if
+			if (allocated(node%lsubscripts)) then
+				if (all(node%lsubscripts%sub_kind == scalar_sub)) first = .true.
 			end if
 
 			if (first) then
@@ -181,7 +183,7 @@ recursive subroutine compile_node(prog, node)
 				idx = add_node(prog, node)
 				call emit(prog, OP_STORE_IDX, a = idx, b = node%op%kind)
 			else
-				! Dot member, slice LHS, or compound without subscripts — fall back
+				! Slice LHS or compound assignment without subscripts — fall back
 				idx = add_node(prog, node)
 				call emit(prog, OP_EVAL_NODE, a = idx)
 			end if
@@ -445,6 +447,24 @@ recursive subroutine compile_node(prog, node)
 			const_idx = add_const(prog, unknown_val())
 			call emit(prog, OP_LOAD_CONST, a = const_idx)
 		end if
+
+	! ---- struct instance construction -----------------------------------------
+	! M5: Compile each member-initialiser expression in order, then emit
+	! OP_MAKE_STRUCT.  The node is stored in the pool so the VM can recover
+	! struct_name and nmembers; the member expressions themselves are bytecode.
+	case (struct_instance_expr)
+		do i = 1, size(node%members)
+			call compile_node(prog, node%members(i))
+		end do
+		idx = add_node(prog, node)
+		call emit(prog, OP_MAKE_STRUCT, a = idx)
+
+	! ---- dot-expression (struct member read) -----------------------------------
+	! M5: Store the dot_expr node in the pool so the VM can call get_val with
+	! full chain information (nested dots, subscripted members, etc.).
+	case (dot_expr)
+		idx = add_node(prog, node)
+		call emit(prog, OP_LOAD_MEMBER, a = idx)
 
 	! ---- fn_declaration: bodies are compiled separately in translation_unit -----
 	! Skip silently here; compilation of the body happens in the translation_unit

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -1,0 +1,40 @@
+
+!===============================================================================
+
+submodule (syntran__compile_m) syntran__compile_ctrl
+
+	! M0 compiler: compiles the entire translation_unit as a single OP_EVAL_NODE.
+	! Subsequent milestones (M1+) will replace OP_EVAL_NODE emissions with real
+	! opcode sequences as each node kind is lowered.
+
+	implicit none
+
+!===============================================================================
+
+contains
+
+!===============================================================================
+
+module subroutine compile_tree(tree, prog)
+
+	type(syntax_node_t), intent(in) :: tree
+	type(program_t), intent(out) :: prog
+
+	!*******
+
+	integer :: idx
+
+	prog = new_program()
+
+	! M0: store the whole tree in the node pool and emit one OP_EVAL_NODE.
+	! The VM will call syntax_eval on it directly.
+	idx = add_node(prog, tree)
+	call emit(prog, OP_EVAL_NODE, a = idx)
+
+end subroutine compile_tree
+
+!===============================================================================
+
+end submodule syntran__compile_ctrl
+
+!===============================================================================

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -739,6 +739,8 @@ module subroutine compile_tree(tree, prog)
 	type(syntax_node_t), intent(in) :: tree
 	type(program_t), intent(out) :: prog
 
+	!print *, 'starting compile_tree()'
+
 	! Reset all compiler state for each fresh compilation
 	loop_depth          = 0
 	nbreak_fixups       = 0

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -3,9 +3,12 @@
 
 submodule (syntran__compile_m) syntran__compile_ctrl
 
-	! M0 compiler: compiles the entire translation_unit as a single OP_EVAL_NODE.
-	! Subsequent milestones (M1+) will replace OP_EVAL_NODE emissions with real
-	! opcode sequences as each node kind is lowered.
+	! Bytecode compiler: AST -> bytecode lowering.
+	!
+	! M0: single OP_EVAL_NODE fallback for any unsupported node.
+	! M1: natively compiles literal_expr, simple name_expr, binary_expr,
+	!     unary_expr, let_expr, simple assignment_expr, and translation_unit.
+	!     Everything else still falls back to OP_EVAL_NODE.
 
 	implicit none
 
@@ -15,21 +18,128 @@ contains
 
 !===============================================================================
 
+recursive subroutine compile_node(prog, node)
+
+	! Lower one AST node to opcodes.  The contract is that this subroutine
+	! always leaves exactly one value on the operand stack after the emitted
+	! opcodes execute — even for the OP_EVAL_NODE fallback.
+
+	type(program_t), intent(inout) :: prog
+	type(syntax_node_t), intent(in) :: node
+
+	!*******
+
+	integer :: idx, i, const_idx
+	logical :: first
+
+	select case (node%kind)
+
+	! ---- literals --------------------------------------------------------------
+	case (literal_expr)
+		const_idx = add_const(prog, node%val)
+		call emit(prog, OP_LOAD_CONST, a = const_idx)
+
+	! ---- variable reads --------------------------------------------------------
+	case (name_expr)
+		if (allocated(node%lsubscripts)) then
+			! Subscripted access — fall back to the AST walker for now
+			idx = add_node(prog, node)
+			call emit(prog, OP_EVAL_NODE, a = idx)
+		else
+			if (node%is_loc) then
+				call emit(prog, OP_LOAD_LOCAL, a = node%id_index)
+			else
+				call emit(prog, OP_LOAD_GLOBAL, a = node%id_index)
+			end if
+		end if
+
+	! ---- arithmetic / comparison / logic / bitwise ----------------------------
+	case (binary_expr)
+		call compile_node(prog, node%left )
+		call compile_node(prog, node%right)
+		call emit(prog, OP_BINOP, a = node%op%kind)
+
+	case (unary_expr)
+		call compile_node(prog, node%right)
+		call emit(prog, OP_UNOP, a = node%op%kind)
+
+	! ---- variable declarations ------------------------------------------------
+	case (let_expr)
+		call compile_node(prog, node%right)
+		if (node%is_loc) then
+			call emit(prog, OP_STORE_LOCAL,  a = node%id_index)
+		else
+			call emit(prog, OP_STORE_GLOBAL, a = node%id_index)
+		end if
+
+	! ---- simple scalar assignment (no subscripts, no dot members, plain =) ----
+	case (assignment_expr)
+		if (.not. allocated(node%member)      .and. &
+		    .not. allocated(node%lsubscripts) .and. &
+		    node%op%kind == equals_token) then
+
+			call compile_node(prog, node%right)
+			if (node%is_loc) then
+				call emit(prog, OP_STORE_LOCAL,  a = node%id_index)
+			else
+				call emit(prog, OP_STORE_GLOBAL, a = node%id_index)
+			end if
+
+		else
+			! Compound assignment or subscript / dot LHS — fall back
+			idx = add_node(prog, node)
+			call emit(prog, OP_EVAL_NODE, a = idx)
+		end if
+
+	! ---- top-level translation unit -------------------------------------------
+	case (translation_unit)
+		! Fn and struct declarations are registered at parse time; skip them here.
+		! Each statement contributes to the result: the last one leaves its value
+		! on the stack; preceding ones are discarded with OP_POP.
+		! This matches eval_translation_unit which takes the last member's result.
+		first = .true.
+		do i = 1, size(node%members)
+			if (node%members(i)%kind == fn_declaration    ) cycle
+			if (node%members(i)%kind == struct_declaration) cycle
+			if (.not. first) call emit(prog, OP_POP)
+			first = .false.
+			call compile_node(prog, node%members(i))
+		end do
+
+		! If all members were fn/struct declarations, nothing was emitted and
+		! the stack is empty.  Emit a LOAD_CONST of an unknown_type sentinel so
+		! vm_run always has one value to return (the REPL cycles on unknown_type).
+		if (first) then
+			const_idx = add_const(prog, unknown_val())
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
+		end if
+
+	! ---- fallback: delegate to the AST walker ---------------------------------
+	case default
+		idx = add_node(prog, node)
+		call emit(prog, OP_EVAL_NODE, a = idx)
+
+	end select
+
+end subroutine compile_node
+
+!===============================================================================
+
+function unknown_val() result(v)
+	! Return a value_t with type = unknown_type (used as an empty-result sentinel).
+	type(value_t) :: v
+	v%type = unknown_type
+end function unknown_val
+
+!===============================================================================
+
 module subroutine compile_tree(tree, prog)
 
 	type(syntax_node_t), intent(in) :: tree
 	type(program_t), intent(out) :: prog
 
-	!*******
-
-	integer :: idx
-
 	prog = new_program()
-
-	! M0: store the whole tree in the node pool and emit one OP_EVAL_NODE.
-	! The VM will call syntax_eval on it directly.
-	idx = add_node(prog, tree)
-	call emit(prog, OP_EVAL_NODE, a = idx)
+	call compile_node(prog, tree)
 
 end subroutine compile_tree
 

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -27,15 +27,18 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	! and decremented on exit.  continue_target(d) is the instruction index to
 	! jump to for a `continue` inside loop depth d.  break fixups inside loops
 	! are collected and backpatched after the loop body is fully compiled.
+	!
+	! All arrays are growable (no hard limit) for parity with the AST walker.
+	! INIT_* constants are starting capacities only; arrays double on demand.
 
-	integer, parameter :: MAX_LOOP_DEPTH   = 64
-	integer, parameter :: MAX_BREAK_FIXUPS = 4096
+	integer, parameter :: INIT_LOOP_DEPTH   = 64
+	integer, parameter :: INIT_BREAK_FIXUPS = 256
 
 	integer :: loop_depth = 0
-	integer :: continue_target(MAX_LOOP_DEPTH) = 0
+	integer, allocatable :: continue_target(:)
 
-	integer :: break_fixup_ips(MAX_BREAK_FIXUPS)    = 0
-	integer :: break_fixup_depths(MAX_BREAK_FIXUPS)  = 0
+	integer, allocatable :: break_fixup_ips(:)
+	integer, allocatable :: break_fixup_depths(:)
 	integer :: nbreak_fixups = 0
 
 	! --- Block-level break context ---
@@ -51,7 +54,7 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 	! outermost block share the same target, so one JUMP exits all of them.
 
 	logical :: in_block_break_ctx = .false.
-	integer :: block_break_ips(MAX_BREAK_FIXUPS) = 0
+	integer, allocatable :: block_break_ips(:)
 	integer :: nblock_break_fixups = 0
 
 	! Set to true while compiling a user function body; used to distinguish
@@ -62,6 +65,24 @@ submodule (syntran__compile_m) syntran__compile_ctrl
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+subroutine grow_int(arr)
+
+	! Double the capacity of an allocatable integer array, preserving contents.
+	! Used to grow continue_target, break_fixup_*, and block_break_ips on demand.
+
+	integer, allocatable, intent(inout) :: arr(:)
+	integer, allocatable :: tmp(:)
+	integer :: n
+
+	n = size(arr)
+	allocate(tmp(2 * n))
+	tmp(1:n) = arr
+	call move_alloc(tmp, arr)
+
+end subroutine grow_int
 
 !===============================================================================
 
@@ -534,6 +555,7 @@ recursive subroutine compile_node(prog, node)
 	! break  -> JUMP L_end  (backpatched after loop)
 	! continue -> JUMP L_top (target known when continue is emitted)
 	case (while_statement)
+		if (loop_depth + 1 > size(continue_target)) call grow_int(continue_target)
 		loop_depth = loop_depth + 1
 		l_top = prog%len_ + 1
 		continue_target(loop_depth) = l_top
@@ -564,6 +586,10 @@ recursive subroutine compile_node(prog, node)
 	case (break_statement)
 		if (loop_depth > 0) then
 			! Inside a native while/for: jump to the loop's end (backpatched)
+			if (nbreak_fixups + 1 > size(break_fixup_ips)) then
+				call grow_int(break_fixup_ips)
+				call grow_int(break_fixup_depths)
+			end if
 			nbreak_fixups = nbreak_fixups + 1
 			break_fixup_ips(nbreak_fixups)    = prog%len_ + 1
 			break_fixup_depths(nbreak_fixups) = loop_depth
@@ -572,6 +598,8 @@ recursive subroutine compile_node(prog, node)
 		else if (in_block_break_ctx) then
 			! Inside the outermost native block (no enclosing loop): jump to
 			! the block's end pad (backpatched when the block finishes)
+			if (nblock_break_fixups + 1 > size(block_break_ips)) &
+				call grow_int(block_break_ips)
 			nblock_break_fixups = nblock_break_fixups + 1
 			block_break_ips(nblock_break_fixups) = prog%len_ + 1
 			call emit(prog, OP_JUMP, a = 0)
@@ -666,6 +694,7 @@ recursive subroutine compile_node(prog, node)
 		idx = add_node(prog, node)
 		call emit(prog, OP_FOR_SETUP, a = idx)
 
+		if (loop_depth + 1 > size(continue_target)) call grow_int(continue_target)
 		loop_depth = loop_depth + 1
 		l_top = prog%len_ + 1
 		continue_target(loop_depth) = l_top
@@ -740,10 +769,10 @@ recursive subroutine compile_node(prog, node)
 		call emit(prog, OP_LOAD_CONST, a = const_idx)
 
 	! ---- user-defined function call -------------------------------------------
-	! Only emit OP_CALL for functions compiled into this program_t (i.e. locally
-	! declared functions whose fn_entry is known).  Module-imported functions and
-	! any call whose fn_id lies outside the compiled range fall back to OP_EVAL_NODE
-	! so the AST walker handles them via eval_fn_call.
+	! All user-defined functions (local and module-imported) are compiled into
+	! this program_t by the translation_unit pre-pass / compile_module_fns (M7).
+	! fn_entry[id] must be registered before execution; a missing registration is
+	! a compiler bug, not a fallback.
 	case (fn_call_expr)
 		! Check registration only: fn_entry[id] may be 0 for a forward reference
 		! (the fn is declared after this call site in the source).  That is fine —
@@ -861,12 +890,21 @@ module subroutine compile_tree(tree, prog)
 
 	!print *, 'starting compile_tree()'
 
-	! Reset all compiler state for each fresh compilation
+	! Reset all compiler state for each fresh compilation.
+	! Growable arrays are allocated here (or reallocated to initial cap if already
+	! allocated from a previous compile_tree call on the same module instance).
 	loop_depth          = 0
 	nbreak_fixups       = 0
 	in_block_break_ctx  = .false.
 	nblock_break_fixups = 0
 	in_fn_body          = .false.
+
+	if (.not. allocated(continue_target)) allocate(continue_target(INIT_LOOP_DEPTH))
+	if (.not. allocated(break_fixup_ips)) then
+		allocate(break_fixup_ips(INIT_BREAK_FIXUPS))
+		allocate(break_fixup_depths(INIT_BREAK_FIXUPS))
+	end if
+	if (.not. allocated(block_break_ips)) allocate(block_break_ips(INIT_BREAK_FIXUPS))
 
 	prog = new_program()
 	call compile_node(prog, tree)

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -128,14 +128,14 @@ end subroutine compile_module_fns
 
 !===============================================================================
 
-subroutine backpatch_breaks(prog, cs, depth, target)
+subroutine backpatch_breaks(prog, cs, depth, tgt)
 
-	! Patch all pending loop-break fixups at the given loop depth to target,
+	! Patch all pending loop-break fixups at the given loop depth to tgt,
 	! then remove them from the fixup list.
 
 	type(program_t),        intent(inout) :: prog
 	type(compiler_state_t), intent(inout) :: cs
-	integer,                intent(in)    :: depth, target
+	integer,                intent(in)    :: depth, tgt
 
 	!*******
 
@@ -144,7 +144,7 @@ subroutine backpatch_breaks(prog, cs, depth, target)
 	j = 0
 	do i = 1, cs%nbreak_fixups
 		if (cs%break_fixup_depths(i) == depth) then
-			call patch_jump(prog, cs%break_fixup_ips(i), target)
+			call patch_jump(prog, cs%break_fixup_ips(i), tgt)
 		else
 			j = j + 1
 			cs%break_fixup_ips(j)    = cs%break_fixup_ips(i)

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -191,7 +191,7 @@ recursive subroutine compile_node(prog, node)
 
 	!*******
 
-	integer :: idx, i, const_idx
+	integer :: idx, i, const_idx, typed_op
 	integer :: jf_ip, j_ip, l_top, l_else, l_end, l_pad
 	integer :: nblock_saved
 	logical :: first, entering_ctx
@@ -200,8 +200,23 @@ recursive subroutine compile_node(prog, node)
 
 	! ---- literals --------------------------------------------------------------
 	case (literal_expr)
-		const_idx = add_const(prog, node%val)
-		call emit(prog, OP_LOAD_CONST, a = const_idx)
+		! Scalar types: embed value directly in the instruction (no const pool).
+		! Non-scalar (strings, arrays): still use const pool.
+		select case (node%val%type)
+		case (bool_type)
+			call emit(prog, OP_LOAD_CONST_BOOL, a = merge(1, 0, node%val%sca%bool))
+		case (i32_type)
+			call emit(prog, OP_LOAD_CONST_I32, a = node%val%sca%i32)
+		case (i64_type)
+			call emit(prog, OP_LOAD_CONST_I64, c = node%val%sca%i64)
+		case (f32_type)
+			call emit(prog, OP_LOAD_CONST_F32, a = transfer(node%val%sca%f32, 0))
+		case (f64_type)
+			call emit(prog, OP_LOAD_CONST_F64, c = transfer(node%val%sca%f64, 0_8))
+		case default
+			const_idx = add_const(prog, node%val)
+			call emit(prog, OP_LOAD_CONST, a = const_idx)
+		end select
 
 	! ---- variable reads --------------------------------------------------------
 	case (name_expr)
@@ -214,7 +229,11 @@ recursive subroutine compile_node(prog, node)
 				call emit(prog, OP_SLICE, a = idx)
 			end if
 		else
-			if (node%is_loc) then
+			! Scalar type: emit typed load (avoids value_copy overhead).
+			typed_op = typed_load_op(node%val%type, .false., node%is_loc)
+			if (typed_op /= 0) then
+				call emit(prog, typed_op, a = node%id_index)
+			else if (node%is_loc) then
 				call emit(prog, OP_LOAD_LOCAL, a = node%id_index)
 			else
 				call emit(prog, OP_LOAD_GLOBAL, a = node%id_index)
@@ -225,16 +244,34 @@ recursive subroutine compile_node(prog, node)
 	case (binary_expr)
 		call compile_node(prog, node%left )
 		call compile_node(prog, node%right)
-		call emit(prog, OP_BINOP, a = node%op%kind)
+		! Same-type scalar: emit typed opcode (no value_move / get_binary_op_kind).
+		! Otherwise emit generic OP_BINOP with pre-computed result type in instr%b
+		! so the VM can skip get_binary_op_kind at runtime.
+		typed_op = binop_typed_opcode(node%op%kind, &
+			node%left%val%type, node%right%val%type)
+		if (typed_op /= 0) then
+			call emit(prog, typed_op)
+		else
+			call emit(prog, OP_BINOP, a = node%op%kind, b = node%val%type)
+		end if
 
 	case (unary_expr)
 		call compile_node(prog, node%right)
-		call emit(prog, OP_UNOP, a = node%op%kind)
+		typed_op = unop_typed_opcode(node%op%kind, node%right%val%type)
+		if (typed_op /= 0) then
+			call emit(prog, typed_op)
+		else
+			call emit(prog, OP_UNOP, a = node%op%kind)
+		end if
 
 	! ---- variable declarations ------------------------------------------------
 	case (let_expr)
 		call compile_node(prog, node%right)
-		if (node%is_loc) then
+		! Scalar type: emit typed store (avoids assign_ overhead).
+		typed_op = typed_store_op(node%val%type, node%is_loc)
+		if (typed_op /= 0) then
+			call emit(prog, typed_op, a = node%id_index)
+		else if (node%is_loc) then
 			call emit(prog, OP_STORE_LOCAL,  a = node%id_index)
 		else
 			call emit(prog, OP_STORE_GLOBAL, a = node%id_index)
@@ -252,7 +289,13 @@ recursive subroutine compile_node(prog, node)
 		         node%op%kind == equals_token) then
 			! Simple plain assignment: a = expr
 			call compile_node(prog, node%right)
-			if (node%is_loc) then
+			! Scalar type (LHS and RHS agree — parser guarantees): typed store.
+			typed_op = 0
+			if (node%val%type == node%right%val%type) &
+				typed_op = typed_store_op(node%val%type, node%is_loc)
+			if (typed_op /= 0) then
+				call emit(prog, typed_op, a = node%id_index)
+			else if (node%is_loc) then
 				call emit(prog, OP_STORE_LOCAL,  a = node%id_index)
 			else
 				call emit(prog, OP_STORE_GLOBAL, a = node%id_index)

--- a/src/core.f90
+++ b/src/core.f90
@@ -678,7 +678,7 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	!*******************************
 	! Parse the tokens
-	tree = parser%parse_unit()
+	call parser%parse_unit(tree)
 
 	!print *, ""
 	!print *, "in core.f90:"

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -44,9 +44,9 @@ module syntran__eval_m
 		! This is the directory containing the main script being evaluated
 		character(len = :), allocatable :: src_dir
 
-		! Use the bytecode VM backend instead of the AST walker.
-		! Set via SYNTRAN_BACKEND=bytecode env var or the --bytecode CLI flag.
-		logical :: bytecode = .false.
+		! Use the bytecode VM backend instead of the AST walker. True by
+		! default, or set SYNTRAN_BACKEND=ast env var for AST walking
+		logical :: bytecode
 
 	end type state_t
 

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -44,6 +44,10 @@ module syntran__eval_m
 		! This is the directory containing the main script being evaluated
 		character(len = :), allocatable :: src_dir
 
+		! Use the bytecode VM backend instead of the AST walker.
+		! Set via SYNTRAN_BACKEND=bytecode env var or the --bytecode CLI flag.
+		logical :: bytecode = .false.
+
 	end type state_t
 
 	!********

--- a/src/eval_array.f90
+++ b/src/eval_array.f90
@@ -109,7 +109,7 @@ recursive module subroutine set_val(node, var, state, val, index_)
 	end if
 
 	if (var%struct(id)%type == str_type) then
-		var%struct(id)%sca%str%s(i8+1: i8+1) = val%sca%str%s
+		var%struct(id)%str%s(i8+1: i8+1) = val%str%s
 		return
 	end if
 
@@ -258,7 +258,8 @@ recursive module subroutine get_val(node, var, state, res, index_)
 	end if
 
 	if (var%struct(id)%type == str_type) then
-		res%sca%str%s = var%struct(id)%sca%str%s(i8+1: i8+1)
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = var%struct(id)%str%s(i8+1: i8+1)
 		res%type = str_type
 		return
 	end if
@@ -874,8 +875,9 @@ module subroutine array_at(val, kind_, i, lbound_, step, ubound_, len_, array, &
 
 	case (str_type)
 		!val%type = str_type
-		val%sca%str%s = str_%sca%str%s(i:i)
-		!print *, "val s = ", val%sca%str%s
+		if (.not. allocated(val%str)) allocate(val%str)
+		val%str%s = str_%str%s(i:i)
+		!print *, "val s = ", val%str%s
 
 	case default
 		write(*,*) err_int_prefix//'for loop not implemented for this array kind'//color_reset
@@ -915,7 +917,7 @@ module subroutine get_array_val(array, i, val)
 			val%sca%f64 = array%f64(i + 1)
 
 		case (str_type)
-			val%sca%str = array%str(i + 1)
+			val%str = array%str(i + 1)
 
 		case default
 			write(*,*) err_int_prefix//"bad type in get_array_val"//color_reset
@@ -957,7 +959,7 @@ module subroutine set_array_val(array, i, val)
 			array%f64(i + 1) = val%to_f64()
 
 		case (str_type)
-			array%str(i + 1) = val%sca%str
+			array%str(i + 1) = val%str
 
 	end select
 

--- a/src/eval_control.f90
+++ b/src/eval_control.f90
@@ -180,10 +180,10 @@ recursive module subroutine eval_for_statement(node, state, res)
 			for_kind = str_type
 			call syntax_eval(node%array, state, tmp)
 			call value_move(tmp, str_)
-			len8 = len(str_%sca%str%s, 8)
+			len8 = len(str_%str%s, 8)
 			itr%type = str_type
 
-			!print *, "str_ = ", str_%sca%str%s
+			!print *, "str_ = ", str_%str%s
 
 		else
 
@@ -375,9 +375,9 @@ recursive module subroutine eval_assignment_expr(node, state, res)
 			! TODO: ban compound character substring assignment
 			i8 = subscript_eval(node, state)
 			if (node%is_loc) then
-				state%locs%vals(id)%sca%str%s(i8+1: i8+1) = res%sca%str%s
+				state%locs%vals(id)%str%s(i8+1: i8+1) = res%str%s
 			else
-				state%vars%vals(id)%sca%str%s(i8+1: i8+1) = res%sca%str%s
+				state%vars%vals(id)%str%s(i8+1: i8+1) = res%str%s
 			end if
 
 		else if (all(node%lsubscripts%sub_kind == scalar_sub)) then
@@ -895,7 +895,7 @@ recursive module subroutine eval_array_expr(node, state, res)
 			res%array%bool = lbound_%sca%bool
 
 		case (str_type)
-			res%array%str = lbound_%sca%str
+			res%array%str = lbound_%str
 
 		case (struct_type)
 

--- a/src/eval_expr.f90
+++ b/src/eval_expr.f90
@@ -168,10 +168,11 @@ recursive module subroutine eval_name_expr(node, state, res)
 			i8 = subscript_eval(node, state)
 			!print *, 'i8 = ', i8
 
+			if (.not. allocated(res%str)) allocate(res%str)
 			if (node%is_loc) then
-				res%sca%str%s = state%locs%vals(id)%sca%str%s(i8+1: i8+1)
+				res%str%s = state%locs%vals(id)%str%s(i8+1: i8+1)
 			else
-				res%sca%str%s = state%vars%vals(id)%sca%str%s(i8+1: i8+1)
+				res%str%s = state%vars%vals(id)%str%s(i8+1: i8+1)
 			end if
 
 		case (range_sub)
@@ -188,13 +189,14 @@ recursive module subroutine eval_name_expr(node, state, res)
 			!print *, 'identifier ', node%identifier%text
 			!print *, 'il = ', il
 			!print *, 'iu = ', iu
-			!print *, 'str = ', state%vars%vals(id)%sca%str%s  ! debug broken for is_loc
+			!print *, 'str = ', state%vars%vals(id)%str%s  ! debug broken for is_loc
 
 			! Not inclusive of upper bound
+			if (.not. allocated(res%str)) allocate(res%str)
 			if (node%is_loc) then
-				res%sca%str%s = state%locs%vals(id)%sca%str%s(il: iu-1)
+				res%str%s = state%locs%vals(id)%str%s(il: iu-1)
 			else
-				res%sca%str%s = state%vars%vals(id)%sca%str%s(il: iu-1)
+				res%str%s = state%vars%vals(id)%str%s(il: iu-1)
 			end if
 
 		case default

--- a/src/eval_fn.f90
+++ b/src/eval_fn.f90
@@ -755,36 +755,38 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 			call syntax_eval(node%args(i), state, arg)
 			call str_%push(arg%to_str())
 		end do
-		res%sca%str%s = str_%trim()
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = str_%trim()
 
 	case ("len")
 
 		call syntax_eval(node%args(1), state, arg)
-		res%sca%i64 = len(arg%sca%str%s, 8)
+		res%sca%i64 = len(arg%str%s, 8)
 
 	case ("repeat")
 
 		call syntax_eval(node%args(1), state, arg1)
 		call syntax_eval(node%args(2), state, arg2)
-		res%sca%str%s = repeat(arg1%sca%str%s, arg2%sca%i32)
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = repeat(arg1%str%s, arg2%sca%i32)
 
 	case ("parse_i32")
 
 		call syntax_eval(node%args(1), state, arg)
-		read(arg%sca%str%s, *, iostat = io) res%sca%i32
+		read(arg%str%s, *, iostat = io) res%sca%i32
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_i32() for argument `"// &
-				arg%sca%str%s//"`"//color_reset
+				arg%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
 	case ("parse_i64")
 
 		call syntax_eval(node%args(1), state, arg)
-		read(arg%sca%str%s, *, iostat = io) res%sca%i64
+		read(arg%str%s, *, iostat = io) res%sca%i64
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_i64() for argument `"// &
-				arg%sca%str%s//"`"//color_reset
+				arg%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
@@ -793,20 +795,20 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 		! TODO: trim "f" literal suffix if present
 
 		call syntax_eval(node%args(1), state, arg)
-		read(arg%sca%str%s, *, iostat = io) res%sca%f32
+		read(arg%str%s, *, iostat = io) res%sca%f32
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_f32() for argument `"// &
-				arg%sca%str%s//"`"//color_reset
+				arg%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
 	case ("parse_f64")
 
 		call syntax_eval(node%args(1), state, arg)
-		read(arg%sca%str%s, *, iostat = io) res%sca%f64
+		read(arg%str%s, *, iostat = io) res%sca%f64
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_f64() for argument `"// &
-				arg%sca%str%s//"`"//color_reset
+				arg%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
@@ -817,8 +819,9 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 		! other character set
 
 		call syntax_eval(node%args(1), state, arg)
-		!res%sca%str%s = char(arg%sca%i32)
-		res%sca%str%s = achar(arg%sca%i32)
+		if (.not. allocated(res%str)) allocate(res%str)
+		!res%str%s = char(arg%sca%i32)
+		res%str%s = achar(arg%sca%i32)
 
 	case ("0i32_sca")
 
@@ -845,17 +848,18 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 		call syntax_eval(node%args(1), state, arg1)
 		call syntax_eval(node%args(2), state, arg2)
 
-		mode = arg2%sca%str%s
+		if (.not. allocated(res%file_)) allocate(res%file_)
+		mode = arg2%str%s
 		!print *, "mode = ", mode
 
 		do i = 1, len(mode)
 			char_ = mode(i: i)
 			select case (char_)
 			case ("r")
-				res%sca%file_%mode_read = .true.
+				res%file_%mode_read = .true.
 
 			case ("w")
-				res%sca%file_%mode_write = .true.
+				res%file_%mode_write = .true.
 
 			case default
 				write(*,*) err_rt_prefix//"bad file mode character """// &
@@ -865,16 +869,16 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 			end select
 		end do
 
-		if (res%sca%file_%mode_read .and. res%sca%file_%mode_write) then
+		if (res%file_%mode_read .and. res%file_%mode_write) then
 			! Maybe "rw" mode could be allowed in the future, but i'm not sure
 			! what a useful application would be.  Perhaps if I exposed a
 			! rewind() or seek() fn
-			write(*,*) err_rt_prefix//"cannot open file """//arg1%sca%str%s &
+			write(*,*) err_rt_prefix//"cannot open file """//arg1%str%s &
 				//""" in combined read/write mode """//mode//""""
 			call internal_error()
 		end if
 
-		if (res%sca%file_%mode_read) then
+		if (res%file_%mode_read) then
 			status_ = "old"
 		else
 			status_ = "unknown"
@@ -882,9 +886,9 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 
 		! Resolve relative paths using src_dir from state
 		! This is the key change for thread-safety
-		resolved_path = resolve_path(state%src_dir, arg1%sca%str%s)
+		resolved_path = resolve_path(state%src_dir, arg1%str%s)
 
-		open(newunit = res%sca%file_%unit_, file = resolved_path, &
+		open(newunit = res%file_%unit_, file = resolved_path, &
 			status = status_, iostat = io)
 		!print *, "io = ", io
 
@@ -897,28 +901,29 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 			call internal_error()
 		end if
 
-		!print *, 'opened unit ', res%sca%file_%unit_
-		res%sca%file_%name_ = arg1%sca%str%s  ! Keep original name for error messages
-		res%sca%file_%eof = .false.
-		res%sca%file_%is_open = .true.
+		!print *, 'opened unit ', res%file_%unit_
+		res%file_%name_ = arg1%str%s  ! Keep original name for error messages
+		res%file_%eof = .false.
+		res%file_%is_open = .true.
 
 	case ("readln")
 
 		call syntax_eval(node%args(1), state, arg1)
 
-		if (.not. arg1%sca%file_%is_open) then
+		if (.not. arg1%file_%is_open) then
 			write(*,*) err_rt_prefix//"readln() was called for file """ &
-				//arg1%sca%file_%name_//""" which is not open"
+				//arg1%file_%name_//""" which is not open"
 			call internal_error()
 		end if
-		if (.not. arg1%sca%file_%mode_read) then
+		if (.not. arg1%file_%mode_read) then
 			write(*,*) err_rt_prefix//"readln() was called for file """ &
-				//arg1%sca%file_%name_//""" which was not opened in read mode ""r"""
+				//arg1%file_%name_//""" which was not opened in read mode ""r"""
 			call internal_error()
 		end if
 
-		!print *, "reading from unit", arg1%sca%file_%unit_
-		res%sca%str%s = read_line(arg1%sca%file_%unit_, io)
+		!print *, "reading from unit", arg1%file_%unit_
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = read_line(arg1%file_%unit_, io)
 		!print *, 'done reading'
 
 		! This could be a very dangerous side effect!  The file argument of
@@ -932,16 +937,16 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 		!!state%vars%vals(node%id_index) = res
 
 		if (io == iostat_end) then
-			!arg1%sca%file_%eof = .true.
+			!arg1%file_%eof = .true.
 			!id = node%id_index
 
 			!print *, "node is_loc = ", node%is_loc
 			!print *, "arg  is_loc = ", node%args(1)%is_loc
 
 			if (node%args(1)%is_loc) then
-				state%locs%vals(node%args(1)%id_index)%sca%file_%eof = .true.
+				state%locs%vals(node%args(1)%id_index)%file_%eof = .true.
 			else
-				state%vars%vals(node%args(1)%id_index)%sca%file_%eof = .true.
+				state%vars%vals(node%args(1)%id_index)%file_%eof = .true.
 			end if
 
 		else if (io == iostat_eor) then
@@ -951,71 +956,71 @@ recursive module subroutine eval_fn_call_intr(node, state, res)
 			! This can get thrown if you attempt to read past EOF.  Maybe add a
 			! more specific message ahead of read attempt in this case?
 			write(*,*) err_rt_prefix//"cannot readln() from file """ &
-				//arg1%sca%file_%name_//""""
+				//arg1%file_%name_//""""
 			write(*,*) "iostat = ", str(io)
 			call internal_error()
 
 		end if
-		!print *, 'eof   = ', arg1%sca%file_%eof
+		!print *, 'eof   = ', arg1%file_%eof
 
 	case ("writeln")
 
 		call syntax_eval(node%args(1), state, arg1)
 
-		if (.not. arg1%sca%file_%is_open) then
+		if (.not. arg1%file_%is_open) then
 			write(*,*) err_rt_prefix//"writeln() was called for file """ &
-				//arg1%sca%file_%name_//""" which is not open"
+				//arg1%file_%name_//""" which is not open"
 			call internal_error()
 		end if
-		if (.not. arg1%sca%file_%mode_write) then
+		if (.not. arg1%file_%mode_write) then
 			write(*,*) err_rt_prefix//"writeln() was called for file """ &
-				//arg1%sca%file_%name_//""" which was not opened in write mode ""w"""
+				//arg1%file_%name_//""" which was not opened in write mode ""w"""
 			call internal_error()
 		end if
 
-		!print *, 'writing to unit ', arg1%sca%file_%unit_
+		!print *, 'writing to unit ', arg1%file_%unit_
 		do i = 2, size(node%args)
 			call syntax_eval(node%args(i), state, arg)
-			write(arg1%sca%file_%unit_, '(a)', advance = 'no') arg%to_str()
+			write(arg1%file_%unit_, '(a)', advance = 'no') arg%to_str()
 		end do
-		write(arg1%sca%file_%unit_, *)
+		write(arg1%file_%unit_, *)
 
 	case ("eof")
 
 		call syntax_eval(node%args(1), state, arg1)
 
-		if (.not. arg1%sca%file_%is_open) then
+		if (.not. arg1%file_%is_open) then
 			write(*,*) err_rt_prefix//"eof() was called for file """ &
-				//arg1%sca%file_%name_//""" which is not open"
+				//arg1%file_%name_//""" which is not open"
 			call internal_error()
 		end if
-		if (.not. arg1%sca%file_%mode_read) then
+		if (.not. arg1%file_%mode_read) then
 			write(*,*) err_rt_prefix//"eof() was called for file """ &
-				//arg1%sca%file_%name_//""" which was not opened in read mode ""r"""
+				//arg1%file_%name_//""" which was not opened in read mode ""r"""
 			call internal_error()
 		end if
 
-		!print *, "checking eof for unit", arg1%sca%file_%unit_
-		res%sca%bool = arg1%sca%file_%eof
+		!print *, "checking eof for unit", arg1%file_%unit_
+		res%sca%bool = arg1%file_%eof
 
-		!print *, 'eof fn = ', arg1%sca%file_%eof
+		!print *, 'eof fn = ', arg1%file_%eof
 
 	case ("close")
 		call syntax_eval(node%args(1), state, arg1)
 
-		if (.not. arg1%sca%file_%is_open) then
+		if (.not. arg1%file_%is_open) then
 			write(*,*) err_rt_prefix//"close() was called for file """ &
-				//arg1%sca%file_%name_//""" which is not open"
+				//arg1%file_%name_//""" which is not open"
 			call internal_error()
 		end if
 		if (node%args(1)%is_loc) then
-			state%locs%vals(node%args(1)%id_index)%sca%file_%is_open = .false.
+			state%locs%vals(node%args(1)%id_index)%file_%is_open = .false.
 		else
-			state%vars%vals(node%args(1)%id_index)%sca%file_%is_open = .false.
+			state%vars%vals(node%args(1)%id_index)%file_%is_open = .false.
 		end if
 
-		!print *, 'closing unit ', arg1%sca%file_%unit_
-		close(arg1%sca%file_%unit_)
+		!print *, 'closing unit ', arg1%file_%unit_
+		close(arg1%file_%unit_)
 
 	case ("exit")
 

--- a/src/gen_math.sh
+++ b/src/gen_math.sh
@@ -27,7 +27,8 @@ nrows=$(( ${#table[@]} / $ncols ))
 
 bin_str_case="
 	case        (magic**2 * str_type + magic * str_type + str_type)
-		res%sca%str%s = left%sca%str%s // right%sca%str%s
+		allocate(res%str)
+		res%str%s = left%str%s // right%str%s
 "
 
 for i in $(seq 0 $(( $nrows - 1 )) ) ; do

--- a/src/math.f90
+++ b/src/math.f90
@@ -78,7 +78,7 @@ subroutine assign_value_t(left, right, op_text)
 			left%sca%i64 = right%to_i64()
 
 		case (str_type)
-			left%sca%str = right%sca%str
+			left%str = right%str
 
 		case (struct_type)
 			left = right
@@ -104,7 +104,7 @@ subroutine assign_value_t(left, right, op_text)
 	case (i64_type)
 		left%array%i64 = right%sca%i64
 	case (str_type)
-		left%array%str = right%sca%str
+		left%array%str = right%str
 	case default
 		write(*,*) err_eval_binary_types(op_text)
 		call internal_error()

--- a/src/math_bin_add.f90
+++ b/src/math_bin_add.f90
@@ -375,7 +375,8 @@ subroutine add_value_t(left, right, res, op_text)
 
 
 	case        (magic**2 * str_type + magic * str_type + str_type)
-		res%sca%str%s = left%sca%str%s // right%sca%str%s
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = left%str%s // right%str%s
 
 
 	case default

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -164,10 +164,10 @@ module syntran__parse_m
 			type(syntax_node_t), intent(out) :: expr
 		end subroutine parse_array_expr
 
-		module function parse_size(parser) result(size)
+		module subroutine parse_size(parser, size)
 			class(parser_t) :: parser
-			type(syntax_node_vector_t) :: size
-		end function parse_size
+			type(syntax_node_vector_t), intent(out) :: size
+		end subroutine parse_size
 
 		recursive module subroutine parse_subscripts(parser, expr)
 			class(parser_t) :: parser
@@ -294,10 +294,10 @@ module syntran__parse_m
 			type(syntax_token_t) :: token
 		end function match_pre
 
-		module function parse_unit(parser) result(unit)
+		module subroutine parse_unit(parser, unit)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: unit
-		end function parse_unit
+			type(syntax_node_t), intent(out) :: unit
+		end subroutine parse_unit
 
 		recursive module function new_parser(str_, src_file, contexts, unit_) result(parser)
 			character(len = *), intent(in) :: str_, src_file

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -116,22 +116,22 @@ module syntran__parse_m
 	interface
 		! Implemented in parse_fn.f90
 
-		module function parse_fn_declaration(parser) result(decl)
+		module subroutine parse_fn_declaration(parser, decl)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: decl
-		end function parse_fn_declaration
+			type(syntax_node_t), intent(out) :: decl
+		end subroutine parse_fn_declaration
 
-		recursive module function parse_fn_call(parser, module_prefix, identifier) result(fn_call)
+		recursive module subroutine parse_fn_call(parser, module_prefix, identifier, fn_call)
 			class(parser_t) :: parser
 			character(len = *), intent(in), optional :: module_prefix
 			type(syntax_token_t), intent(in), optional :: identifier
-			type(syntax_node_t) :: fn_call
-		end function parse_fn_call
+			type(syntax_node_t), intent(out) :: fn_call
+		end subroutine parse_fn_call
 
-		recursive module function parse_qualified_expr(parser) result(expr)
+		recursive module subroutine parse_qualified_expr(parser, expr)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: expr
-		end function parse_qualified_expr
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_qualified_expr
 
 		module subroutine parse_type(parser, type_text, type)
 			class(parser_t) :: parser
@@ -141,16 +141,16 @@ module syntran__parse_m
 
 		! TODO: move struct stuff to another translation unit? parse_fn.f90 is a
 		! very manageable ~1100 lines rn, so not much benefit to splitting
-		module function parse_struct_declaration(parser) result(decl)
+		module subroutine parse_struct_declaration(parser, decl)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: decl
-		end function parse_struct_declaration
+			type(syntax_node_t), intent(out) :: decl
+		end subroutine parse_struct_declaration
 
-		recursive module function parse_struct_instance(parser, struct_name) result(instance)
+		recursive module subroutine parse_struct_instance(parser, inst, struct_name)
 			class(parser_t) :: parser
+			type(syntax_node_t), intent(out) :: inst
 			character(len = *), intent(in), optional :: struct_name
-			type(syntax_node_t) :: instance
-		end function parse_struct_instance
+		end subroutine parse_struct_instance
 
 	end interface
 
@@ -159,10 +159,10 @@ module syntran__parse_m
 	interface
 		! Implemented in parse_array.f90
 
-		recursive module function parse_array_expr(parser) result(expr)
+		recursive module subroutine parse_array_expr(parser, expr)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: expr
-		end function
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_array_expr
 
 		module function parse_size(parser) result(size)
 			class(parser_t) :: parser
@@ -181,50 +181,50 @@ module syntran__parse_m
 	interface
 		! Implemented in parse_control.f90
 
-		recursive module function parse_if_statement(parser) result(statement)
+		recursive module subroutine parse_if_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_if_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_if_statement
 
-		module function parse_return_statement(parser) result(statement)
+		module subroutine parse_return_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_return_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_return_statement
 
-		module function parse_break_statement(parser) result(statement)
+		module subroutine parse_break_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_break_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_break_statement
 
-		module function parse_continue_statement(parser) result(statement)
+		module subroutine parse_continue_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_continue_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_continue_statement
 
-		module function parse_use_statement(parser) result(statement)
+		module subroutine parse_use_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_use_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_use_statement
 
-		recursive module function parse_for_statement(parser) result(statement)
+		recursive module subroutine parse_for_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_for_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_for_statement
 
-		recursive module function parse_while_statement(parser) result(statement)
+		recursive module subroutine parse_while_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_while_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_while_statement
 
-		recursive module function parse_block_statement(parser) result(block)
+		recursive module subroutine parse_block_statement(parser, block)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: block
-		end function parse_block_statement
+			type(syntax_node_t), intent(out) :: block
+		end subroutine parse_block_statement
 
-		recursive module function parse_statement(parser) result(statement)
+		recursive module subroutine parse_statement(parser, statement)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: statement
-		end function parse_statement
+			type(syntax_node_t), intent(out) :: statement
+		end subroutine parse_statement
 
 	end interface
 
@@ -233,26 +233,26 @@ module syntran__parse_m
 	interface
 		! Implemented in parse_expr.f90
 
-		recursive module function parse_expr_statement(parser) result(expr)
+		recursive module subroutine parse_expr_statement(parser, expr)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: expr
-		end function parse_expr_statement
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_expr_statement
 
-		recursive module function parse_expr(parser, parent_prec) result(expr)
+		recursive module subroutine parse_expr(parser, parent_prec, expr)
 			class(parser_t) :: parser
 			integer, optional, intent(in) :: parent_prec
-			type(syntax_node_t) :: expr
-		end function parse_expr
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_expr
 
-		recursive module function parse_primary_expr(parser) result(expr)
+		recursive module subroutine parse_primary_expr(parser, expr)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: expr
-		end function parse_primary_expr
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_primary_expr
 
-		recursive module function parse_name_expr(parser) result(expr)
+		recursive module subroutine parse_name_expr(parser, expr)
 			class(parser_t) :: parser
-			type(syntax_node_t) :: expr
-		end function parse_name_expr
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_name_expr
 
 		recursive module subroutine parse_dot(parser, expr)
 			class(parser_t) :: parser

--- a/src/parse_array.f90
+++ b/src/parse_array.f90
@@ -15,7 +15,7 @@ contains
 
 !===============================================================================
 
-recursive module function parse_array_expr(parser) result(expr)
+recursive module subroutine parse_array_expr(parser, expr)
 
 	! These are the possible kinds of array literals:
 	!
@@ -27,12 +27,11 @@ recursive module function parse_array_expr(parser) result(expr)
 	!     size_array :  [0,1,2,3,4,5 ; 2,3]           explicit csv multi-rank array
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t), intent(out) :: expr
 
 	!********
 
-	integer :: span_beg, span_end, pos0, lb_beg, lb_end, ub_beg, ub_end, rank_
+	integer :: span_beg, span_end, pos0, lb_beg, lb_end, ub_beg, ub_end, rank_, i
 
 	type(syntax_node_t)  :: lbound_, step, ubound_, len_, elem
 	type(syntax_node_vector_t) :: elems, size_
@@ -78,7 +77,7 @@ recursive module function parse_array_expr(parser) result(expr)
 
 	span_beg = parser%peek_pos(0)
 	lb_beg   = span_beg
-	lbound_  = parser%parse_expr()
+	call parser%parse_expr(expr=lbound_)
 	span_end = parser%peek_pos(0) - 1
 	lb_end   = span_end
 
@@ -118,12 +117,8 @@ recursive module function parse_array_expr(parser) result(expr)
 		rbracket = parser%match(rbracket_token)
 
 		allocate(expr%val%array)
-		allocate(expr%lbound)
-
-		call syntax_nodes_copy(expr%size, size_%v( 1: size_%len_ ))
 
 		expr%kind           = array_expr
-
 		expr%val%type        = array_type
 		if (allocated(lbound_%val%struct_name)) then
 			expr%val%struct_name = lbound_%val%struct_name
@@ -139,15 +134,12 @@ recursive module function parse_array_expr(parser) result(expr)
 		expr%val%array%kind = unif_array
 		expr%val%array%rank = size_%len_
 
-		!print *, 'expr%val%type       = ', expr%val%type
-		!print *, 'expr%val%array%type = ', expr%val%array%type
-
-		! Does this syntax node need to own these members, or can we just save
-		! them in the array_t?  I think they do need to be duplicated, as they
-		! may be an expression and not just a literal.  So, sizes have to be
-		! allocated dynamically during evaluation, not during parsing
-
-		expr%lbound = lbound_
+		! Move children (avoids deep copies)
+		call syntax_node_move(lbound_, expr%lbound)
+		allocate(expr%size(size_%len_))
+		do i = 1, size_%len_
+			call syntax_node_move_into(size_%v(i), expr%size(i))
+		end do
 
 		return
 
@@ -160,7 +152,7 @@ recursive module function parse_array_expr(parser) result(expr)
 
 		span_beg = parser%peek_pos(0)
 		ub_beg   = span_beg
-		ubound_  = parser%parse_expr()
+		call parser%parse_expr(expr=ubound_)
 		span_end = parser%peek_pos(0) - 1
 		ub_end   = span_end
 
@@ -187,7 +179,7 @@ recursive module function parse_array_expr(parser) result(expr)
 			colon    = parser%match(colon_token)
 
 			span_beg = parser%peek_pos(0)
-			ubound_  = parser%parse_expr()
+			call parser%parse_expr(expr=ubound_)
 			span_end = parser%peek_pos(0) - 1
 
 			if (.not. is_num_type(ubound_%val%type)) then
@@ -203,9 +195,6 @@ recursive module function parse_array_expr(parser) result(expr)
 			rbracket = parser%match(rbracket_token)
 
 			allocate(expr%val%array)
-			allocate(expr%lbound)
-			allocate(expr%step)
-			allocate(expr%ubound)
 
 			expr%kind           = array_expr
 			expr%val%type       = array_type
@@ -238,9 +227,9 @@ recursive module function parse_array_expr(parser) result(expr)
 			expr%val%array%kind = step_array
 			expr%val%array%rank = 1
 
-			expr%lbound = lbound_
-			expr%step   = step
-			expr%ubound = ubound_
+			call syntax_node_move(lbound_, expr%lbound)
+			call syntax_node_move(step,    expr%step)
+			call syntax_node_move(ubound_, expr%ubound)
 
 			return
 
@@ -253,7 +242,7 @@ recursive module function parse_array_expr(parser) result(expr)
 			semicolon    = parser%match(semicolon_token)
 
 			span_beg = parser%peek_pos(0)
-			len_     = parser%parse_expr()
+			call parser%parse_expr(expr=len_)
 			span_end = parser%peek_pos(0) - 1
 
 			!print *, 'len_ = ', parser%text(span_beg, span_end)
@@ -285,9 +274,6 @@ recursive module function parse_array_expr(parser) result(expr)
 			rbracket = parser%match(rbracket_token)
 
 			allocate(expr%val%array)
-			allocate(expr%lbound)
-			allocate(expr%ubound)
-			allocate(expr%len_)
 
 			expr%kind           = array_expr
 			expr%val%type       = array_type
@@ -295,9 +281,9 @@ recursive module function parse_array_expr(parser) result(expr)
 			expr%val%array%kind = len_array
 			expr%val%array%rank = 1
 
-			expr%lbound = lbound_
-			expr%ubound = ubound_
-			expr%len_   = len_
+			call syntax_node_move(lbound_, expr%lbound)
+			call syntax_node_move(ubound_, expr%ubound)
+			call syntax_node_move(len_,    expr%len_)
 
 			return
 
@@ -311,32 +297,27 @@ recursive module function parse_array_expr(parser) result(expr)
 		!print *, 'ubound_ = ', ubound_%str()
 
 		allocate(expr%val%array)
-		allocate(expr%lbound)
-		allocate(expr%ubound)
 
 		expr%kind = array_expr
-
 		expr%val%type = array_type
-
 		expr%val%array%kind = bound_array
 		expr%val%array%rank = 1
 
-		expr%lbound = lbound_
-		expr%ubound = ubound_
+		call syntax_node_move(lbound_, expr%lbound)
+		call syntax_node_move(ubound_, expr%ubound)
 
+		! Read type info from moved children (not from consumed locals)
 		if (all(i32_type == &
-			[lbound_%val%type, ubound_%val%type]) &! .or. &
+			[expr%lbound%val%type, expr%ubound%val%type]) &! .or. &
 			) then
 
-			!print *, 'setting lbound_ type'
-			expr%val%array%type = lbound_%val%type
+			expr%val%array%type = expr%lbound%val%type
 
 		! TODO: make is_int_type() elemental, then we can sugar up this syntax
 		else if (all([ &
-			is_int_type(lbound_%val%type), &
-			is_int_type(ubound_%val%type)])) then
+			is_int_type(expr%lbound%val%type), &
+			is_int_type(expr%ubound%val%type)])) then
 
-			!print *, 'setting i64_type'
 			expr%val%array%type = i64_type
 
 		else
@@ -384,7 +365,7 @@ recursive module function parse_array_expr(parser) result(expr)
 		comma    = parser%match(comma_token)
 
 		span_beg = parser%peek_pos(0)
-		elem     = parser%parse_expr()
+		call parser%parse_expr(expr=elem)
 		span_end = parser%peek_pos(0) - 1
 
 		!print *, 'elem ', elem%val%str()
@@ -432,17 +413,20 @@ recursive module function parse_array_expr(parser) result(expr)
 
 		allocate(expr%val%array)
 
-		call syntax_nodes_copy(expr%size, size_%v( 1: size_%len_ ))
-
 		expr%kind           = array_expr
-
 		expr%val%type       = array_type
-
 		expr%val%array%type = lbound_%val%type
 		expr%val%array%kind = size_array
 		expr%val%array%rank = size_%len_
 
-		call syntax_nodes_copy(expr%elems, elems%v( 1: elems%len_ ))
+		allocate(expr%size(size_%len_))
+		do i = 1, size_%len_
+			call syntax_node_move_into(size_%v(i), expr%size(i))
+		end do
+		allocate(expr%elems(elems%len_))
+		do i = 1, elems%len_
+			call syntax_node_move_into(elems%v(i), expr%elems(i))
+		end do
 
 		return
 
@@ -453,30 +437,27 @@ recursive module function parse_array_expr(parser) result(expr)
 	rbracket = parser%match(rbracket_token)
 
 	allocate(expr%val%array)
-	expr%kind           = array_expr
-
-	!expr%val%type       = lbound_%val%type
+	expr%kind            = array_expr
 	expr%val%type        = array_type
 	if (allocated(lbound_%val%struct_name)) then
 		expr%val%struct_name = lbound_%val%struct_name
 	end if
 
-	!print *, "expr struct_name = ", expr%val%struct_name
-
 	expr%val%array%type = lbound_%val%type
 	if (lbound_%val%type == array_type) then
-		! If lbound is another array, get its subtype here instead
 		expr%val%array%type = lbound_%val%array%type
 	end if
 
 	expr%val%array%kind = expl_array
 	expr%val%array%rank = 1
 	expr%val%array%len_ = elems%len_
-	!print*, "expl_array"
 
-	call syntax_nodes_copy(expr%elems, elems%v( 1: elems%len_ ))
+	allocate(expr%elems(elems%len_))
+	do i = 1, elems%len_
+		call syntax_node_move_into(elems%v(i), expr%elems(i))
+	end do
 
-end function parse_array_expr
+end subroutine parse_array_expr
 
 !===============================================================================
 
@@ -522,7 +503,7 @@ recursive module subroutine parse_subscripts(parser, expr)
 		else
 
 			ls_beg = parser%current_pos()
-			lsubscript = parser%parse_expr()
+			call parser%parse_expr(expr=lsubscript)
 			ls_end = parser%current_pos()
 
 			!print *, 'lsubscript = ', lsubscript%str()
@@ -565,7 +546,7 @@ recursive module subroutine parse_subscripts(parser, expr)
 					lsubscript%sub_kind = range_sub
 
 					us_beg = parser%current_pos()
-					usubscript = parser%parse_expr()
+					call parser%parse_expr(expr=usubscript)
 					us_end = parser%current_pos()
 
 					if (.not. any(usubscript%val%type == [i32_type, i64_type, unknown_type])) then
@@ -583,7 +564,7 @@ recursive module subroutine parse_subscripts(parser, expr)
 						ssubscript = usubscript
 
 						us_beg = parser%current_pos()
-						usubscript = parser%parse_expr()
+						call parser%parse_expr(expr=usubscript)
 						us_end = parser%current_pos()
 						if (.not. any(usubscript%val%type == [i32_type, i64_type, unknown_type])) then
 							span = new_span(us_beg, us_end - us_beg + 1)
@@ -709,7 +690,7 @@ module function parse_size(parser) result(size)
 		pos0 = parser%pos
 
 		span_beg = parser%peek_pos(0)
-		len      = parser%parse_expr()
+		call parser%parse_expr(expr=len)
 		span_end = parser%peek_pos(0) - 1
 
 		!print *, 'len = ', parser%text(span_beg, span_end)

--- a/src/parse_array.f90
+++ b/src/parse_array.f90
@@ -112,7 +112,7 @@ recursive module subroutine parse_array_expr(parser, expr)
 		! [lbound; rows, cols]
 		! [lbound; rows, cols, sheets, ...]
 
-		size_ = parser%parse_size()
+		call parser%parse_size(size_)
 
 		rbracket = parser%match(rbracket_token)
 
@@ -407,7 +407,7 @@ recursive module subroutine parse_array_expr(parser, expr)
 				parser%context(), span, parser%text(lb_beg, lb_end)))
 		end if
 
-		size_ = parser%parse_size()
+		call parser%parse_size(size_)
 
 		rbracket = parser%match(rbracket_token)
 
@@ -668,11 +668,11 @@ end subroutine parse_subscripts
 
 !===============================================================================
 
-module function parse_size(parser) result(size)
+module subroutine parse_size(parser, size)
 
 	class(parser_t) :: parser
 
-	type(syntax_node_vector_t) :: size
+	type(syntax_node_vector_t), intent(out) :: size
 
 	!********
 
@@ -714,7 +714,7 @@ module function parse_size(parser) result(size)
 
 	end do
 
-end function parse_size
+end subroutine parse_size
 
 !===============================================================================
 

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -397,7 +397,7 @@ module subroutine parse_use_statement(parser, statement)
 	mod_parser%num_structs = parser%num_structs
 
 	! Parse the module
-	mod_unit = mod_parser%parse_unit()
+	call mod_parser%parse_unit(mod_unit)
 
 	! Update parent's variable, function, and struct counts to include module definitions
 	parser%num_vars = mod_parser%num_vars

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -17,16 +17,16 @@ contains
 
 !===============================================================================
 
-module function parse_return_statement(parser) result(statement)
+module subroutine parse_return_statement(parser, statement)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 
 	!********
 
 	integer :: right_beg, right_end
 
+	type(syntax_node_t)  :: right_tmp
 	type(syntax_token_t) :: return_token, semi
 	type(text_span_t) :: span
 
@@ -38,25 +38,16 @@ module function parse_return_statement(parser) result(statement)
 
 	statement%kind = return_statement
 
-	allocate(statement%right)
-
 	if (parser%current_kind() == semicolon_token) then
 		! Void return statement
-
-		!! already matched below
-		!semi = parser%match(semicolon_token)
-
-		!right_end = parser%peek_pos(0) - 1
 		right_end = parser%peek_pos(0)
-
+		allocate(statement%right)
 		statement%right%val%type = void_type
-
 	else
-		! expr or statement?
 		right_beg = parser%peek_pos(0)
-		statement%right = parser%parse_expr()
+		call parser%parse_expr(expr=right_tmp)
+		call syntax_node_move(right_tmp, statement%right)
 		right_end = parser%peek_pos(0) - 1
-
 	end if
 	semi = parser%match(semicolon_token)
 
@@ -76,14 +67,14 @@ module function parse_return_statement(parser) result(statement)
 	end if
 	end if
 
-end function parse_return_statement
+end subroutine parse_return_statement
 
 !===============================================================================
 
-module function parse_break_statement(parser) result(statement)
+module subroutine parse_break_statement(parser, statement)
 
 	class(parser_t) :: parser
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 	!********
 	type(syntax_token_t) :: break_token, semi
 
@@ -91,14 +82,14 @@ module function parse_break_statement(parser) result(statement)
 	statement%kind = break_statement
 	semi = parser%match(semicolon_token)
 
-end function parse_break_statement
+end subroutine parse_break_statement
 
 !===============================================================================
 
-module function parse_continue_statement(parser) result(statement)
+module subroutine parse_continue_statement(parser, statement)
 
 	class(parser_t) :: parser
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 	!********
 	type(syntax_token_t) :: continue_token, semi
 
@@ -106,11 +97,11 @@ module function parse_continue_statement(parser) result(statement)
 	statement%kind = continue_statement
 	semi = parser%match(semicolon_token)
 
-end function parse_continue_statement
+end subroutine parse_continue_statement
 
 !===============================================================================
 
-module function parse_use_statement(parser) result(statement)
+module subroutine parse_use_statement(parser, statement)
 
 	use syntran__errors_m
 
@@ -122,7 +113,7 @@ module function parse_use_statement(parser) result(statement)
 	! - `use path/to/module;  imports path/to/module.syntran, can be combined with qualified or unqualified forms above
 
 	class(parser_t) :: parser
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 	!********
 	character(len = :), allocatable :: module_name, import_name, module_path
 	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
@@ -518,10 +509,9 @@ module function parse_use_statement(parser) result(statement)
 	! not just parsed.
 	statement%kind = use_statement
 	statement%is_empty = .false.
-	allocate(statement%member)
-	statement%member = mod_unit
+	call syntax_node_move(mod_unit, statement%member)
 
-end function parse_use_statement
+end subroutine parse_use_statement
 
 !===============================================================================
 
@@ -575,11 +565,10 @@ end subroutine qualify_value_struct_name
 
 !===============================================================================
 
-recursive module function parse_if_statement(parser) result(statement)
+recursive module subroutine parse_if_statement(parser, statement)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 
 	!********
 
@@ -594,12 +583,8 @@ recursive module function parse_if_statement(parser) result(statement)
 	if_token  = parser%match(if_keyword)
 
 	cond_beg  = parser%peek_pos(0)
-	condition = parser%parse_expr()
-
-	!cond_end  = parser%peek_pos(-1)
+	call parser%parse_expr(expr=condition)
 	cond_end  = parser%peek_pos(0) - 1
-
-	!print *, 'cond_beg, cond_end = ', cond_beg, cond_end
 
 	! Check that condition type is bool.  If the condition depends on a fn which
 	! is declared below, it may be unknown on pass 0
@@ -611,41 +596,29 @@ recursive module function parse_if_statement(parser) result(statement)
 			"if-statement"))
 	end if
 
-	if_clause = parser%parse_statement()  ! Immo calls this "then statement"
-
-	allocate(statement%condition, statement%if_clause)
+	call parser%parse_statement(if_clause)
 
 	statement%kind = if_statement
-	statement%condition = condition
-	statement%if_clause = if_clause
+	call syntax_node_move(condition, statement%condition)
+	call syntax_node_move(if_clause, statement%if_clause)
 
 	if (parser%current_kind() == else_keyword) then
-		!print *, 'parsing else clause'
-
 		else_token = parser%match(else_keyword)
-		else_clause = parser%parse_statement()
-
-		allocate(statement%else_clause)
-		statement%else_clause = else_clause
-
-	!else
-	!	print *, 'no else clause'
+		call parser%parse_statement(else_clause)
+		call syntax_node_move(else_clause, statement%else_clause)
 	end if
 
 	! No additional parsing work is required to handle "else if".  That's just
 	! an else clause which contains another if statement
 
-	!print *, 'done parse_if_statement'
-
-end function parse_if_statement
+end subroutine parse_if_statement
 
 !===============================================================================
 
-recursive module function parse_for_statement(parser) result(statement)
+recursive module subroutine parse_for_statement(parser, statement)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 
 	!********
 
@@ -686,7 +659,7 @@ recursive module function parse_for_statement(parser) result(statement)
 
 	arr_beg  = parser%peek_pos(0)
 	!array      = parser%parse_array_expr()
-	array      = parser%parse_primary_expr()
+	call parser%parse_primary_expr(array)
 	arr_end  = parser%peek_pos(0) - 1
 
 	if (parser%is_loc) then
@@ -748,29 +721,24 @@ recursive module function parse_for_statement(parser) result(statement)
 
 	end if
 
-	body = parser%parse_statement()
+	call parser%parse_statement(body)
 
-	allocate(statement%array)
-	allocate(statement%body)
-
-	statement%kind = for_statement
-
+	statement%kind       = for_statement
 	statement%identifier = identifier
-	statement%array      = array
-	statement%body       = body
+	call syntax_node_move(array, statement%array)
+	call syntax_node_move(body,  statement%body)
 
 	call parser%vars%pop_scope()
 	call parser%locs%pop_scope()
 
-end function parse_for_statement
+end subroutine parse_for_statement
 
 !===============================================================================
 
-recursive module function parse_while_statement(parser) result(statement)
+recursive module subroutine parse_while_statement(parser, statement)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 
 	!********
 
@@ -783,7 +751,7 @@ recursive module function parse_while_statement(parser) result(statement)
 	while_token  = parser%match(while_keyword)
 
 	cond_beg  = parser%peek_pos(0)
-	condition = parser%parse_expr()
+	call parser%parse_expr(expr=condition)
 	cond_end  = parser%peek_pos(0) - 1
 
 	! Check that condition type is bool
@@ -795,29 +763,26 @@ recursive module function parse_while_statement(parser) result(statement)
 			"while-loop"))
 	end if
 
-	body = parser%parse_statement()
-
-	allocate(statement%condition, statement%body)
+	call parser%parse_statement(body)
 
 	statement%kind = while_statement
+	call syntax_node_move(condition, statement%condition)
+	call syntax_node_move(body,      statement%body)
 
-	statement%condition = condition
-	statement%body      = body
-
-end function parse_while_statement
+end subroutine parse_while_statement
 
 !===============================================================================
 
-recursive module function parse_block_statement(parser) result(block)
+recursive module subroutine parse_block_statement(parser, block)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: block
+	type(syntax_node_t), intent(out) :: block
 
 	!********
 
 	type(syntax_node_vector_t) :: members
 	type(syntax_token_t) :: left, right, dummy
+	type(syntax_node_t)  :: stmt_tmp
 
 	integer :: i, pos0
 
@@ -835,14 +800,11 @@ recursive module function parse_block_statement(parser) result(block)
 
 		pos0 = parser%pos
 		i = i + 1
-		!print *, '    statement ', i
 
-		call members%push(parser%parse_statement())
+		call parser%parse_statement(stmt_tmp)
+		call members%push_move(stmt_tmp)
 
-		! Avoid infinite loops on malformed blocks like this:
-		!   {
-		!     4) + 5;
-		!   }
+		! Avoid infinite loops on malformed blocks
 		if (parser%pos == pos0) dummy = parser%next()
 
 	end do
@@ -854,20 +816,22 @@ recursive module function parse_block_statement(parser) result(block)
 
 	block%kind = block_statement
 
-	! Convert to standard array
-	call syntax_nodes_copy(block%members, members%v( 1: members%len_ ))
+	! Move members from vector directly (avoids deep copy)
+	allocate(block%members(members%len_))
+	do i = 1, members%len_
+		call syntax_node_move_into(members%v(i), block%members(i))
+	end do
 
-end function parse_block_statement
+end subroutine parse_block_statement
 
 !===============================================================================
 
-recursive module function parse_statement(parser) result(statement)
+recursive module subroutine parse_statement(parser, statement)
 
 	use syntran__errors_m
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: statement
+	type(syntax_node_t), intent(out) :: statement
 
 	!********
 
@@ -879,32 +843,32 @@ recursive module function parse_statement(parser) result(statement)
 
 	select case (parser%current_kind())
 	case (lbrace_token)
-		statement = parser%parse_block_statement()
+		call parser%parse_block_statement(statement)
 
 	case (if_keyword)
-		statement = parser%parse_if_statement()
+		call parser%parse_if_statement(statement)
 
 	case (for_keyword)
-		statement = parser%parse_for_statement()
+		call parser%parse_for_statement(statement)
 
 	case (while_keyword)
-		statement = parser%parse_while_statement()
+		call parser%parse_while_statement(statement)
 
 	case (return_keyword)
-		statement = parser%parse_return_statement()
+		call parser%parse_return_statement(statement)
 
 	case (break_keyword)
-		statement = parser%parse_break_statement()
+		call parser%parse_break_statement(statement)
 
 	case (continue_keyword)
-		statement = parser%parse_continue_statement()
+		call parser%parse_continue_statement(statement)
 
 	case (use_keyword)
-		statement = parser%parse_use_statement()
+		call parser%parse_use_statement(statement)
 
 	case default
 		pos_beg   = parser%peek_pos(0)
-		statement = parser%parse_expr_statement()
+		call parser%parse_expr_statement(statement)
 		pos_end   = parser%peek_pos(0)
 		semi      = parser%match(semicolon_token)
 
@@ -951,7 +915,7 @@ recursive module function parse_statement(parser) result(statement)
 
 	end select
 
-end function parse_statement
+end subroutine parse_statement
 
 !===============================================================================
 

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -554,7 +554,7 @@ recursive module subroutine parse_primary_expr(parser, expr)
 
 			keyword = parser%next()
 			bool = keyword%kind == true_keyword
-			expr = new_bool(bool)
+			call new_bool(bool, expr)
 
 			!print *, 'expr%val%sca%bool = ', expr%val%sca%bool
 
@@ -618,27 +618,27 @@ recursive module subroutine parse_primary_expr(parser, expr)
 		case (f32_token)
 
 			token = parser%match(f32_token)
-			expr  = new_f32(token%val%sca%f32)
+			call new_f32(token%val%sca%f32, expr)
 
 		case (f64_token)
 
 			token = parser%match(f64_token)
-			expr  = new_f64(token%val%sca%f64)
+			call new_f64(token%val%sca%f64, expr)
 
 		case (str_token)
 
 			token = parser%match(str_token)
-			expr  = new_str(token%val%str%s)
+			call new_str(token%val%str%s, expr)
 
 		case (i64_token)
 
 			token = parser%match(i64_token)
-			expr  = new_i64(token%val%sca%i64)
+			call new_i64(token%val%sca%i64, expr)
 
 		case default
 
 			token = parser%match(i32_token)
-			expr  = new_i32(token%val%sca%i32)
+			call new_i32(token%val%sca%i32, expr)
 
 			if (debug > 1) print *, 'token = ', expr%val%to_str()
 
@@ -677,12 +677,12 @@ recursive module subroutine parse_name_expr(parser, expr)
 	end if
 
 	if (parser%is_loc .and. io == 0) then
-		expr = new_name_expr(identifier, var)
+		call new_name_expr(identifier, var, expr)
 		expr%id_index = id_index
 		expr%is_loc = .true.
 	else
 		call parser%vars%search(identifier%text, id_index, io, var)
-		expr = new_name_expr(identifier, var)
+		call new_name_expr(identifier, var, expr)
 		expr%id_index = id_index
 		expr%is_loc = .false.
 

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -635,7 +635,7 @@ recursive module function parse_primary_expr(parser) result(expr)
 		case (str_token)
 
 			token = parser%match(str_token)
-			expr  = new_str(token%val%sca%str%s)
+			expr  = new_str(token%val%str%s)
 
 		case (i64_token)
 

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -15,11 +15,10 @@ contains
 
 !===============================================================================
 
-recursive module function parse_expr_statement(parser) result(expr)
+recursive module subroutine parse_expr_statement(parser, expr)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t), intent(out) :: expr
 
 	!********
 
@@ -67,7 +66,7 @@ recursive module function parse_expr_statement(parser) result(expr)
 
 		op         = parser%next()
 
-		right      = parser%parse_expr_statement()
+		call parser%parse_expr_statement(right)
 		!right      = parser%parse_expr()
 
 		if (right%val%type ==  void_type) then
@@ -83,7 +82,7 @@ recursive module function parse_expr_statement(parser) result(expr)
 		!right      = parser%parse_statement()
 		!!semi       = parser%match(semicolon_token)
 
-		expr = new_declaration_expr(identifier, op, right)
+		call new_declaration_expr(identifier, op, right, expr)
 
 		!print *, "right type = ", kind_name(right%val%type)
 		!print *, "expr  type = ", kind_name(expr %val%type)
@@ -196,13 +195,11 @@ recursive module function parse_expr_statement(parser) result(expr)
 			expr%is_loc = .false.
 
 			op    = parser%next()
-			right = parser%parse_expr_statement()
+			call parser%parse_expr_statement(right)
 
 			expr%kind = assignment_expr
-
-			if (.not. allocated(expr%right)) allocate(expr%right)
-			expr%op    = op
-			expr%right = right
+			expr%op   = op
+			call syntax_node_move(right, expr%right)
 
 			ltype = expr%val%type
 			rtype = expr%right%val%type
@@ -307,25 +304,22 @@ recursive module function parse_expr_statement(parser) result(expr)
 			parser%pos = pos0
 			!print *, "rewinding ********"
 			!print *, 'pos0 = ', pos0
-			expr = parser%parse_expr()
+			call parser%parse_expr(expr=expr)
 			return
 		end if
 		!print *, 'parsing assignment'
 
 		op    = parser%next()
-		right = parser%parse_expr_statement()
+		call parser%parse_expr_statement(right)
 		!print *, "1a right index = ", right%right%id_index
 
 		! regular vs compound assignment exprs are denoted by the op.  all of
 		! them are the same kind
 		expr%kind = assignment_expr
 
-		if (.not. allocated(expr%right)) allocate(expr%right)
-
 		expr%identifier = identifier
-
-		expr%op    = op
-		expr%right = right
+		expr%op         = op
+		call syntax_node_move(right, expr%right)
 
 		!print *, 'expr ident text = ', expr%identifier%text
 		!print *, 'op = ', op%text
@@ -402,14 +396,14 @@ recursive module function parse_expr_statement(parser) result(expr)
 
 	end if
 
-	expr = parser%parse_expr()
+	call parser%parse_expr(expr=expr)
 	!semi       = parser%match(semicolon_token)
 
-end function parse_expr_statement
+end subroutine parse_expr_statement
 
 !===============================================================================
 
-recursive module function parse_expr(parser, parent_prec) result(expr)
+recursive module subroutine parse_expr(parser, parent_prec, expr)
 
 	! In episode 3, Immo renamed this fn to "ParseBinaryExpression()", but
 	! I consider that confusing because the result could be either unary or
@@ -418,15 +412,14 @@ recursive module function parse_expr(parser, parent_prec) result(expr)
 	class(parser_t) :: parser
 
 	integer, optional, intent(in) :: parent_prec
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t), intent(out) :: expr
 
 	!********
 
 	integer :: parent_precl, prec, ltype, rtype, larrtype, rarrtype, &
 		lrank, rrank
 
-	type(syntax_node_t) :: right
+	type(syntax_node_t) :: right, bin_tmp
 	type(syntax_token_t) :: op
 	type(text_span_t) :: span
 
@@ -440,8 +433,8 @@ recursive module function parse_expr(parser, parent_prec) result(expr)
 	if (prec /= 0 .and. prec >= parent_precl) then
 
 		op    = parser%next()
-		right = parser%parse_expr(prec)
-		expr  = new_unary_expr(op, right)
+		call parser%parse_expr(prec, right)
+		call new_unary_expr(op, right, expr)
 
 		rtype = right%val%type
 		if (rtype == array_type) rarrtype = expr%right%val%array%type
@@ -456,7 +449,7 @@ recursive module function parse_expr(parser, parent_prec) result(expr)
 		end if
 
 	else
-		expr = parser%parse_primary_expr()
+		call parser%parse_primary_expr(expr)
 	end if
 
 	do
@@ -464,8 +457,9 @@ recursive module function parse_expr(parser, parent_prec) result(expr)
 		if (prec == 0 .or. prec <= parent_precl) exit
 
 		op    = parser%next()
-		right = parser%parse_expr(prec)
-		expr  = new_binary_expr(expr, op, right)
+		call parser%parse_expr(prec, right)
+		call new_binary_expr(expr, op, right, bin_tmp)
+		call syntax_node_move_into(bin_tmp, expr)
 
 		ltype = expr%left %val%type
 		rtype = expr%right%val%type
@@ -514,15 +508,14 @@ recursive module function parse_expr(parser, parent_prec) result(expr)
 
 	end do
 
-end function parse_expr
+end subroutine parse_expr
 
 !===============================================================================
 
-recursive module function parse_primary_expr(parser) result(expr)
+recursive module subroutine parse_primary_expr(parser, expr)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t), intent(out) :: expr
 
 	!********
 
@@ -545,14 +538,14 @@ recursive module function parse_primary_expr(parser) result(expr)
 			! "a = (b = 1)" or not.  Note that "a = b = 1" is allowed either way
 
 			!expr  = parser%parse_expr()
-			expr  = parser%parse_expr_statement()
+			call parser%parse_expr_statement(expr)
 
 			right = parser%match(rparen_token)
 
 		case (lbracket_token)
 
 			! Brackets are matched within parse_array_expr
-			expr = parser%parse_array_expr()
+			call parser%parse_array_expr(expr)
 
 			!print *, '2 expr%val%type = ', expr%val%type
 			!print *, '2 expr%val%array%type = ', expr%val%array%type
@@ -571,9 +564,9 @@ recursive module function parse_primary_expr(parser) result(expr)
 
 			if (parser%peek_kind(1) == double_colon_token) then
 				! Qualified name like `std::println()` or `mod::fn()`
-				expr = parser%parse_qualified_expr()
+				call parser%parse_qualified_expr(expr)
 			else if (parser%peek_kind(1) == lparen_token) then
-				expr = parser%parse_fn_call()
+				call parser%parse_fn_call(fn_call=expr)
 			else if (parser%peek_kind(1) == lbrace_token) then
 
 				! There is an ambiguity here because struct instantiators and
@@ -611,15 +604,15 @@ recursive module function parse_primary_expr(parser) result(expr)
 
 				!if (io == 0) then
 				if (exists) then
-					expr = parser%parse_struct_instance()
+					call parser%parse_struct_instance(expr)
 					!print *, "back in parse_expr.f90"
 				else
 					! Same as default case below
-					expr = parser%parse_name_expr()
+					call parser%parse_name_expr(expr)
 				end if
 
 			else
-				expr = parser%parse_name_expr()
+				call parser%parse_name_expr(expr)
 			end if
 
 		case (f32_token)
@@ -651,15 +644,14 @@ recursive module function parse_primary_expr(parser) result(expr)
 
 	end select
 
-end function parse_primary_expr
+end subroutine parse_primary_expr
 
 !===============================================================================
 
-recursive module function parse_name_expr(parser) result(expr)
+recursive module subroutine parse_name_expr(parser, expr)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t), intent(out) :: expr
 
 	!********
 
@@ -715,7 +707,7 @@ recursive module function parse_name_expr(parser) result(expr)
 	!print *, "tail parse_dot"
 	call parser%parse_dot(expr)
 
-end function parse_name_expr
+end subroutine parse_name_expr
 
 !===============================================================================
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -456,7 +456,7 @@ recursive module subroutine parse_qualified_expr(parser, expr)
 			return
 		end if
 
-		expr = new_name_expr(fn_identifier, var_val)
+		call new_name_expr(fn_identifier, var_val, expr)
 		expr%id_index = id_index
 		expr%module_prefix = module_name
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -17,13 +17,12 @@ contains
 
 !===============================================================================
 
-recursive module function parse_fn_call(parser, module_prefix, identifier) result(fn_call)
+recursive module subroutine parse_fn_call(parser, module_prefix, identifier, fn_call)
 
 	class(parser_t) :: parser
 	character(len = *), intent(in), optional :: module_prefix
 	type(syntax_token_t), intent(in), optional :: identifier
-
-	type(syntax_node_t) :: fn_call
+	type(syntax_node_t), intent(out) :: fn_call
 
 	!********
 
@@ -79,7 +78,7 @@ recursive module function parse_fn_call(parser, module_prefix, identifier) resul
 		end if
 		call is_ref%push(arg_is_ref)
 
-		arg = parser%parse_expr()
+		call parser%parse_expr(expr=arg)
 
 		! Check that arg expr is name_expr.  Maybe it can be extended later to
 		! subscript exprs, but for now only names work
@@ -379,22 +378,25 @@ recursive module function parse_fn_call(parser, module_prefix, identifier) resul
 
 	fn_call%id_index = id_index
 
-	call syntax_nodes_copy(fn_call%args, args%v( 1: args%len_ ))
+	! Move args from vector (avoids deep copy)
+	allocate(fn_call%args(args%len_))
+	do i = 1, args%len_
+		call syntax_node_move_into(args%v(i), fn_call%args(i))
+	end do
 
 	!print *, 'done parsing fn_call'
 
-end function parse_fn_call
+end subroutine parse_fn_call
 
 !===============================================================================
 
-recursive module function parse_qualified_expr(parser) result(expr)
+recursive module subroutine parse_qualified_expr(parser, expr)
 
 	! Parse qualified names like `std::println()`, `mod::name`,
 	! or nested namespaces like `math::vectors::fn()`
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t), intent(out) :: expr
 
 	!********
 
@@ -428,13 +430,13 @@ recursive module function parse_qualified_expr(parser) result(expr)
 
 	if (parser%current_kind() == lparen_token) then
 		! Qualified function call: std::println(...) or math::vectors::fn(...)
-		expr = parser%parse_fn_call(module_name, fn_identifier)
+		call parser%parse_fn_call(module_name, fn_identifier, expr)
 
 	else if (parser%current_kind() == lbrace_token) then
 		! Qualified struct instance: mod::Struct{...}
 		lookup_name = module_name // "::" // fn_name
 		if (parser%structs%exists(lookup_name)) then
-			expr = parser%parse_struct_instance(lookup_name)
+			call parser%parse_struct_instance(expr, lookup_name)
 		else
 			! Struct not found
 			span = new_span(fn_identifier%pos, len(fn_identifier%text))
@@ -462,15 +464,14 @@ recursive module function parse_qualified_expr(parser) result(expr)
 		call parser%parse_dot(expr)
 	end if
 
-end function parse_qualified_expr
+end subroutine parse_qualified_expr
 
 !===============================================================================
 
-module function parse_fn_declaration(parser) result(decl)
+module subroutine parse_fn_declaration(parser, decl)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: decl
+	type(syntax_node_t), intent(out) :: decl
 
 	!********
 
@@ -641,7 +642,7 @@ module function parse_fn_declaration(parser) result(decl)
 	parser%fn_name = identifier%text
 	parser%fn_type = fn%type
 
-	body = parser%parse_statement()
+	call parser%parse_statement(body)
 
 	if (.not. parser%returned) then
 		span = new_span(fn_beg, fn_name_end - fn_beg + 1)
@@ -658,13 +659,10 @@ module function parse_fn_declaration(parser) result(decl)
 	parser%num_fns = parser%num_fns + 1
 	decl%id_index  = parser%num_fns
 
-	allocate(decl%body)
-
-	decl%kind = fn_declaration
-
+	decl%kind       = fn_declaration
 	decl%identifier = identifier
 	decl%num_locs   = parser%num_locs
-	decl%body       = body
+	call syntax_node_move(body, decl%body)
 	!print *, "decl num_locs = ", decl%num_locs
 
 	call parser%vars%pop_scope()
@@ -708,15 +706,14 @@ module function parse_fn_declaration(parser) result(decl)
 	!print *, 'size(decl%params) = ', size(decl%params)
 	!print *, 'decl%params = ', decl%params
 
-end function parse_fn_declaration
+end subroutine parse_fn_declaration
 
 !===============================================================================
 
-module function parse_struct_declaration(parser) result(decl)
+module subroutine parse_struct_declaration(parser, decl)
 
 	class(parser_t) :: parser
-
-	type(syntax_node_t) :: decl
+	type(syntax_node_t), intent(out) :: decl
 
 	!********
 
@@ -886,20 +883,19 @@ module function parse_struct_declaration(parser) result(decl)
 
 	!print *, "done parsing struct"
 
-end function parse_struct_declaration
+end subroutine parse_struct_declaration
 
 !===============================================================================
 
-recursive module function parse_struct_instance(parser, struct_name) result(inst)
+recursive module subroutine parse_struct_instance(parser, inst, struct_name)
 
 	! A struct instantiator initializes all the members of an instance of a
 	! struct
 
 	class(parser_t) :: parser
 
+	type(syntax_node_t), intent(out) :: inst
 	character(len = *), intent(in), optional :: struct_name
-
-	type(syntax_node_t) :: inst
 
 	!********
 
@@ -974,7 +970,7 @@ recursive module function parse_struct_instance(parser, struct_name) result(inst
 		name   = parser%match(identifier_token)
 		equals = parser%match(equals_token)
 		pos1   = parser%current_pos()
-		mem    = parser%parse_expr()
+		call parser%parse_expr(expr=mem)
 
 		!print *, "name%text = ", name%text
 
@@ -1092,7 +1088,7 @@ recursive module function parse_struct_instance(parser, struct_name) result(inst
 
 	!print *, "ending parse_struct_instance()"
 
-end function parse_struct_instance
+end subroutine parse_struct_instance
 
 !===============================================================================
 

--- a/src/parse_misc.f90
+++ b/src/parse_misc.f90
@@ -346,11 +346,11 @@ end function match_pre
 
 !===============================================================================
 
-module function parse_unit(parser) result(unit)
+module subroutine parse_unit(parser, unit)
 
 	class(parser_t) :: parser
 
-	type(syntax_node_t) :: unit
+	type(syntax_node_t), intent(out) :: unit
 
 	!********
 
@@ -496,7 +496,7 @@ module function parse_unit(parser) result(unit)
 	! Eof is matched in the caller syntax_parse() to deal with broken stdin
 	! lines with interactive interpretation
 
-end function parse_unit
+end subroutine parse_unit
 
 !===============================================================================
 

--- a/src/parse_misc.f90
+++ b/src/parse_misc.f90
@@ -355,6 +355,7 @@ module function parse_unit(parser) result(unit)
 	!********
 
 	type(syntax_node_vector_t) :: members
+	type(syntax_node_t)  :: stmt_tmp
 	type(syntax_token_t) :: dummy
 
 	integer :: i, pos0, num_vars0, num_fns0, num_structs0
@@ -396,11 +397,14 @@ module function parse_unit(parser) result(unit)
 
 		select case (parser%current_kind())
 		case (fn_keyword)
-			call members%push(parser%parse_fn_declaration())
+			call parser%parse_fn_declaration(stmt_tmp)
+			call members%push_move(stmt_tmp)
 		case (struct_keyword)
-			call members%push(parser%parse_struct_declaration())
+			call parser%parse_struct_declaration(stmt_tmp)
+			call members%push_move(stmt_tmp)
 		case default
-			call members%push(parser%parse_statement())
+			call parser%parse_statement(stmt_tmp)
+			call members%push_move(stmt_tmp)
 		end select
 
 		! Break infinite loops
@@ -456,11 +460,14 @@ module function parse_unit(parser) result(unit)
 
 			select case (parser%current_kind())
 			case (fn_keyword)
-				call members%push(parser%parse_fn_declaration())
+				call parser%parse_fn_declaration(stmt_tmp)
+				call members%push_move(stmt_tmp)
 			case (struct_keyword)
-				call members%push(parser%parse_struct_declaration())
+				call parser%parse_struct_declaration(stmt_tmp)
+				call members%push_move(stmt_tmp)
 			case default
-				call members%push(parser%parse_statement())
+				call parser%parse_statement(stmt_tmp)
+				call members%push_move(stmt_tmp)
 			end select
 
 			! Break infinite loops
@@ -480,8 +487,11 @@ module function parse_unit(parser) result(unit)
 
 	unit%kind = translation_unit
 
-	! Convert to standard array
-	call syntax_nodes_copy(unit%members, members%v( 1: members%len_ ))
+	! Move members from vector directly (avoids deep copy)
+	allocate(unit%members(members%len_))
+	do i = 1, members%len_
+		call syntax_node_move_into(members%v(i), unit%members(i))
+	end do
 
 	! Eof is matched in the caller syntax_parse() to deal with broken stdin
 	! lines with interactive interpretation

--- a/src/parse_misc.f90
+++ b/src/parse_misc.f90
@@ -185,8 +185,8 @@ recursive module subroutine preprocess(parser, tokens_in, src_file, contexts, un
 			!print *, 'get_dir(src_file) = ', get_dir(src_file)
 
 			i = i + 1
-			filename = get_dir(src_file)//tokens_in(i)%val%sca%str%s  ! relative to src file
-			!filename = tokens_in(i)%val%sca%str%s                    ! relative to runtime pwd
+			filename = get_dir(src_file)//tokens_in(i)%val%str%s  ! relative to src file
+			!filename = tokens_in(i)%val%str%s                    ! relative to runtime pwd
 
 			!print *, 'include filename = ', quote(filename)
 

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -8,12 +8,37 @@ module syntran
 	! syntran library as an API (as opposed to using the syntran CLI)
 
 	use syntran__core_m
+	use syntran__compile_m
+	use syntran__vm_m
 
 	implicit none
 
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+subroutine eval_dispatch(tree, state, res)
+
+	! Dispatch to the bytecode VM or the AST walker based on state%bytecode.
+
+	type(syntax_node_t), intent(in) :: tree
+	type(state_t), intent(inout) :: state
+	type(value_t), intent(out) :: res
+
+	!*******
+
+	type(program_t) :: prog
+
+	if (state%bytecode) then
+		call compile_tree(tree, prog)
+		call vm_run(prog, state, res)
+	else
+		call syntax_eval(tree, state, res)
+	end if
+
+end subroutine eval_dispatch
 
 !===============================================================================
 
@@ -99,7 +124,7 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 		end if
 
 		! TODO: chdir option?
-		call syntax_eval(compilation, state, res)
+		call eval_dispatch(compilation, state, res)
 		res_str = res%to_str()
 		write(*,*) '    '//res_str
 
@@ -202,7 +227,7 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 		! Don't try to evaluate with errors
 		if (compilation%diagnostics%len_ > 0) cycle
 
-		call syntax_eval(compilation, state, res )
+		call eval_dispatch(compilation, state, res)
 
 		!print *, "res type = ", kind_name(res%type)
 		if (res%type == void_type   ) cycle
@@ -239,7 +264,7 @@ integer function syntran_eval_i32(str_) result(eval_i32)
 		return
 	end if
 
-	call syntax_eval(tree, state, val)
+	call eval_dispatch(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	eval_i32 = val%sca%i32
@@ -270,7 +295,7 @@ integer(kind = 8) function syntran_eval_i64(str_) result(val_)
 		return
 	end if
 
-	call syntax_eval(tree, state, val)
+	call eval_dispatch(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	val_ = val%sca%i64
@@ -304,7 +329,7 @@ real(kind = 4) function syntran_eval_f32(str_, quiet) result(eval_f32)
 		return
 	end if
 
-	call syntax_eval(tree, state, val)
+	call eval_dispatch(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	eval_f32 = val%sca%f32
@@ -339,7 +364,7 @@ real(kind = 8) function syntran_eval_f64(str_, quiet) result(eval_f64)
 		return
 	end if
 
-	call syntax_eval(tree, state, val)
+	call eval_dispatch(tree, state, val)
 
 	! TODO: check kind, add optional iostat arg
 	eval_f64 = val%sca%f64
@@ -363,11 +388,24 @@ subroutine init_state(state, script_args, src_dir)
 	type(string_vector_t), intent(in), optional :: script_args
 	character(len = *), intent(in), optional :: src_dir
 
+	!*******
+
+	character(len = 64) :: backend_env
+	integer :: backend_status
+
 	call declare_intr_fns(state%fns)
 
 	state%returned  = .false.
 	state%breaked   = .false.
 	state%continued = .false.
+
+	! Select evaluation backend via SYNTRAN_BACKEND env var.
+	! SYNTRAN_BACKEND=bytecode  -> use the bytecode VM
+	! (anything else)           -> use the AST walker (default)
+	call get_environment_variable('SYNTRAN_BACKEND', backend_env, &
+		status = backend_status)
+	state%bytecode = (backend_status == 0 .and. &
+		trim(backend_env) == 'bytecode')
 
 	! Is it safe to initialize these arrays both here and in new_parser?  Test
 	! interactive interp
@@ -466,7 +504,7 @@ function syntran_eval(str_, quiet, src_file, chdir_, script_args) result(res)
 	! No chdir() needed - src_dir is now in state and will be used by open()
 
 	!print *, "evaling "
-	call syntax_eval(tree, state, val)
+	call eval_dispatch(tree, state, val)
 	!print *, "done"
 	res = val%to_str()
 	!print *, 'res = ', res

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -409,6 +409,10 @@ subroutine init_state(state, script_args, src_dir)
 	if (backend_status == 0) then
 		if (trim(backend_env) == "ast") then
 			state%bytecode = .false.
+			write(error_unit, '(a)') fg_bold_yellow//'Warning'//color_reset// &
+				': SYNTRAN_BACKEND=ast is deprecated. ' // &
+				'The AST walker will be removed in a future release. If you encounter ' // &
+				'bugs, please report them at https://github.com/JeffIrwin/syntran/issues'
 		end if
 	end if
 	!state%bytecode = (backend_status == 0 .and. &

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -415,8 +415,6 @@ subroutine init_state(state, script_args, src_dir)
 				'bugs, please report them at https://github.com/JeffIrwin/syntran/issues'
 		end if
 	end if
-	!state%bytecode = (backend_status == 0 .and. &
-	!	trim(backend_env) == 'bytecode')
 
 	! Is it safe to initialize these arrays both here and in new_parser?  Test
 	! interactive interp

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -404,8 +404,15 @@ subroutine init_state(state, script_args, src_dir)
 	! (anything else)           -> use the AST walker (default)
 	call get_environment_variable('SYNTRAN_BACKEND', backend_env, &
 		status = backend_status)
-	state%bytecode = (backend_status == 0 .and. &
-		trim(backend_env) == 'bytecode')
+
+	state%bytecode = .true.
+	if (backend_status == 0) then
+		if (trim(backend_env) == "ast") then
+			state%bytecode = .false.
+		end if
+	end if
+	!state%bytecode = (backend_status == 0 .and. &
+	!	trim(backend_env) == 'bytecode')
 
 	! Is it safe to initialize these arrays both here and in new_parser?  Test
 	! interactive interp

--- a/src/tests/test-src/array-i32/test-09.syntran
+++ b/src/tests/test-src/array-i32/test-09.syntran
@@ -1,0 +1,33 @@
+// Test native scalar array index read/write (OP_INDEX_NAT, OP_STORE_IDX_NAT)
+
+// Basic read
+let a = [4, 3, 5, 2, 1];
+let i = 2;
+let v = a[i];
+
+// Basic write (plain '=')
+a[0] = 99;
+a[i] = 7;
+
+// Read via compound index expr
+let j = i + 1;
+let w = a[j];
+
+// Swap via native read/write
+let tmp = a[0];
+a[0] = a[1];
+a[1] = tmp;
+
+// Size-based subscript (i64 subscript → i32 array, tests type-mismatch coercion)
+let n = size(a, 0);   // i64
+a[n - 1] = 42;        // i64 subscript, i32 rhs → OP_STORE_IDX_NAT fallback or native
+
+let norm = 0;
+let expect = [3, 99, 7, 2, 42];
+for ii in [0: size(expect, 0)]
+{
+    let diff = a[ii] - expect[ii];
+    if (diff < 0) diff = -diff;
+    norm = norm + diff;
+}
+return norm;

--- a/src/tests/test-src/array-i32/test-09.syntran
+++ b/src/tests/test-src/array-i32/test-09.syntran
@@ -22,12 +22,7 @@ a[1] = tmp;
 let n = size(a, 0);   // i64
 a[n - 1] = 42;        // i64 subscript, i32 rhs → OP_STORE_IDX_NAT fallback or native
 
-let norm = 0;
 let expect = [3, 99, 7, 2, 42];
-for ii in [0: size(expect, 0)]
-{
-    let diff = a[ii] - expect[ii];
-    if (diff < 0) diff = -diff;
-    norm = norm + diff;
-}
+let norm = sum(abs(a - expect));
 return norm;
+

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4840,10 +4840,164 @@ subroutine unit_tests(iostat)
 	! TODO: add tests that mock interpreting one line at a time (as opposed to
 	! whole files)
 
+	call unit_test_pow_scalar  (npass, nfail)
+	call unit_test_mixed_i32i64(npass, nfail)
+	call unit_test_arr_binop   (npass, nfail)
+
 	call log_test_summary(npass, nfail)
 	iostat = nfail
 
 end subroutine unit_tests
+
+!===============================================================================
+
+!===============================================================================
+
+subroutine unit_test_pow_scalar(npass, nfail)
+
+	! Same-type scalar ** tests (exercises OP_POW_* specialized opcodes).
+	! Existing tests cover mixed-type power (i64**i32, etc.) and array power;
+	! these add same-type scalar cases not previously tested.
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'scalar power (specialized opcodes)'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			! i32 ** i32 (existing tests only have compound **= or mixed types)
+			eval('2 ** 10;')  == '1024', &
+			eval('3 ** 3;')   == '27',   &
+			eval('2 ** 0;')   == '1',    &
+			! i64 ** i64 (existing tests have i64**i32 mixed, not same-type)
+			eval('i64(200000) ** i64(2);') == '40000000000', &
+			eval('i64(3) ** i64(10);')     == '59049',       &
+			! f32 ** f32 (4.0f is f32, 0.5f is f32)
+			eval('abs(4.0f ** 0.5f - 2.0f) < 1.0e-5f;') == 'true', &
+			! f64 ** f64 (undecorated 2.0 is f64 in Syntran)
+			eval('abs(4.0 ** 0.5 - 2.0) < 1.0e-12;') == 'true', &
+			eval('abs(9.0 ** 0.5 - 3.0) < 1.0e-12;') == 'true', &
+			.false.  &
+		]
+
+	tests = tests(1: size(tests) - 1)
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_pow_scalar
+
+!===============================================================================
+
+subroutine unit_test_mixed_i32i64(npass, nfail)
+
+	! Mixed i32/i64 scalar arithmetic and comparisons (exercises OP_*_I32_I64
+	! and OP_*_I64_I32 specialized opcodes).
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'mixed i32/i64 (specialized opcodes)'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			! Arithmetic: i32 op i64 -> i64
+			eval('let a = i32(3); let b = i64(5); a + b;') == '8', &
+			eval('let a = i32(3); let b = i64(5); a - b;') == '-2', &
+			eval('let a = i32(3); let b = i64(5); a * b;') == '15', &
+			eval('let a = i32(10); let b = i64(3); a / b;') == '3', &
+			eval('let a = i32(10); let b = i64(3); a % b;') == '1', &
+			! Arithmetic: i64 op i32 -> i64
+			eval('let a = i64(8123123123); let b = i32(3); a + b;') == '8123123126', &
+			eval('let a = i64(8123123123); let b = i32(3); a - b;') == '8123123120', &
+			eval('let a = i64(8123123123); let b = i32(2); a * b;') == '16246246246', &
+			eval('let a = i64(8123123123); let b = i32(3); a / b;') == '2707707707', &
+			eval('let a = i64(8123123123); let b = i32(3); a % b;') == '2', &
+			! Comparisons: i32 op i64
+			eval('let a = i32(3); let b = i64(5); a < b;')  == 'true',  &
+			eval('let a = i32(5); let b = i64(3); a < b;')  == 'false', &
+			eval('let a = i32(3); let b = i64(5); a <= b;') == 'true',  &
+			eval('let a = i32(3); let b = i64(3); a <= b;') == 'true',  &
+			eval('let a = i32(5); let b = i64(3); a > b;')  == 'true',  &
+			eval('let a = i32(3); let b = i64(5); a > b;')  == 'false', &
+			eval('let a = i32(5); let b = i64(3); a >= b;') == 'true',  &
+			eval('let a = i32(3); let b = i64(3); a >= b;') == 'true',  &
+			eval('let a = i32(3); let b = i64(3); a == b;') == 'true',  &
+			eval('let a = i32(3); let b = i64(4); a == b;') == 'false', &
+			eval('let a = i32(3); let b = i64(4); a != b;') == 'true',  &
+			eval('let a = i32(3); let b = i64(3); a != b;') == 'false', &
+			! Comparisons: i64 op i32
+			eval('let a = i64(5); let b = i32(3); a < b;')  == 'false', &
+			eval('let a = i64(3); let b = i32(5); a < b;')  == 'true',  &
+			eval('let a = i64(3); let b = i32(3); a <= b;') == 'true',  &
+			eval('let a = i64(5); let b = i32(3); a > b;')  == 'true',  &
+			eval('let a = i64(3); let b = i32(3); a >= b;') == 'true',  &
+			eval('let a = i64(3); let b = i32(3); a == b;') == 'true',  &
+			eval('let a = i64(3); let b = i32(4); a != b;') == 'true',  &
+			.false.  &
+		]
+
+	tests = tests(1: size(tests) - 1)
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_mixed_i32i64
+
+!===============================================================================
+
+subroutine unit_test_arr_binop(npass, nfail)
+
+	! Same-type f64 array binop tests that aren't covered elsewhere.
+	! (i32/f32/i64 array arithmetic and comparisons are tested in
+	! unit_test_arr_op and unit_test_arr_comp; f64 array +, <, > are also
+	! there.  Only the remaining f64 array ops are genuinely new.)
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'f64 array binops (specialized opcodes)'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			! f64 array arithmetic (undecorated 2.0 is f64 in Syntran)
+			eval('all([4.0, 9.0] - [1.0, 4.0] == [3.0, 5.0]);') == 'true', &
+			eval('all([2.0, 3.0] * [4.0, 5.0] == [8.0, 15.0]);') == 'true', &
+			eval('all([9.0, 6.0] / [3.0, 2.0] == [3.0, 3.0]);')  == 'true', &
+			eval('all([7.0, 5.0] % [3.0, 2.0] == [1.0, 1.0]);')  == 'true', &
+			! f64 array comparisons not covered by existing tests (<=, >=, ==, !=)
+			eval('[1.0, 2.0] <= [1.0, 1.0];') == '[true, false]', &
+			eval('[2.0, 1.0] >= [1.0, 2.0];') == '[true, false]', &
+			eval('[1.0, 2.0] == [1.0, 3.0];') == '[true, false]', &
+			eval('[1.0, 2.0] != [1.0, 3.0];') == '[false, true]', &
+			.false.  &
+		]
+
+	tests = tests(1: size(tests) - 1)
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_arr_binop
 
 !===============================================================================
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -2936,6 +2936,7 @@ subroutine unit_test_array_i32_2(npass, nfail)
 			interpret_file(path//'test-06.syntran', quiet) == '16', &
 			interpret_file(path//'test-07.syntran', quiet) == '13', &
 			interpret_file(path//'test-08.syntran', quiet) == 'true', &
+			interpret_file(path//'test-09.syntran', quiet) == '0', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -4844,6 +4844,7 @@ subroutine unit_tests(iostat)
 	call unit_test_pow_scalar  (npass, nfail)
 	call unit_test_mixed_i32i64(npass, nfail)
 	call unit_test_arr_binop   (npass, nfail)
+	call unit_test_deep_recursion(npass, nfail)
 
 	call log_test_summary(npass, nfail)
 	iostat = nfail
@@ -4999,6 +5000,51 @@ subroutine unit_test_arr_binop(npass, nfail)
 	call unit_test_coda(tests, label, npass, nfail)
 
 end subroutine unit_test_arr_binop
+
+!===============================================================================
+
+subroutine unit_test_deep_recursion(npass, nfail)
+
+	! Test that the VM's growable call-frame / for-iterator / loop-context stacks
+	! handle recursion and loop nesting well past their initial capacities.
+	! The initial caps are INIT_FRAMES_CAP=64 and INIT_FORS_CAP=16; these tests
+	! use depths large enough to trigger at least one doubling pass.
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'deep recursion / loop nesting (growable VM stacks)'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			! Recursion past INIT_FRAMES_CAP (64): sum_to(400) = 400*401/2 = 80200
+			eval('fn sum_to(n: i32): i32 { if n <= 0 { return 0; } return n + sum_to(n - 1); } sum_to(400);') == '80200', &
+			! Deeply nested for loops past INIT_FORS_CAP (16): 20 nested for loops,
+			! each iterating once ([0:1] = one iteration in Syntran bound_array).
+			! Body increments s; expect s == 1.
+			eval('let s = 0;' // &
+			     'for i0 in [0:1] { for i1 in [0:1] { for i2 in [0:1] { for i3 in [0:1] {' // &
+			     'for i4 in [0:1] { for i5 in [0:1] { for i6 in [0:1] { for i7 in [0:1] {' // &
+			     'for i8 in [0:1] { for i9 in [0:1] { for i10 in [0:1] { for i11 in [0:1] {' // &
+			     'for i12 in [0:1] { for i13 in [0:1] { for i14 in [0:1] { for i15 in [0:1] {' // &
+			     'for i16 in [0:1] { for i17 in [0:1] { for i18 in [0:1] { for i19 in [0:1] {' // &
+			     's = s + 1; }}}}}}}}}}}}}}}}}}}}' // &
+			     's;') == '1', &
+			.false.  &
+		]
+
+	tests = tests(1: size(tests) - 1)
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_deep_recursion
 
 !===============================================================================
 

--- a/src/types.f90
+++ b/src/types.f90
@@ -47,8 +47,10 @@ module syntran__types_m
 		integer :: intr_id = 0
 
 		contains
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => fn_copy
 			generic, public :: assignment(=) => copy
+#endif
 
 	end type fn_t
 
@@ -63,8 +65,10 @@ module syntran__types_m
 		integer :: id_index
 
 		contains
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => fn_ternary_tree_copy
 			generic, public :: assignment(=) => copy
+#endif
 
 	end type fn_ternary_tree_node_t
 
@@ -202,8 +206,10 @@ module syntran__types_m
 
 		contains
 			!procedure :: print => ternary_node_print
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => ternary_tree_copy
 			generic, public :: assignment(=) => copy
+#endif
 
 	end type ternary_tree_node_t
 
@@ -239,8 +245,10 @@ module syntran__types_m
 				push_scope, pop_scope
 
 			! This is required unfortunately
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => vars_copy
 			generic, public :: assignment(=) => copy
+#endif
 
 	end type vars_t
 
@@ -257,8 +265,10 @@ module syntran__types_m
 
 		contains
 			! This is also required unfortunately
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => struct_copy
 			generic, public :: assignment(=) => copy
+#endif
 
 	end type struct_t
 
@@ -274,8 +284,10 @@ module syntran__types_m
 
 		contains
 			! This is also required unfortunately too
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => struct_ternary_tree_copy
 			generic, public :: assignment(=) => copy
+#endif
 			!final :: struct_ternary_tree_final
 
 	end type struct_ternary_tree_node_t
@@ -322,8 +334,10 @@ module syntran__types_m
 		integer :: len_, cap
 		contains
 			procedure :: push => push_node
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => syntax_node_vector_copy
 			generic, public :: assignment(=) => copy
+#endif
 	end type syntax_node_vector_t
 
 !===============================================================================

--- a/src/types.f90
+++ b/src/types.f90
@@ -679,11 +679,11 @@ module syntran__types_m
 			type(syntax_node_t) , intent(out) :: expr
 		end subroutine new_declaration_expr
 
-		module function new_name_expr(identifier, val) result(expr)
+		module subroutine new_name_expr(identifier, val, expr)
 			type(syntax_token_t), intent(in) :: identifier
-			type(value_t) :: val
-			type(syntax_node_t) :: expr
-		end function new_name_expr
+			type(value_t)                    :: val
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_name_expr
 
 		module subroutine new_binary_expr(left, op, right, expr)
 			type(syntax_node_t) , intent(inout) :: left, right
@@ -697,35 +697,35 @@ module syntran__types_m
 			type(syntax_node_t) , intent(out)   :: expr
 		end subroutine new_unary_expr
 
-		module function new_bool(bool) result(expr)
-			logical, intent(in) :: bool
-			type(syntax_node_t) :: expr
-		end function new_bool
+		module subroutine new_bool(bool, expr)
+			logical            , intent(in)  :: bool
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_bool
 
-		module function new_f32(f32) result(expr)
-			real(kind = 4), intent(in) :: f32
-			type(syntax_node_t) :: expr
-		end function new_f32
+		module subroutine new_f32(f32, expr)
+			real(kind = 4)     , intent(in)  :: f32
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_f32
 
-		module function new_f64(f64) result(expr)
-			real(kind = 8), intent(in) :: f64
-			type(syntax_node_t) :: expr
-		end function new_f64
+		module subroutine new_f64(f64, expr)
+			real(kind = 8)     , intent(in)  :: f64
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_f64
 
-		module function new_i32(i32) result(expr)
-			integer(kind = 4), intent(in) :: i32
-			type(syntax_node_t) :: expr
-		end function new_i32
+		module subroutine new_i32(i32, expr)
+			integer(kind = 4)  , intent(in)  :: i32
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_i32
 
-		module function new_i64(i64) result(expr)
-			integer(kind = 8), intent(in) :: i64
-			type(syntax_node_t) :: expr
-		end function new_i64
+		module subroutine new_i64(i64, expr)
+			integer(kind = 8)  , intent(in)  :: i64
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_i64
 
-		module function new_str(str_) result(expr)
-			character(len = *), intent(in) :: str_
-			type(syntax_node_t) :: expr
-		end function new_str
+		module subroutine new_str(str_, expr)
+			character(len = *) , intent(in)  :: str_
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine new_str
 
 	end interface
 

--- a/src/types.f90
+++ b/src/types.f90
@@ -43,6 +43,9 @@ module syntran__types_m
 
 		logical :: is_intr = .true.
 
+		! M6: integer dispatch id for intrinsic fns (0 = unassigned / user fn)
+		integer :: intr_id = 0
+
 		contains
 			procedure, pass(dst) :: copy => fn_copy
 			generic, public :: assignment(=) => copy

--- a/src/types.f90
+++ b/src/types.f90
@@ -333,7 +333,8 @@ module syntran__types_m
 		type(syntax_node_t), allocatable :: v(:)
 		integer :: len_, cap
 		contains
-			procedure :: push => push_node
+			procedure :: push      => push_node
+			procedure :: push_move => push_node_move
 #ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => syntax_node_vector_copy
 			generic, public :: assignment(=) => copy
@@ -379,6 +380,15 @@ module syntran__types_m
 			class(syntax_node_t), intent(inout) :: dst
 			class(syntax_node_t), intent(in)    :: src
 		end subroutine syntax_node_copy
+
+		recursive module subroutine syntax_node_move(src, dst)
+			type(syntax_node_t), intent(inout)            :: src
+			type(syntax_node_t), allocatable, intent(out) :: dst
+		end subroutine syntax_node_move
+
+		recursive module subroutine syntax_node_move_into(src, dst)
+			type(syntax_node_t), intent(inout) :: src, dst
+		end subroutine syntax_node_move_into
 
 		recursive module subroutine ternary_tree_copy(dst, src)
 			class(ternary_tree_node_t), intent(inout) :: dst
@@ -450,6 +460,11 @@ module syntran__types_m
 			class(syntax_node_vector_t) :: vector
 			type(syntax_node_t) :: val
 		end subroutine push_node
+
+		module subroutine push_node_move(vector, val)
+			class(syntax_node_vector_t) :: vector
+			type(syntax_node_t), intent(inout) :: val
+		end subroutine push_node_move
 
 		recursive module subroutine ternary_search(node, key, id_index, iostat, val)
 			type(ternary_tree_node_t), intent(in), allocatable :: node
@@ -658,11 +673,11 @@ module syntran__types_m
 			type(value_t) :: val
 		end function new_literal_value
 
-		module function new_declaration_expr(identifier, op, right) result(expr)
+		module subroutine new_declaration_expr(identifier, op, right, expr)
 			type(syntax_token_t), intent(in) :: identifier, op
-			type(syntax_node_t), intent(in) :: right
-			type(syntax_node_t) :: expr
-		end function new_declaration_expr
+			type(syntax_node_t) , intent(in) :: right
+			type(syntax_node_t) , intent(out) :: expr
+		end subroutine new_declaration_expr
 
 		module function new_name_expr(identifier, val) result(expr)
 			type(syntax_token_t), intent(in) :: identifier
@@ -670,17 +685,17 @@ module syntran__types_m
 			type(syntax_node_t) :: expr
 		end function new_name_expr
 
-		module function new_binary_expr(left, op, right) result(expr)
-			type(syntax_node_t), intent(in) :: left, right
-			type(syntax_token_t), intent(in) :: op
-			type(syntax_node_t) :: expr
-		end function new_binary_expr
+		module subroutine new_binary_expr(left, op, right, expr)
+			type(syntax_node_t) , intent(inout) :: left, right
+			type(syntax_token_t), intent(in)    :: op
+			type(syntax_node_t) , intent(out)   :: expr
+		end subroutine new_binary_expr
 
-		module function new_unary_expr(op, right) result(expr)
-			type(syntax_node_t), intent(in) :: right
-			type(syntax_token_t), intent(in) :: op
-			type(syntax_node_t) :: expr
-		end function new_unary_expr
+		module subroutine new_unary_expr(op, right, expr)
+			type(syntax_node_t) , intent(inout) :: right
+			type(syntax_token_t), intent(in)    :: op
+			type(syntax_node_t) , intent(out)   :: expr
+		end subroutine new_unary_expr
 
 		module function new_bool(bool) result(expr)
 			logical, intent(in) :: bool

--- a/src/types_copy.f90
+++ b/src/types_copy.f90
@@ -417,6 +417,150 @@ end subroutine syntax_node_copy
 
 !===============================================================================
 
+recursive module subroutine syntax_node_move(src, dst)
+
+	! Move src into dst (freshly allocated).  Transfers all allocatable
+	! components from src to dst via move_alloc (O(1) for node arrays/strings)
+	! and value_move for the val member.  After return, src's allocatables are
+	! unallocated; scalars are undefined.  Mirrors value_move() in value.f90.
+	!
+	! dst is allocatable so callers can pass unallocated allocatable components
+	! (e.g. expr%right) without pre-allocating.
+
+	type(syntax_node_t), intent(inout)            :: src
+	type(syntax_node_t), allocatable, intent(out) :: dst
+
+	!********
+
+	allocate(dst)
+
+	! POD scalars
+	dst%kind            = src%kind
+	dst%op              = src%op
+	dst%identifier      = src%identifier
+	dst%id_index        = src%id_index
+	dst%num_locs        = src%num_locs
+	dst%is_loc          = src%is_loc
+	dst%sub_kind        = src%sub_kind
+	dst%is_empty        = src%is_empty
+	dst%expecting       = src%expecting
+	dst%first_expecting = src%first_expecting
+
+	! diagnostics: move the internal array, copy scalars
+	call move_alloc(src%diagnostics%v, dst%diagnostics%v)
+	dst%diagnostics%len_ = src%diagnostics%len_
+	dst%diagnostics%cap  = src%diagnostics%cap
+
+	! value_t member
+	call value_move(src%val, dst%val)
+
+	! Allocatable strings
+	call move_alloc(src%struct_name,    dst%struct_name)
+	call move_alloc(src%module_prefix,  dst%module_prefix)
+	call move_alloc(src%first_expected, dst%first_expected)
+
+	! Allocatable primitive arrays
+	call move_alloc(src%params, dst%params)
+	call move_alloc(src%is_ref, dst%is_ref)
+
+	! Scalar allocatable node children
+	call move_alloc(src%left,        dst%left)
+	call move_alloc(src%right,       dst%right)
+	call move_alloc(src%condition,   dst%condition)
+	call move_alloc(src%if_clause,   dst%if_clause)
+	call move_alloc(src%else_clause, dst%else_clause)
+	call move_alloc(src%body,        dst%body)
+	call move_alloc(src%array,       dst%array)
+	call move_alloc(src%member,      dst%member)
+	call move_alloc(src%lbound,      dst%lbound)
+	call move_alloc(src%step,        dst%step)
+	call move_alloc(src%ubound,      dst%ubound)
+	call move_alloc(src%len_,        dst%len_)
+	call move_alloc(src%rank,        dst%rank)
+
+	! Array allocatable node children
+	call move_alloc(src%members,     dst%members)
+	call move_alloc(src%elems,       dst%elems)
+	call move_alloc(src%lsubscripts, dst%lsubscripts)
+	call move_alloc(src%usubscripts, dst%usubscripts)
+	call move_alloc(src%ssubscripts, dst%ssubscripts)
+	call move_alloc(src%args,        dst%args)
+	call move_alloc(src%size,        dst%size)
+
+end subroutine syntax_node_move
+
+!===============================================================================
+
+recursive module subroutine syntax_node_move_into(src, dst)
+
+	! Like syntax_node_move but dst is non-allocatable (already associated with
+	! storage).  Overwrites dst's scalar fields and move_allocs all allocatable
+	! components (move_alloc handles deallocation of dst's existing allocatables
+	! before the transfer).  Used where dst is a non-allocatable variable that
+	! needs to receive a new value without a deep copy, e.g. the accumulator in
+	! the binary operator loop in parse_expr.
+
+	type(syntax_node_t), intent(inout) :: src, dst
+
+	!********
+
+	! POD scalars
+	dst%kind            = src%kind
+	dst%op              = src%op
+	dst%identifier      = src%identifier
+	dst%id_index        = src%id_index
+	dst%num_locs        = src%num_locs
+	dst%is_loc          = src%is_loc
+	dst%sub_kind        = src%sub_kind
+	dst%is_empty        = src%is_empty
+	dst%expecting       = src%expecting
+	dst%first_expecting = src%first_expecting
+
+	! diagnostics: move the internal array, copy scalars
+	call move_alloc(src%diagnostics%v, dst%diagnostics%v)
+	dst%diagnostics%len_ = src%diagnostics%len_
+	dst%diagnostics%cap  = src%diagnostics%cap
+
+	! value_t member
+	call value_move(src%val, dst%val)
+
+	! Allocatable strings
+	call move_alloc(src%struct_name,    dst%struct_name)
+	call move_alloc(src%module_prefix,  dst%module_prefix)
+	call move_alloc(src%first_expected, dst%first_expected)
+
+	! Allocatable primitive arrays
+	call move_alloc(src%params, dst%params)
+	call move_alloc(src%is_ref, dst%is_ref)
+
+	! Scalar allocatable node children
+	call move_alloc(src%left,        dst%left)
+	call move_alloc(src%right,       dst%right)
+	call move_alloc(src%condition,   dst%condition)
+	call move_alloc(src%if_clause,   dst%if_clause)
+	call move_alloc(src%else_clause, dst%else_clause)
+	call move_alloc(src%body,        dst%body)
+	call move_alloc(src%array,       dst%array)
+	call move_alloc(src%member,      dst%member)
+	call move_alloc(src%lbound,      dst%lbound)
+	call move_alloc(src%step,        dst%step)
+	call move_alloc(src%ubound,      dst%ubound)
+	call move_alloc(src%len_,        dst%len_)
+	call move_alloc(src%rank,        dst%rank)
+
+	! Array allocatable node children
+	call move_alloc(src%members,     dst%members)
+	call move_alloc(src%elems,       dst%elems)
+	call move_alloc(src%lsubscripts, dst%lsubscripts)
+	call move_alloc(src%usubscripts, dst%usubscripts)
+	call move_alloc(src%ssubscripts, dst%ssubscripts)
+	call move_alloc(src%args,        dst%args)
+	call move_alloc(src%size,        dst%size)
+
+end subroutine syntax_node_move_into
+
+!===============================================================================
+
 recursive module subroutine ternary_tree_copy(dst, src)
 
 	! Deep copy.  This overwrites dst with src.  If dst had keys that weren't in

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -244,7 +244,7 @@ module subroutine push_token(vector, val)
 
 		tmp_cap = 2 * vector%len_
 		allocate(tmp( tmp_cap ))
-		tmp(1: vector%cap) = vector%v
+		if (vector%cap > 0) tmp(1: vector%cap) = vector%v
 
 		call move_alloc(tmp, vector%v)
 		vector%cap = tmp_cap

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -271,42 +271,51 @@ module subroutine push_node(vector, val)
 	vector%len_ = vector%len_ + 1
 
 	if (vector%len_ > vector%cap) then
-		!print *, 'growing vector ====================================='
-
 		tmp_cap = 2 * vector%len_
-		allocate(tmp( tmp_cap ))
-
-		!print *, 'copy 1'
-		!!tmp(1: vector%cap) = vector%v
+		allocate(tmp(tmp_cap))
 		do i = 1, vector%cap
 			tmp(i) = vector%v(i)
 		end do
-
-		!print *, 'move'
-		!!call move_alloc(tmp, vector%v)
-
 		deallocate(vector%v)
-		allocate(vector%v( tmp_cap ))
-
-		! Unfortunately we have to copy TO tmp AND back FROM tmp.  I guess the
-		! fact that each node itself has allocatable members creates invalid
-		! references otherwise.
-
-		!print *, 'copy 2'
-		!!vector%v(1: vector%cap) = tmp(1: vector%cap)
+		allocate(vector%v(tmp_cap))
 		do i = 1, vector%cap
 			vector%v(i) = tmp(i)
 		end do
-
 		vector%cap = tmp_cap
-
 	end if
 
-	!print *, 'set val'
-	vector%v( vector%len_ ) = val
-	!print *, 'done push_node'
+	vector%v(vector%len_) = val
 
 end subroutine push_node
+
+!===============================================================================
+
+module subroutine push_node_move(vector, val)
+
+	class(syntax_node_vector_t) :: vector
+	type(syntax_node_t), intent(inout) :: val
+
+	!********
+
+	type(syntax_node_t), allocatable :: tmp(:)
+
+	integer :: tmp_cap, i
+
+	vector%len_ = vector%len_ + 1
+
+	if (vector%len_ > vector%cap) then
+		tmp_cap = 2 * vector%len_
+		allocate(tmp(tmp_cap))
+		do i = 1, vector%cap
+			call syntax_node_move_into(vector%v(i), tmp(i))
+		end do
+		call move_alloc(tmp, vector%v)
+		vector%cap = tmp_cap
+	end if
+
+	call syntax_node_move_into(val, vector%v(vector%len_))
+
+end subroutine push_node_move
 
 !===============================================================================
 

--- a/src/types_node.f90
+++ b/src/types_node.f90
@@ -76,7 +76,10 @@ module function new_literal_value(type, bool, i32, i64, f32, f64, str_) result(v
 	if (present(f64 )) val%sca%f64   = f64
 	if (present(i32 )) val%sca%i32   = i32
 	if (present(i64 )) val%sca%i64   = i64
-	if (present(str_)) val%sca%str%s = str_
+	if (present(str_)) then
+		allocate(val%str)
+		val%str%s = str_
+	end if
 
 end function new_literal_value
 

--- a/src/types_node.f90
+++ b/src/types_node.f90
@@ -117,24 +117,17 @@ end subroutine new_declaration_expr
 
 !===============================================================================
 
-module function new_name_expr(identifier, val) result(expr)
+module subroutine new_name_expr(identifier, val, expr)
 
-	type(syntax_token_t), intent(in) :: identifier
-	type(syntax_node_t) :: expr
-	type(value_t) :: val
+	type(syntax_token_t), intent(in)  :: identifier
+	type(value_t)                     :: val
+	type(syntax_node_t), intent(out)  :: expr
 
 	expr%kind = name_expr
 	expr%identifier = identifier
 	expr%val = val
 
-	!if (expr%val%type == array_type) then
-	!	!if (.not. allocated(expr%val%array)) allocate(expr%val%array)
-	!	allocate(expr%val%array)
-	!	!expr%val%array = right%val%array
-	!	expr%val%array = val%array
-	!end if
-
-end function new_name_expr
+end subroutine new_name_expr
 
 !===============================================================================
 
@@ -232,77 +225,75 @@ end subroutine new_unary_expr
 
 !===============================================================================
 
-module function new_bool(bool) result(expr)
+module subroutine new_bool(bool, expr)
 
-	logical, intent(in) :: bool
-	type(syntax_node_t) :: expr
+	logical            , intent(in)  :: bool
+	type(syntax_node_t), intent(out) :: expr
 
-	! The expression node is a generic literal expression, while its child val
-	! member indicates the specific type (e.g. bool_type or i32_type)
 	expr%kind = literal_expr
 	expr%val = new_literal_value(bool_type, bool = bool)
 
-end function new_bool
+end subroutine new_bool
 
 !********
 
-module function new_f32(f32) result(expr)
+module subroutine new_f32(f32, expr)
 
-	real(kind = 4), intent(in) :: f32
-	type(syntax_node_t) :: expr
+	real(kind = 4)     , intent(in)  :: f32
+	type(syntax_node_t), intent(out) :: expr
 
 	expr%kind = literal_expr
 	expr%val  = new_literal_value(f32_type, f32 = f32)
 
-end function new_f32
+end subroutine new_f32
 
 !********
 
-module function new_f64(f64) result(expr)
+module subroutine new_f64(f64, expr)
 
-	real(kind = 8), intent(in) :: f64
-	type(syntax_node_t) :: expr
+	real(kind = 8)     , intent(in)  :: f64
+	type(syntax_node_t), intent(out) :: expr
 
 	expr%kind = literal_expr
 	expr%val  = new_literal_value(f64_type, f64 = f64)
 
-end function new_f64
+end subroutine new_f64
 
 !********
 
-module function new_i32(i32) result(expr)
+module subroutine new_i32(i32, expr)
 
-	integer(kind = 4), intent(in) :: i32
-	type(syntax_node_t) :: expr
+	integer(kind = 4)  , intent(in)  :: i32
+	type(syntax_node_t), intent(out) :: expr
 
 	expr%kind = literal_expr
 	expr%val  = new_literal_value(i32_type, i32 = i32)
 
-end function new_i32
+end subroutine new_i32
 
 !********
 
-module function new_i64(i64) result(expr)
+module subroutine new_i64(i64, expr)
 
-	integer(kind = 8), intent(in) :: i64
-	type(syntax_node_t) :: expr
+	integer(kind = 8)  , intent(in)  :: i64
+	type(syntax_node_t), intent(out) :: expr
 
 	expr%kind = literal_expr
 	expr%val  = new_literal_value(i64_type, i64 = i64)
 
-end function new_i64
+end subroutine new_i64
 
 !********
 
-module function new_str(str_) result(expr)
+module subroutine new_str(str_, expr)
 
-	character(len = *), intent(in) :: str_
-	type(syntax_node_t) :: expr
+	character(len = *) , intent(in)  :: str_
+	type(syntax_node_t), intent(out) :: expr
 
 	expr%kind = literal_expr
 	expr%val  = new_literal_value(str_type, str_ = str_)
 
-end function new_str
+end subroutine new_str
 
 !===============================================================================
 

--- a/src/types_node.f90
+++ b/src/types_node.f90
@@ -48,10 +48,14 @@ module function new_syntax_token_vector() result(vector)
 
 	type(syntax_token_vector_t) :: vector
 
+	! cap=0 / no pre-allocation: ifort (following the standard) calls value_copy
+	! via defined assignment when copying the vector result, passing uninitialized
+	! v(:)%val as class(value_t) src — which ifort rejects.  gfortran uses a
+	! bitwise copy and never invokes the defined assignment for array components,
+	! so the bug is ifort-only.  Starting unallocated means there is nothing to
+	! copy and value_copy is never called with uninitialized data.
 	vector%len_ = 0
-	vector%cap = 2  ! I think a small default makes sense here
-
-	allocate(vector%v( vector%cap ))
+	vector%cap = 0
 
 end function new_syntax_token_vector
 

--- a/src/types_node.f90
+++ b/src/types_node.f90
@@ -89,7 +89,7 @@ end function new_literal_value
 
 !===============================================================================
 
-module function new_declaration_expr(identifier, op, right) result(expr)
+module subroutine new_declaration_expr(identifier, op, right, expr)
 
 	! TODO: IMO this fn is overly abstracted.  It's only used once, so
 	! just paste it their and delete the fn.  That will make it easier to
@@ -97,8 +97,7 @@ module function new_declaration_expr(identifier, op, right) result(expr)
 
 	type(syntax_token_t), intent(in) :: identifier, op
 	type(syntax_node_t) , intent(in) :: right
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t) , intent(out) :: expr
 
 	!********
 
@@ -114,14 +113,7 @@ module function new_declaration_expr(identifier, op, right) result(expr)
 	! Pass the result value type up the tree for type checking in parent
 	expr%val = right%val
 
-	!expr%val%type = right%val%type
-	!if (expr%val%type == array_type) then
-	!	!print *, 'new_declaration_expr array_type'
-	!	allocate(expr%val%array)
-	!	expr%val%array = right%val%array
-	!end if
-
-end function new_declaration_expr
+end subroutine new_declaration_expr
 
 !===============================================================================
 
@@ -146,12 +138,11 @@ end function new_name_expr
 
 !===============================================================================
 
-module function new_binary_expr(left, op, right) result(expr)
+module subroutine new_binary_expr(left, op, right, expr)
 
-	type(syntax_node_t) , intent(in) :: left, right
-	type(syntax_token_t), intent(in) :: op
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t) , intent(inout) :: left, right  ! consumed by move
+	type(syntax_token_t), intent(in)    :: op
+	type(syntax_node_t) , intent(out)   :: expr
 
 	!********
 
@@ -162,26 +153,19 @@ module function new_binary_expr(left, op, right) result(expr)
 	if (debug > 1) print *, 'op    = ', op%text
 	if (debug > 1) print *, 'right = ', right%str()
 
-	expr%kind = binary_expr
-
-	allocate(expr%left)
-	allocate(expr%right)
-
-	expr%left  = left
-	expr%op    = op
-	expr%right = right
-
-	!print *, 'left type  = ', kind_name(left%val%type)
-
+	! Read type info before moves (left/right val%array may be moved)
 	larrtype = unknown_type
 	rarrtype = unknown_type
 	if (left %val%type == array_type) larrtype = left %val%array%type
 	if (right%val%type == array_type) rarrtype = right%val%array%type
-
-	!print *, 'larrtype = ', kind_name(larrtype)
-
 	ltype = left%val%type
 	rtype = right%val%type
+
+	expr%kind = binary_expr
+	expr%op   = op
+
+	call syntax_node_move(left,  expr%left)
+	call syntax_node_move(right, expr%right)
 
 	! Pass the result value type up the tree for type checking in parent
 	type_ = get_binary_op_kind(ltype, op%kind, rtype, &
@@ -194,10 +178,10 @@ module function new_binary_expr(left, op, right) result(expr)
 		allocate(expr%val%array)
 
 		expr%val%array%type = array_to_scalar_type(type_)
-		if (left%val%type == array_type) then
-			expr%val%array%rank = left %val%array%rank
+		if (ltype == array_type) then
+			expr%val%array%rank = expr%left%val%array%rank
 		else
-			expr%val%array%rank = right%val%array%rank
+			expr%val%array%rank = expr%right%val%array%rank
 		end if
 
 		expr%val%type = array_type
@@ -216,39 +200,35 @@ module function new_binary_expr(left, op, right) result(expr)
 	if (debug > 1) print *, 'new_binary_expr = ', expr%str()
 	if (debug > 1) print *, 'done new_binary_expr'
 
-end function new_binary_expr
+end subroutine new_binary_expr
 
 !===============================================================================
 
-module function new_unary_expr(op, right) result(expr)
+module subroutine new_unary_expr(op, right, expr)
 
-	type(syntax_node_t) , intent(in) :: right
-	type(syntax_token_t), intent(in) :: op
-
-	type(syntax_node_t) :: expr
+	type(syntax_node_t) , intent(inout) :: right   ! consumed by move
+	type(syntax_token_t), intent(in)    :: op
+	type(syntax_node_t) , intent(out)   :: expr
 
 	!********
 
 	if (debug > 1) print *, 'new_unary_expr'
 
 	expr%kind = unary_expr
+	expr%op   = op
 
-	allocate(expr%right)
-
-	expr%op    = op
-	expr%right = right
+	call syntax_node_move(right, expr%right)
 
 	! Pass the result value type up the tree for type checking in parent.  IIRC
 	! all unary operators result in the same type as their operand, hence there
 	! is a get_binary_op_kind() fn but no get_unary_op_kind() fn
 
-	expr%val = right%val
-	!expr%val%type = right%val%type
+	expr%val = expr%right%val
 
 	if (debug > 1) print *, 'new_unary_expr = ', expr%str()
 	if (debug > 1) print *, 'done new_unary_expr'
 
-end function new_unary_expr
+end subroutine new_unary_expr
 
 !===============================================================================
 

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -32,6 +32,7 @@ module syntran__utils_m
 			FG_BRIGHT_MAGENTA_  = esc//'[95m', &
 			FG_BRIGHT_CYAN_     = esc//'[96m', &
 			FG_BRIGHT_WHITE_    = esc//'[97m', &
+			FG_BOLD_YELLOW_     = esc//'[1;33m', &
 			COLOR_RESET_        = esc//'[0m'
 
 	! Either copies of the above or empty strings, depending on `--color` arg
@@ -45,6 +46,7 @@ module syntran__utils_m
 			fg_bright_magenta, &
 			fg_bright_cyan, &
 			fg_bright_white, &
+			fg_bold_yellow, &
 			color_reset
 
 	!********

--- a/src/value.f90
+++ b/src/value.f90
@@ -323,7 +323,7 @@ recursive subroutine value_copy(dst, src)
 	! Args have to be in the confusing dst, src order for overloading
 
 	class(value_t), intent(inout) :: dst
-	class(value_t), intent(in)    :: src
+	type(value_t),  intent(in)    :: src
 
 	!********
 

--- a/src/value.f90
+++ b/src/value.f90
@@ -126,8 +126,10 @@ module syntran__value_m
 			procedure :: to_i64 => value_to_i64
 			procedure :: to_i32_array => value_to_i32_array  ! for user-facing casting fn
 			procedure :: to_i64_array => value_to_i64_array
+#ifndef SYNTRAN_INTEL
 			procedure, pass(dst) :: copy => value_copy
 			generic, public :: assignment(=) => copy
+#endif
 
 	end type value_t
 

--- a/src/value.f90
+++ b/src/value.f90
@@ -33,10 +33,10 @@ module syntran__value_m
 
 	type scalar_t
 
-		! Scalar value type.  Cannot be an array!
-
-		type(file_t)      :: file_
-		type(string_t)    :: str
+		! Scalar value type for numeric/bool values.  Cannot be an array!
+		! String and file values are stored in value_t%str / value_t%file_
+		! so that this type is a plain POD — copies are cheap (no allocatable
+		! components).
 
 		logical           :: bool
 		integer(kind = 4) :: i32
@@ -89,7 +89,16 @@ module syntran__value_m
 	type value_t
 		integer :: type = unknown_type
 
+		! Numeric/bool scalars.  scalar_t is a plain POD (no allocatable
+		! components) so copying it is cheap.  str_ and file types are
+		! handled by the allocatable components below.
 		type(scalar_t) :: sca
+
+		! String and file values — moved out of scalar_t so that scalar_t
+		! (and therefore sca copies) are POD-cheap.  Only allocated when
+		! value%type == str_type or file_type respectively.
+		type(string_t), allocatable :: str
+		type(file_t  ), allocatable :: file_
 
 		! Back when array_t could contain value_t's, gfortran would use up infinite
 		! RAM trying to parse the circular type dependencies unless this was a
@@ -126,7 +135,8 @@ module syntran__value_m
 		type(value_t), allocatable :: v(:)
 		integer :: len_, cap
 		contains
-			procedure :: push => push_value
+			procedure :: push      => push_value
+			procedure :: push_move => push_value_move
 	end type value_vector_t
 
 !===============================================================================
@@ -140,7 +150,7 @@ function new_value_vector() result(vector)
 	type(value_vector_t) :: vector
 
 	vector%len_ = 0
-	vector%cap = 2  ! I think a small default makes sense here
+	vector%cap = 64  ! Large enough to avoid growth churn in hot loops
 
 	allocate(vector%v( vector%cap ))
 
@@ -149,6 +159,8 @@ end function new_value_vector
 !===============================================================================
 
 subroutine push_value(vector, val)
+
+	! Push a deep copy of val onto the stack.
 
 	class(value_vector_t) :: vector
 	type(value_t) :: val
@@ -162,42 +174,56 @@ subroutine push_value(vector, val)
 	vector%len_ = vector%len_ + 1
 
 	if (vector%len_ > vector%cap) then
-		!print *, 'growing vector ====================================='
-
 		tmp_cap = 2 * vector%len_
 		allocate(tmp( tmp_cap ))
-
-		!print *, 'copy 1'
-		!!tmp(1: vector%cap) = vector%v
+		! Move existing elements into tmp (cheap: move_alloc for arrays/structs).
+		! After each value_move, vector%v(i) has its allocatable components cleared,
+		! making the subsequent move_alloc safe.
 		do i = 1, vector%cap
-			tmp(i) = vector%v(i)
+			call value_move(vector%v(i), tmp(i))
 		end do
-
-		!print *, 'move'
-		!!call move_alloc(tmp, vector%v)
-
-		deallocate(vector%v)
-		allocate(vector%v( tmp_cap ))
-
-		! Unfortunately we have to copy TO tmp AND back FROM tmp.  I guess the
-		! fact that each node itself has allocatable members creates invalid
-		! references otherwise.
-
-		!print *, 'copy 2'
-		!!vector%v(1: vector%cap) = tmp(1: vector%cap)
-		do i = 1, vector%cap
-			vector%v(i) = tmp(i)
-		end do
-
+		! Replace vector%v with the new larger allocation in one descriptor swap.
+		call move_alloc(tmp, vector%v)
 		vector%cap = tmp_cap
-
 	end if
 
-	!print *, 'set val'
-	vector%v( vector%len_ ) = val
-	!print *, 'done push_value'
+	vector%v( vector%len_ ) = val   ! deep copy: source (val) must stay live
 
 end subroutine push_value
+
+!===============================================================================
+
+subroutine push_value_move(vector, val)
+
+	! Push val onto the stack by moving it (consuming val).
+	! Used for freshly computed temporaries that have no other live references
+	! (e.g. binop results, intrinsic return values).  Avoids the deep copy in
+	! push_value; for array/struct values this is O(1) instead of O(n).
+
+	class(value_vector_t) :: vector
+	type(value_t), intent(inout) :: val   ! consumed; undefined after return
+
+	!********
+
+	type(value_t), allocatable :: tmp(:)
+
+	integer :: tmp_cap, i
+
+	vector%len_ = vector%len_ + 1
+
+	if (vector%len_ > vector%cap) then
+		tmp_cap = 2 * vector%len_
+		allocate(tmp( tmp_cap ))
+		do i = 1, vector%cap
+			call value_move(vector%v(i), tmp(i))
+		end do
+		call move_alloc(tmp, vector%v)
+		vector%cap = tmp_cap
+	end if
+
+	call value_move(val, vector%v( vector%len_ ))
+
+end subroutine push_value_move
 
 !===============================================================================
 
@@ -264,17 +290,23 @@ recursive subroutine value_move(src, dst)
 	select case (src%type)
 	case (array_type)
 		call move_alloc(src%array, dst%array)
+		! Struct arrays also use struct(:) for elements and struct_name for type tag.
+		if (allocated(src%struct)) call move_alloc(src%struct, dst%struct)
+		if (allocated(src%struct_name)) call move_alloc(src%struct_name, dst%struct_name)
 
 	case (struct_type)
 		call move_alloc(src%struct_name, dst%struct_name)
 		call move_alloc(src%struct, dst%struct)
 
+	case (str_type)
+		call move_alloc(src%str, dst%str)
+
+	case (file_type)
+		call move_alloc(src%file_, dst%file_)
+
 	case default
-		! This copy (not move) could be inefficient for large string scalars.
-		! Might be worth making value%sca allocatable if it doesn't add too much
-		! complexity.  Otherwise, consider further selecting the case by each
-		! scalar type
-		dst%sca  = src%sca
+		! POD copy: scalar_t now contains only bool/i32/i64/f32/f64 — cheap.
+		dst%sca = src%sca
 
 	end select
 
@@ -300,7 +332,20 @@ recursive subroutine value_copy(dst, src)
 	if (debug > 3) print *, 'starting value_copy()'
 
 	dst%type = src%type
-	dst%sca  = src%sca
+	dst%sca  = src%sca   ! POD copy: bool/i32/i64/f32/f64 only — cheap
+
+	if (allocated(src%str)) then
+		dst%str = src%str   ! intrinsic assignment handles allocatable char
+	else if (allocated(dst%str)) then
+		deallocate(dst%str)
+	end if
+
+	if (allocated(src%file_)) then
+		if (.not. allocated(dst%file_)) allocate(dst%file_)
+		dst%file_ = src%file_   ! copies all fields including name_ (alloc char)
+	else if (allocated(dst%file_)) then
+		deallocate(dst%file_)
+	end if
 
 	if (allocated(src%struct_name)) then
 		dst%struct_name = src%struct_name
@@ -445,7 +490,7 @@ subroutine push_array(vector, val)
 	case (bool_type)
 		vector%bool( vector%len_ ) = val%sca%bool
 	case (str_type)
-		vector%str ( vector%len_ ) = val%sca%str
+		vector%str ( vector%len_ ) = val%str
 	case default
 		write(*,*) err_int_prefix//'push_array type not implemented'
 		call internal_error()
@@ -587,8 +632,8 @@ function value_to_i32(val) result(ans)
 
 		case (str_type)
 
-			if (len(val%sca%str%s) == 1) then
-				ans = iachar(val%sca%str%s)
+			if (allocated(val%str) .and. len(val%str%s) == 1) then
+				ans = iachar(val%str%s)
 			else
 				write(*,*) err_int_prefix//'cannot convert from type `' &
 					//kind_name(val%type)//'` to i32.  Use `parse_i32()`'//color_reset
@@ -943,6 +988,22 @@ recursive function value_to_str(val) result(ans)
 
 			ans = str_vec%v( 1: str_vec%len_ )
 
+		case (str_type)
+			! TODO: wrap in quotes for clarity?  Would be a breaking change.
+			if (allocated(val%str)) then
+				ans = val%str%s
+			else
+				ans = ''
+			end if
+
+		case (file_type)
+			if (allocated(val%file_)) then
+				ans = "{file_unit: "//str(val%file_%unit_)//", filename: """// &
+					val%file_%name_//"""}"
+			else
+				ans = "{file_unit: <unset>}"
+			end if
+
 		case default
 			ans = val%sca%to_str(val%type)
 
@@ -993,15 +1054,6 @@ recursive function scalar_to_str(val, type) result(ans)
 
 		case (i64_type)
 			ans = i64_str(val%i64)
-
-		case (str_type)
-			! TODO: wrap str in quotes for clarity, both scalars and str array
-			! elements?  This would be a breaking change.  Update tests.
-			ans = val%str%s
-
-		case (file_type)
-			ans = "{file_unit: "//str(val%file_%unit_)//", filename: """// &
-				val%file_%name_//"""}"
 
 		case default
 			ans = err_prefix//"<invalid_value>"//color_reset

--- a/src/value.f90
+++ b/src/value.f90
@@ -303,7 +303,13 @@ recursive subroutine value_move(src, dst)
 	! build-in move_alloc() (and `mv file1 file2`)
 	!
 	! This is kind of a fake move.  Arrays and structs are moved, but primitive
-	! scalars are just copied
+	! scalars are just copied.
+	!
+	! Note: dst%type = src%type is set unconditionally first.  Callers (e.g.
+	! parse_expr.f90) may read src's type tag AFTER a move to this subroutine
+	! returns; that is safe because this routine does not clear src%type.
+	! src's allocatables are, however, cleared (moved to dst) for array/struct/
+	! str/file types.
 
 	type(value_t), intent(inout) :: src
 	type(value_t), intent(out)   :: dst
@@ -361,13 +367,16 @@ recursive subroutine value_copy(dst, src)
 	dst%type = src%type
 	dst%sca  = src%sca   ! POD copy: bool/i32/i64/f32/f64 only — cheap
 
-	if (allocated(src%str)) then
+	! Guard str/file_ copies on type, not just on allocated().  A reused stack
+	! slot may carry a stale allocatable from a prior value (different type); we
+	! must not propagate it to dst when the current type no longer uses it.
+	if (src%type == str_type .and. allocated(src%str)) then
 		dst%str = src%str   ! intrinsic assignment handles allocatable char
 	else if (allocated(dst%str)) then
 		deallocate(dst%str)
 	end if
 
-	if (allocated(src%file_)) then
+	if (src%type == file_type .and. allocated(src%file_)) then
 		if (.not. allocated(dst%file_)) allocate(dst%file_)
 		dst%file_ = src%file_   ! copies all fields including name_ (alloc char)
 	else if (allocated(dst%file_)) then

--- a/src/value.f90
+++ b/src/value.f90
@@ -273,6 +273,31 @@ end subroutine push_value_move
 
 !===============================================================================
 
+subroutine value_reset(val)
+
+	! Reset val to unknown_type, freeing any allocatable components.
+	! Used by the VM call-frame locals pool to clean up a reused slot.
+	! Fast path for primitive scalars (no allocatables to free).
+
+	type(value_t), intent(inout) :: val
+
+	select case (val%type)
+	case (bool_type, i32_type, i64_type, f32_type, f64_type)
+		! Scalar: nothing allocated, just clear the type tag.
+		val%type = unknown_type
+	case default
+		if (allocated(val%array     )) deallocate(val%array     )
+		if (allocated(val%str       )) deallocate(val%str       )
+		if (allocated(val%file_     )) deallocate(val%file_     )
+		if (allocated(val%struct    )) deallocate(val%struct    )
+		if (allocated(val%struct_name)) deallocate(val%struct_name)
+		val%type = unknown_type
+	end select
+
+end subroutine value_reset
+
+!===============================================================================
+
 recursive subroutine value_move(src, dst)
 	! Note the args are reversed wrt value_copy.  It is however consistent with
 	! build-in move_alloc() (and `mv file1 file2`)

--- a/src/vm.f90
+++ b/src/vm.f90
@@ -1,0 +1,35 @@
+
+!===============================================================================
+
+module syntran__vm_m
+
+	! Stack-based bytecode virtual machine.
+	!
+	! Module + submodule layout mirrors eval.f90 + eval_*.f90.
+	! Submodules:
+	!   vm_exec.f90  - main dispatch loop (vm_run)
+
+	use syntran__bytecode_m
+	use syntran__eval_m
+
+	implicit none
+
+!===============================================================================
+
+	interface
+
+		! Implemented in vm_exec.f90
+
+		module subroutine vm_run(prog, state, res)
+			type(program_t), intent(in) :: prog
+			type(state_t), intent(inout) :: state
+			type(value_t), intent(out) :: res
+		end subroutine
+
+	end interface
+
+!===============================================================================
+
+end module syntran__vm_m
+
+!===============================================================================

--- a/src/vm.f90
+++ b/src/vm.f90
@@ -26,6 +26,14 @@ module syntran__vm_m
 			type(value_t), intent(out) :: res
 		end subroutine
 
+		! Implemented in vm_intr.f90
+		module subroutine vm_call_intr(intr_id, nargs, args, state, res)
+			integer, intent(in) :: intr_id, nargs
+			type(value_t), intent(in) :: args(:)
+			type(state_t), intent(inout) :: state
+			type(value_t), intent(out) :: res
+		end subroutine
+
 	end interface
 
 !===============================================================================

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -5,7 +5,6 @@ submodule (syntran__vm_m) syntran__vm_exec
 
 	! Stack-based bytecode VM execution loop.
 	!
-	! M0: OP_EVAL_NODE fallback (delegates to syntax_eval; kept as debug opcode).
 	! M1: native handlers for scalars, loads/stores, binop, unop.
 	! M2: OP_JUMP / OP_JUMP_IF_FALSE for if/while/block/break/continue.
 	! M3: OP_CALL / OP_RET / OP_LOAD_REF_* for user-defined function frames.
@@ -90,20 +89,17 @@ end subroutine grow_frames
 subroutine grow_fors(for_iters)
 	! Double the for-iterator stack.  for_iter_t has no allocatable components
 	! at the top level (its value_t/array_t members have allocatables inside),
-	! so we use elementwise deep copy via the project's standard copy pattern.
+	! so assignment is used for each element.  Copies into the doubled buffer
+	! directly to avoid the extra round-trip through a same-sized tmp.
 	type(for_iter_t), allocatable, intent(inout) :: for_iters(:)
 	type(for_iter_t), allocatable :: tmp(:)
 	integer :: i, n
 	n = size(for_iters)
-	allocate(tmp(n))		! stage into a same-sized tmp first
+	allocate(tmp(2 * n))
 	do i = 1, n
 		tmp(i) = for_iters(i)
 	end do
-	deallocate(for_iters)
-	allocate(for_iters(2 * n))
-	do i = 1, n
-		for_iters(i) = tmp(i)
-	end do
+	call move_alloc(tmp, for_iters)
 end subroutine grow_fors
 
 !===============================================================================
@@ -446,9 +442,11 @@ module subroutine vm_run(prog, state, res)
 	integer :: id, type_, n_mem
 	integer(kind = 8) :: i8
 
-	! M6: temporary arg array for OP_CALL_INTR native dispatch
-	type(value_t), allocatable :: iargs(:)
-	integer :: nintr
+	! M6: reusable arg pool for OP_CALL_INTR native dispatch.
+	! Mirrors the params_pool/params_pool_cap pattern for OP_CALL; avoids
+	! allocate/deallocate on every intrinsic call.
+	type(value_t), allocatable :: iargs_pool(:)
+	integer :: iargs_pool_cap, nintr
 
 	! Call-frame stack (growable; no hard recursion limit)
 	type(frame_t), allocatable :: frames(:)
@@ -463,6 +461,7 @@ module subroutine vm_run(prog, state, res)
 	nframes         = 0
 	nfor            = 0
 	params_pool_cap = 0
+	iargs_pool_cap  = 0
 	stack           = new_value_vector()
 	allocate(frames(INIT_FRAMES_CAP))
 	allocate(for_iters(INIT_FORS_CAP))
@@ -476,60 +475,6 @@ module subroutine vm_run(prog, state, res)
 		associate(instr => prog%code(ip))
 
 		select case (instr%op)
-
-		! --- fallback: AST walker ---
-		case (OP_EVAL_NODE)
-			call syntax_eval(prog%nodes(instr%a), state, val)
-			call vm_push_move(stack, val)
-			if (state%returned) then
-				if (nframes > 0) then
-					! A return_statement executed inside an AST-walker fallback
-					! (e.g. a for loop) while we're inside a compiled function
-					! frame.  Perform the OP_RET cleanup inline so the frame is
-					! correctly unwound.
-					call vm_pop_copy(stack, val)   ! TOS = return value
-
-					! Move by-ref params back and restore caller locs
-					associate(fr => frames(nframes), &
-					          cn => prog%nodes(frames(nframes)%node_idx))
-					nparams = size(cn%params)
-					if (nparams > params_pool_cap) then
-						if (allocated(params_pool)) deallocate(params_pool)
-						allocate(params_pool(nparams))
-						params_pool_cap = nparams
-					end if
-					do i = 1, nparams
-						if (cn%is_ref(i)) then
-							call value_move(state%locs%vals(cn%params(i)), params_pool(i))
-						end if
-					end do
-					! Save callee locs to pool, then restore caller locs.
-					if (allocated(state%locs%vals)) then
-						call move_alloc(state%locs%vals, frames(nframes)%locs_buf)
-					end if
-					if (allocated(fr%caller_locs)) then
-						call move_alloc(fr%caller_locs, state%locs%vals)
-					end if
-					do i = 1, nparams
-						if (.not. cn%is_ref(i)) cycle
-						if (cn%args(i)%is_loc) then
-							call value_move(params_pool(i), &
-								state%locs%vals(cn%args(i)%id_index))
-						else
-							call value_move(params_pool(i), &
-								state%vars%vals(cn%args(i)%id_index))
-						end if
-					end do
-					next_ip = fr%return_ip
-					end associate
-					nframes = nframes - 1
-					state%returned = .false.
-					call vm_push_move(stack, val)
-				else
-					! Top-level return: exit the main VM loop.
-					next_ip = prog%len_ + 1
-				end if
-			end if
 
 		! --- constants and variable loads ---
 		case (OP_LOAD_CONST)
@@ -854,9 +799,15 @@ module subroutine vm_run(prog, state, res)
 		! readln/close: inline handling with slot writeback via instr%c.
 		case (OP_CALL_INTR)
 			nintr = instr%b
-			allocate(iargs(nintr))
+			! Grow the reusable iargs pool if needed (amortised; avoids
+			! allocate/deallocate on every intrinsic call).
+			if (nintr > iargs_pool_cap) then
+				if (allocated(iargs_pool)) deallocate(iargs_pool)
+				allocate(iargs_pool(nintr))
+				iargs_pool_cap = nintr
+			end if
 			do i = nintr, 1, -1
-				call vm_pop_copy(stack, iargs(i))
+				call vm_pop_copy(stack, iargs_pool(i))
 			end do
 
 			if (instr%a == INTR_READLN) then
@@ -866,19 +817,19 @@ module subroutine vm_run(prog, state, res)
 				logical :: is_loc_
 				slot_id_ = int(instr%c / 2)
 				is_loc_  = (mod(instr%c, 2_8) == 1_8)
-				if (.not. iargs(1)%file_%is_open) then
+				if (.not. iargs_pool(1)%file_%is_open) then
 					write(*,*) err_rt_prefix//'readln() was called for file "' &
-						//iargs(1)%file_%name_//'" which is not open'
+						//iargs_pool(1)%file_%name_//'" which is not open'
 					call internal_error()
 				end if
-				if (.not. iargs(1)%file_%mode_read) then
+				if (.not. iargs_pool(1)%file_%mode_read) then
 					write(*,*) err_rt_prefix//'readln() was called for file "' &
-						//iargs(1)%file_%name_//'" which was not opened in read mode "r"'
+						//iargs_pool(1)%file_%name_//'" which was not opened in read mode "r"'
 					call internal_error()
 				end if
 				val%type = str_type
 				if (.not. allocated(val%str)) allocate(val%str)
-				val%str%s = read_line(iargs(1)%file_%unit_, io_)
+				val%str%s = read_line(iargs_pool(1)%file_%unit_, io_)
 				if (io_ == iostat_end) then
 					if (is_loc_) then
 						state%locs%vals(slot_id_)%file_%eof = .true.
@@ -887,7 +838,7 @@ module subroutine vm_run(prog, state, res)
 					end if
 				else if (io_ /= 0 .and. io_ /= iostat_eor) then
 					write(*,*) err_rt_prefix//'cannot readln() from file "' &
-						//iargs(1)%file_%name_//'"'
+						//iargs_pool(1)%file_%name_//'"'
 					call internal_error()
 				end if
 				end block
@@ -899,9 +850,9 @@ module subroutine vm_run(prog, state, res)
 				logical :: is_loc_
 				slot_id_ = int(instr%c / 2)
 				is_loc_  = (mod(instr%c, 2_8) == 1_8)
-				if (.not. iargs(1)%file_%is_open) then
+				if (.not. iargs_pool(1)%file_%is_open) then
 					write(*,*) err_rt_prefix//'close() was called for file "' &
-						//iargs(1)%file_%name_//'" which is not open'
+						//iargs_pool(1)%file_%name_//'" which is not open'
 					call internal_error()
 				end if
 				if (is_loc_) then
@@ -909,15 +860,14 @@ module subroutine vm_run(prog, state, res)
 				else
 					state%vars%vals(slot_id_)%file_%is_open = .false.
 				end if
-				close(iargs(1)%file_%unit_)
+				close(iargs_pool(1)%file_%unit_)
 				val%type = unknown_type
 				end block
 
 			else
-				call vm_call_intr(instr%a, nintr, iargs, state, val)
+				call vm_call_intr(instr%a, nintr, iargs_pool(1:nintr), state, val)
 			end if
 
-			deallocate(iargs)
 			call vm_push_move(stack, val)
 
 		! --- M8: for-loop setup ---------------------------------------------------
@@ -1440,8 +1390,8 @@ module subroutine vm_run(prog, state, res)
 					prod_ = prod_ * state%locs%vals(instr%a)%array%size(k_)
 				end do
 				! Use to_*() for type-safe reads — handles RHS type != array element type
-			! (e.g. h is i64 from size(), but s is an i32 array).
-			select case (state%locs%vals(instr%a)%array%type)
+				! (e.g. h is i64 from size(), but s is an i32 array).
+				select case (state%locs%vals(instr%a)%array%type)
 				case (bool_type)
 					state%locs%vals(instr%a)%array%bool(lin_+1) = stack%v(base_+nsub_+1)%sca%bool
 				case (i32_type)
@@ -1770,7 +1720,8 @@ module subroutine vm_run(prog, state, res)
 	end do
 
 	! The final result is whatever is left on top of the stack.
-	if (stack%len_ > 0) res = stack%v(stack%len_)
+	! Move rather than copy — the stack is local and discarded immediately.
+	if (stack%len_ > 0) call value_move(stack%v(stack%len_), res)
 
 end subroutine vm_run
 

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -260,6 +260,8 @@ module subroutine vm_run(prog, state, res)
 	type(for_iter_t) :: for_iters(MAX_FORS)
 	integer :: nfor
 
+	!print *, "starting vm_run()"
+
 	nframes = 0
 	nfor    = 0
 	stack   = new_value_vector()

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -321,11 +321,22 @@ module subroutine vm_run(prog, state, res)
 			call vm_push_copy(stack, state%locs%vals(instr%a))
 
 		! --- variable stores (keep TOS on stack, copy into slot) ---
+		! Use assign_() when the slot already has a type (i.e. post-let assignment)
+		! to preserve the lhs type and cast the rhs. Raw copy for let_expr init
+		! (slot starts as unknown_type).
 		case (OP_STORE_GLOBAL)
-			state%vars%vals(instr%a) = stack%v(stack%len_)
+			if (state%vars%vals(instr%a)%type == unknown_type) then
+				state%vars%vals(instr%a) = stack%v(stack%len_)
+			else
+				call assign_(state%vars%vals(instr%a), stack%v(stack%len_), '=')
+			end if
 
 		case (OP_STORE_LOCAL)
-			state%locs%vals(instr%a) = stack%v(stack%len_)
+			if (state%locs%vals(instr%a)%type == unknown_type) then
+				state%locs%vals(instr%a) = stack%v(stack%len_)
+			else
+				call assign_(state%locs%vals(instr%a), stack%v(stack%len_), '=')
+			end if
 
 		! --- binary operation ---
 		case (OP_BINOP)

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -3,15 +3,156 @@
 
 submodule (syntran__vm_m) syntran__vm_exec
 
-	! M0 VM execution loop.  For now the only opcode is OP_EVAL_NODE which
-	! delegates to the AST-walking syntax_eval.  Subsequent milestones will add
-	! real opcodes as each node kind is lowered in the compiler.
+	! Stack-based bytecode VM execution loop.
+	!
+	! M0: OP_EVAL_NODE fallback (delegates to syntax_eval).
+	! M1: native handlers for scalars, loads/stores, binop, unop.
 
 	implicit none
 
 !===============================================================================
 
 contains
+
+!===============================================================================
+
+! --- operand-stack helpers ----------------------------------------------------
+!
+! The operand stack is a value_vector_t.  For scalars (M1) both push_copy and
+! the pop pattern are equivalent, but the names signal intent for future moves.
+
+subroutine vm_push_copy(stack, val)
+	! Push a deep copy of val onto the stack.  Used when the source must remain
+	! live (LOAD_GLOBAL, LOAD_LOCAL, LOAD_CONST).
+	type(value_vector_t), intent(inout) :: stack
+	type(value_t), intent(in) :: val
+	call stack%push(val)		! push_value does deep copy + growth
+end subroutine vm_push_copy
+
+!===============================================================================
+
+subroutine vm_pop_copy(stack, val)
+	! Pop the top of stack into val via deep copy, decrement len_.
+	type(value_vector_t), intent(inout) :: stack
+	type(value_t), intent(out) :: val
+	val = stack%v(stack%len_)	! deep copy via value_copy
+	stack%len_ = stack%len_ - 1
+end subroutine vm_pop_copy
+
+!===============================================================================
+
+subroutine vm_pop_discard(stack)
+	! Discard the top of stack (OP_POP).  Scalars have no allocatable members
+	! so we just decrement len_ without freeing.  Strings/arrays/structs that
+	! appear here are left in the dead slot until the vector is released.
+	type(value_vector_t), intent(inout) :: stack
+	if (stack%len_ > 0) stack%len_ = stack%len_ - 1
+end subroutine vm_pop_discard
+
+!===============================================================================
+
+subroutine do_binop(left, right, op_kind, res)
+
+	! Compute a binary operation on two values, mirroring eval_binary_expr.
+	! The math routines (add, subtract, etc.) are available because
+	! syntran__vm_m uses syntran__eval_m which uses syntran__math_m and
+	! syntran__bool_m.
+
+	type(value_t), intent(in) :: left, right
+	integer, intent(in) :: op_kind
+	type(value_t), intent(out) :: res
+
+	!*******
+
+	integer :: larrtype, rarrtype
+
+	larrtype = unknown_type
+	rarrtype = unknown_type
+	if (left %type == array_type) larrtype = left %array%type
+	if (right%type == array_type) rarrtype = right%array%type
+
+	res%type = get_binary_op_kind(left%type, op_kind, right%type, &
+		larrtype, rarrtype)
+
+	select case (res%type)
+	case (bool_array_type, f32_array_type, f64_array_type, &
+		i32_array_type, i64_array_type, str_array_type)
+		res%type = array_type
+	end select
+
+	select case (op_kind)
+	case (plus_token)
+		call add(left, right, res, '+')
+	case (minus_token)
+		call subtract(left, right, res, '-')
+	case (star_token)
+		call mul(left, right, res, '*')
+	case (sstar_token)
+		call pow(left, right, res, '**')
+	case (slash_token)
+		call div(left, right, res, '/')
+	case (percent_token)
+		call mod_(left, right, res, '%')
+	case (and_keyword)
+		call and_(left, right, res, 'and')
+	case (or_keyword)
+		call or_(left, right, res, 'or')
+	case (eequals_token)
+		call is_eq(left, right, res, '==')
+	case (bang_equals_token)
+		call is_ne(left, right, res, '!=')
+	case (less_token)
+		call is_lt(left, right, res, '<')
+	case (less_equals_token)
+		call is_le(left, right, res, '<=')
+	case (greater_token)
+		call is_gt(left, right, res, '>')
+	case (greater_equals_token)
+		call is_ge(left, right, res, '>=')
+	case (lless_token)
+		call left_shift(left, right, res, '<<')
+	case (ggreater_token)
+		call right_shift(left, right, res, '>>')
+	case (caret_token)
+		call bit_xor(left, right, res, '^')
+	case (pipe_token)
+		call bit_or(left, right, res, '|')
+	case (amp_token)
+		call bit_and(left, right, res, '&')
+	case default
+		write(*,*) 'VM: unknown binary op ', op_kind
+		call internal_error()
+	end select
+
+end subroutine do_binop
+
+!===============================================================================
+
+subroutine do_unop(right, op_kind, res)
+
+	! Compute a unary operation, mirroring eval_unary_expr.
+
+	type(value_t), intent(in) :: right
+	integer, intent(in) :: op_kind
+	type(value_t), intent(out) :: res
+
+	res%type = right%type
+
+	select case (op_kind)
+	case (plus_token)
+		res = right
+	case (minus_token)
+		call negate(right, res, '-')
+	case (not_keyword)
+		call not_(right, res, 'not')
+	case (bang_token)
+		call bit_not(right, res, '~')
+	case default
+		write(*,*) 'VM: unknown unary op ', op_kind
+		call internal_error()
+	end select
+
+end subroutine do_unop
 
 !===============================================================================
 
@@ -23,24 +164,68 @@ module subroutine vm_run(prog, state, res)
 
 	!*******
 
+	type(value_vector_t) :: stack
+	type(value_t) :: left, right, val
 	integer :: ip
+
+	stack = new_value_vector()
 
 	do ip = prog%entry_main, prog%len_
 
-		select case (prog%code(ip)%op)
+		associate(instr => prog%code(ip))
 
+		select case (instr%op)
+
+		! --- fallback: AST walker ---
 		case (OP_EVAL_NODE)
+			call syntax_eval(prog%nodes(instr%a), state, val)
+			call vm_push_copy(stack, val)
 
-			! Delegate to the AST walker.  The result of the last OP_EVAL_NODE
-			! becomes the program result, matching eval_translation_unit semantics.
-			call syntax_eval(prog%nodes(prog%code(ip)%a), state, res)
+		! --- constants and variable loads ---
+		case (OP_LOAD_CONST)
+			call vm_push_copy(stack, prog%consts(instr%a))
+
+		case (OP_LOAD_GLOBAL)
+			call vm_push_copy(stack, state%vars%vals(instr%a))
+
+		case (OP_LOAD_LOCAL)
+			call vm_push_copy(stack, state%locs%vals(instr%a))
+
+		! --- variable stores (keep TOS on stack, copy into slot) ---
+		case (OP_STORE_GLOBAL)
+			state%vars%vals(instr%a) = stack%v(stack%len_)
+
+		case (OP_STORE_LOCAL)
+			state%locs%vals(instr%a) = stack%v(stack%len_)
+
+		! --- binary operation ---
+		case (OP_BINOP)
+			call vm_pop_copy(stack, right)
+			call vm_pop_copy(stack, left)
+			call do_binop(left, right, instr%a, val)
+			call vm_push_copy(stack, val)
+
+		! --- unary operation ---
+		case (OP_UNOP)
+			call vm_pop_copy(stack, right)
+			call do_unop(right, instr%a, val)
+			call vm_push_copy(stack, val)
+
+		! --- discard ---
+		case (OP_POP)
+			call vm_pop_discard(stack)
 
 		case default
-			write(*,*) 'VM: unknown opcode ', prog%code(ip)%op
+			write(*,*) 'VM: unknown opcode ', instr%op
 
 		end select
 
+		end associate
+
 	end do
+
+	! The final result is whatever is left on top of the stack.
+	if (stack%len_ > 0) res = stack%v(stack%len_)
 
 end subroutine vm_run
 

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -228,6 +228,121 @@ end subroutine do_binop
 
 !===============================================================================
 
+subroutine do_array_binop_typed(left, right, op_kind, elem_type, res)
+
+	! Fast-path for same-type numeric array ⊕ array operations emitted as
+	! OP_ARR_BINOP.  Inlines the array kernels from the math/bool routines,
+	! avoiding the magic-dispatch and subroutine-call overhead of do_binop.
+	!
+	! op_kind : token kind (plus_token, minus_token, …, bang_equals_token)
+	! elem_type: i32_type | i64_type | f32_type | f64_type  (same for both operands)
+
+	type(value_t), intent(inout) :: left, right
+	integer, intent(in) :: op_kind, elem_type
+	type(value_t), intent(out) :: res
+
+	res%type = array_type
+
+	select case (op_kind)
+
+	! --- Arithmetic: result element type == operand element type ---
+	case (plus_token)
+		res%array = mold(left%array, elem_type)
+		select case (elem_type)
+		case (i32_type); res%array%i32 = left%array%i32 + right%array%i32
+		case (i64_type); res%array%i64 = left%array%i64 + right%array%i64
+		case (f32_type); res%array%f32 = left%array%f32 + right%array%f32
+		case (f64_type); res%array%f64 = left%array%f64 + right%array%f64
+		end select
+	case (minus_token)
+		res%array = mold(left%array, elem_type)
+		select case (elem_type)
+		case (i32_type); res%array%i32 = left%array%i32 - right%array%i32
+		case (i64_type); res%array%i64 = left%array%i64 - right%array%i64
+		case (f32_type); res%array%f32 = left%array%f32 - right%array%f32
+		case (f64_type); res%array%f64 = left%array%f64 - right%array%f64
+		end select
+	case (star_token)
+		res%array = mold(left%array, elem_type)
+		select case (elem_type)
+		case (i32_type); res%array%i32 = left%array%i32 * right%array%i32
+		case (i64_type); res%array%i64 = left%array%i64 * right%array%i64
+		case (f32_type); res%array%f32 = left%array%f32 * right%array%f32
+		case (f64_type); res%array%f64 = left%array%f64 * right%array%f64
+		end select
+	case (slash_token)
+		res%array = mold(left%array, elem_type)
+		select case (elem_type)
+		case (i32_type); res%array%i32 = left%array%i32 / right%array%i32
+		case (i64_type); res%array%i64 = left%array%i64 / right%array%i64
+		case (f32_type); res%array%f32 = left%array%f32 / right%array%f32
+		case (f64_type); res%array%f64 = left%array%f64 / right%array%f64
+		end select
+	case (percent_token)
+		res%array = mold(left%array, elem_type)
+		select case (elem_type)
+		case (i32_type); res%array%i32 = mod(left%array%i32, right%array%i32)
+		case (i64_type); res%array%i64 = mod(left%array%i64, right%array%i64)
+		case (f32_type); res%array%f32 = mod(left%array%f32, right%array%f32)
+		case (f64_type); res%array%f64 = mod(left%array%f64, right%array%f64)
+		end select
+
+	! --- Comparisons: result is a bool array ---
+	case (less_token)
+		res%array = mold(left%array, bool_type)
+		select case (elem_type)
+		case (i32_type); res%array%bool = left%array%i32 < right%array%i32
+		case (i64_type); res%array%bool = left%array%i64 < right%array%i64
+		case (f32_type); res%array%bool = left%array%f32 < right%array%f32
+		case (f64_type); res%array%bool = left%array%f64 < right%array%f64
+		end select
+	case (less_equals_token)
+		res%array = mold(left%array, bool_type)
+		select case (elem_type)
+		case (i32_type); res%array%bool = left%array%i32 <= right%array%i32
+		case (i64_type); res%array%bool = left%array%i64 <= right%array%i64
+		case (f32_type); res%array%bool = left%array%f32 <= right%array%f32
+		case (f64_type); res%array%bool = left%array%f64 <= right%array%f64
+		end select
+	case (greater_token)
+		res%array = mold(left%array, bool_type)
+		select case (elem_type)
+		case (i32_type); res%array%bool = left%array%i32 > right%array%i32
+		case (i64_type); res%array%bool = left%array%i64 > right%array%i64
+		case (f32_type); res%array%bool = left%array%f32 > right%array%f32
+		case (f64_type); res%array%bool = left%array%f64 > right%array%f64
+		end select
+	case (greater_equals_token)
+		res%array = mold(left%array, bool_type)
+		select case (elem_type)
+		case (i32_type); res%array%bool = left%array%i32 >= right%array%i32
+		case (i64_type); res%array%bool = left%array%i64 >= right%array%i64
+		case (f32_type); res%array%bool = left%array%f32 >= right%array%f32
+		case (f64_type); res%array%bool = left%array%f64 >= right%array%f64
+		end select
+	case (eequals_token)
+		res%array = mold(left%array, bool_type)
+		select case (elem_type)
+		case (i32_type); res%array%bool = left%array%i32 == right%array%i32
+		case (i64_type); res%array%bool = left%array%i64 == right%array%i64
+		case (f32_type); res%array%bool = left%array%f32 == right%array%f32
+		case (f64_type); res%array%bool = left%array%f64 == right%array%f64
+		end select
+	case (bang_equals_token)
+		res%array = mold(left%array, bool_type)
+		select case (elem_type)
+		case (i32_type); res%array%bool = left%array%i32 /= right%array%i32
+		case (i64_type); res%array%bool = left%array%i64 /= right%array%i64
+		case (f32_type); res%array%bool = left%array%f32 /= right%array%f32
+		case (f64_type); res%array%bool = left%array%f64 /= right%array%f64
+		end select
+
+	end select
+
+end subroutine do_array_binop_typed
+
+!===============================================================================
+
 subroutine do_unop(right, op_kind, res)
 
 	! Compute a unary operation, mirroring eval_unary_expr.
@@ -1031,6 +1146,144 @@ module subroutine vm_run(prog, state, res)
 			stack%v(stack%len_-1)%sca%f64 = mod(stack%v(stack%len_-1)%sca%f64, &
 			                                     stack%v(stack%len_  )%sca%f64)
 			stack%len_ = stack%len_ - 1
+
+		! Power: same layout as arithmetic (result same type, left=TOS-1, right=TOS).
+		! Semantics match math_bin_pow.f90 same-type scalar cases.
+		case (OP_POW_I32)
+			stack%v(stack%len_-1)%sca%i32 = stack%v(stack%len_-1)%sca%i32 &
+			                              ** stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_POW_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              ** stack%v(stack%len_  )%sca%i64
+			stack%len_ = stack%len_ - 1
+		case (OP_POW_F32)
+			stack%v(stack%len_-1)%sca%f32 = stack%v(stack%len_-1)%sca%f32 &
+			                              ** stack%v(stack%len_  )%sca%f32
+			stack%len_ = stack%len_ - 1
+		case (OP_POW_F64)
+			stack%v(stack%len_-1)%sca%f64 = stack%v(stack%len_-1)%sca%f64 &
+			                              ** stack%v(stack%len_  )%sca%f64
+			stack%len_ = stack%len_ - 1
+
+		! Mixed i32/i64 arithmetic: result is i64. TOS-1 type updated to i64_type.
+		! OP_<OP>_I32_I64: left=i32 (TOS-1), right=i64 (TOS).
+		! OP_<OP>_I64_I32: left=i64 (TOS-1), right=i32 (TOS).
+		case (OP_ADD_I32_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i32 &
+			                              + stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = i64_type
+			stack%len_ = stack%len_ - 1
+		case (OP_ADD_I64_I32)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              + stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_SUB_I32_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i32 &
+			                              - stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = i64_type
+			stack%len_ = stack%len_ - 1
+		case (OP_SUB_I64_I32)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              - stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_MUL_I32_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i32 &
+			                              * stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = i64_type
+			stack%len_ = stack%len_ - 1
+		case (OP_MUL_I64_I32)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              * stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_DIV_I32_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i32 &
+			                              / stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = i64_type
+			stack%len_ = stack%len_ - 1
+		case (OP_DIV_I64_I32)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              / stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_MOD_I32_I64)
+			stack%v(stack%len_-1)%sca%i64 = mod(int(stack%v(stack%len_-1)%sca%i32, 8), &
+			                                     stack%v(stack%len_  )%sca%i64)
+			stack%v(stack%len_-1)%type = i64_type
+			stack%len_ = stack%len_ - 1
+		case (OP_MOD_I64_I32)
+			stack%v(stack%len_-1)%sca%i64 = mod(stack%v(stack%len_-1)%sca%i64, &
+			                                     int(stack%v(stack%len_  )%sca%i32, 8))
+			stack%len_ = stack%len_ - 1
+
+		! Mixed i32/i64 comparisons: result is bool. TOS-1 type updated to bool_type.
+		case (OP_LT_I32_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                               < stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LT_I64_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                               < stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LE_I32_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              <= stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LE_I64_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              <= stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GT_I32_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                               > stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GT_I64_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                               > stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GE_I32_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              >= stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GE_I64_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              >= stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_EQ_I32_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              == stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_EQ_I64_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              == stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_NE_I32_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              /= stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_NE_I64_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              /= stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+
+		! Same-type numeric array binop: a=op_kind (token), b=element type.
+		! Dispatches to do_array_binop_typed (inlined array kernels).
+		case (OP_ARR_BINOP)
+			call vm_pop_copy(stack, right)
+			call vm_pop_copy(stack, left)
+			call do_array_binop_typed(left, right, instr%a, instr%b, val)
+			call vm_push_move(stack, val)
 
 		! Comparisons: result type is bool; TOS-1 type updated to bool_type.
 		case (OP_LT_I32)

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -57,24 +57,37 @@ contains
 
 ! --- operand-stack helpers ----------------------------------------------------
 !
-! The operand stack is a value_vector_t.  For scalars (M1) both push_copy and
-! the pop pattern are equivalent, but the names signal intent for future moves.
+! vm_push_copy: push a deep copy; source remains live (LOAD_CONST, LOAD_GLOBAL,
+!   LOAD_LOCAL — the variable slot / constant pool entry must not be cleared).
+! vm_push_move: push by move; source is a temporary that dies here (binop
+!   result, intrinsic return value, etc.).  O(1) for array/struct values.
+! vm_pop_copy:  pop TOS via move (the slot is dead after decrement; "copy" in
+!   the name is historical).  Callers always pop into a local variable.
 
 subroutine vm_push_copy(stack, val)
-	! Push a deep copy of val onto the stack.  Used when the source must remain
-	! live (LOAD_GLOBAL, LOAD_LOCAL, LOAD_CONST).
+	! Push a deep copy of val.  Source must remain live after this call.
 	type(value_vector_t), intent(inout) :: stack
 	type(value_t), intent(in) :: val
-	call stack%push(val)		! push_value does deep copy + growth
+	call stack%push(val)		! push_value: deep copy + growth
 end subroutine vm_push_copy
 
 !===============================================================================
 
+subroutine vm_push_move(stack, val)
+	! Push val by moving it (consuming val).  Val must be a temporary with no
+	! other live references.  For array/struct values this avoids an O(n) copy.
+	type(value_vector_t), intent(inout) :: stack
+	type(value_t), intent(inout) :: val
+	call stack%push_move(val)	! push_value_move: move + growth
+end subroutine vm_push_move
+
+!===============================================================================
+
 subroutine vm_pop_copy(stack, val)
-	! Pop the top of stack into val via deep copy, decrement len_.
+	! Pop TOS into val via move (slot becomes dead; name kept for stability).
 	type(value_vector_t), intent(inout) :: stack
 	type(value_t), intent(out) :: val
-	val = stack%v(stack%len_)	! deep copy via value_copy
+	call value_move(stack%v(stack%len_), val)
 	stack%len_ = stack%len_ - 1
 end subroutine vm_pop_copy
 
@@ -264,7 +277,7 @@ module subroutine vm_run(prog, state, res)
 		! --- fallback: AST walker ---
 		case (OP_EVAL_NODE)
 			call syntax_eval(prog%nodes(instr%a), state, val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 			if (state%returned) then
 				if (nframes > 0) then
 					! A return_statement executed inside an AST-walker fallback
@@ -303,7 +316,7 @@ module subroutine vm_run(prog, state, res)
 					nframes = nframes - 1
 					deallocate(params_tmp)
 					state%returned = .false.
-					call vm_push_copy(stack, val)
+					call vm_push_move(stack, val)
 				else
 					! Top-level return: exit the main VM loop.
 					next_ip = prog%len_ + 1
@@ -343,13 +356,13 @@ module subroutine vm_run(prog, state, res)
 			call vm_pop_copy(stack, right)
 			call vm_pop_copy(stack, left)
 			call do_binop(left, right, instr%a, val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- unary operation ---
 		case (OP_UNOP)
 			call vm_pop_copy(stack, right)
 			call do_unop(right, instr%a, val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- discard ---
 		case (OP_POP)
@@ -369,11 +382,11 @@ module subroutine vm_run(prog, state, res)
 		! written back from the callee's frame at OP_RET time.
 		case (OP_LOAD_REF_GLOBAL)
 			call value_move(state%vars%vals(instr%a), val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		case (OP_LOAD_REF_LOCAL)
 			call value_move(state%locs%vals(instr%a), val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- user function call -----------------------------------------------
 		! Stack layout on entry (bottom to top):
@@ -465,7 +478,7 @@ module subroutine vm_run(prog, state, res)
 			deallocate(params_tmp)
 
 			! Push the return value onto the caller's operand stack.
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- scalar subscript read: a[i] or s[i] -----------------------------------
 		! Evaluates subscript indices via subscript_eval (which calls syntax_eval
@@ -484,10 +497,11 @@ module subroutine vm_run(prog, state, res)
 
 			if (type_ == str_type) then
 				val%type = str_type
+				if (.not. allocated(val%str)) allocate(val%str)
 				if (n%is_loc) then
-					val%sca%str%s = state%locs%vals(id)%sca%str%s(i8+1: i8+1)
+					val%str%s = state%locs%vals(id)%str%s(i8+1: i8+1)
 				else
-					val%sca%str%s = state%vars%vals(id)%sca%str%s(i8+1: i8+1)
+					val%str%s = state%vars%vals(id)%str%s(i8+1: i8+1)
 				end if
 			else
 				if (n%is_loc) then
@@ -497,7 +511,7 @@ module subroutine vm_run(prog, state, res)
 				end if
 			end if
 
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 			end associate
 
 		! --- slice / non-scalar subscript read: a[i:j], a[:], a[[0,2,4]] ---------
@@ -505,7 +519,7 @@ module subroutine vm_run(prog, state, res)
 		! subscripts, step subscripts, and multi-rank combinations.
 		case (OP_SLICE)
 			call eval_name_expr(prog%nodes(instr%a), state, val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- scalar subscript write: a[i] = x  or  a[i] += x -------------------
 		! TOS holds the already-evaluated RHS.  Uses subscript_eval to find the
@@ -526,11 +540,11 @@ module subroutine vm_run(prog, state, res)
 			if (type_ == str_type) then
 				! String character assignment: s[i] = char_expr
 				if (n%is_loc) then
-					state%locs%vals(id)%sca%str%s(i8+1: i8+1) = right%sca%str%s
+					state%locs%vals(id)%str%s(i8+1: i8+1) = right%str%s
 				else
-					state%vars%vals(id)%sca%str%s(i8+1: i8+1) = right%sca%str%s
+					state%vars%vals(id)%str%s(i8+1: i8+1) = right%str%s
 				end if
-				call vm_push_copy(stack, right)
+				call vm_push_move(stack, right)
 			else
 				! Array element assignment (including compound ops)
 				if (n%is_loc) then
@@ -542,7 +556,7 @@ module subroutine vm_run(prog, state, res)
 					call do_compound(val, right, instr%b)
 					call set_val(n, state%vars%vals(id), state, val, index_ = i8)
 				end if
-				call vm_push_copy(stack, val)
+				call vm_push_move(stack, val)
 			end if
 			end associate
 
@@ -559,7 +573,7 @@ module subroutine vm_run(prog, state, res)
 			do i = n_mem, 1, -1
 				call vm_pop_copy(stack, val%struct(i))
 			end do
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 			end associate
 
 		! --- dot member read ------------------------------------------------------
@@ -573,7 +587,7 @@ module subroutine vm_run(prog, state, res)
 			else
 				call get_val(n, state%vars%vals(id), state, val)
 			end if
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 			end associate
 
 		! --- dot member write -----------------------------------------------------
@@ -592,7 +606,7 @@ module subroutine vm_run(prog, state, res)
 				call do_compound(val, right, instr%b)
 				call set_val(n, state%vars%vals(id), state, val)
 			end if
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 			end associate
 
 		! --- M6: intrinsic function call -----------------------------------------
@@ -612,27 +626,28 @@ module subroutine vm_run(prog, state, res)
 				logical :: is_loc_
 				slot_id_ = int(instr%c / 2)
 				is_loc_  = (mod(instr%c, 2_8) == 1_8)
-				if (.not. iargs(1)%sca%file_%is_open) then
+				if (.not. iargs(1)%file_%is_open) then
 					write(*,*) err_rt_prefix//'readln() was called for file "' &
-						//iargs(1)%sca%file_%name_//'" which is not open'
+						//iargs(1)%file_%name_//'" which is not open'
 					call internal_error()
 				end if
-				if (.not. iargs(1)%sca%file_%mode_read) then
+				if (.not. iargs(1)%file_%mode_read) then
 					write(*,*) err_rt_prefix//'readln() was called for file "' &
-						//iargs(1)%sca%file_%name_//'" which was not opened in read mode "r"'
+						//iargs(1)%file_%name_//'" which was not opened in read mode "r"'
 					call internal_error()
 				end if
 				val%type = str_type
-				val%sca%str%s = read_line(iargs(1)%sca%file_%unit_, io_)
+				if (.not. allocated(val%str)) allocate(val%str)
+				val%str%s = read_line(iargs(1)%file_%unit_, io_)
 				if (io_ == iostat_end) then
 					if (is_loc_) then
-						state%locs%vals(slot_id_)%sca%file_%eof = .true.
+						state%locs%vals(slot_id_)%file_%eof = .true.
 					else
-						state%vars%vals(slot_id_)%sca%file_%eof = .true.
+						state%vars%vals(slot_id_)%file_%eof = .true.
 					end if
 				else if (io_ /= 0 .and. io_ /= iostat_eor) then
 					write(*,*) err_rt_prefix//'cannot readln() from file "' &
-						//iargs(1)%sca%file_%name_//'"'
+						//iargs(1)%file_%name_//'"'
 					call internal_error()
 				end if
 				end block
@@ -644,17 +659,17 @@ module subroutine vm_run(prog, state, res)
 				logical :: is_loc_
 				slot_id_ = int(instr%c / 2)
 				is_loc_  = (mod(instr%c, 2_8) == 1_8)
-				if (.not. iargs(1)%sca%file_%is_open) then
+				if (.not. iargs(1)%file_%is_open) then
 					write(*,*) err_rt_prefix//'close() was called for file "' &
-						//iargs(1)%sca%file_%name_//'" which is not open'
+						//iargs(1)%file_%name_//'" which is not open'
 					call internal_error()
 				end if
 				if (is_loc_) then
-					state%locs%vals(slot_id_)%sca%file_%is_open = .false.
+					state%locs%vals(slot_id_)%file_%is_open = .false.
 				else
-					state%vars%vals(slot_id_)%sca%file_%is_open = .false.
+					state%vars%vals(slot_id_)%file_%is_open = .false.
 				end if
-				close(iargs(1)%sca%file_%unit_)
+				close(iargs(1)%file_%unit_)
 				val%type = unknown_type
 				end block
 
@@ -663,7 +678,7 @@ module subroutine vm_run(prog, state, res)
 			end if
 
 			deallocate(iargs)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- M8: for-loop setup ---------------------------------------------------
 		! Evaluates loop bounds / computes len8; pushes a for_iter_t onto the
@@ -806,7 +821,7 @@ module subroutine vm_run(prog, state, res)
 					for_iters(fi)%itr_type = str_type
 					call syntax_eval(nd%array, state, tmp_)
 					call value_move(tmp_, for_iters(fi)%str_)
-					for_iters(fi)%len8 = len(for_iters(fi)%str_%sca%str%s, 8)
+					for_iters(fi)%len8 = len(for_iters(fi)%str_%str%s, 8)
 				else
 					for_iters(fi)%for_kind = array_expr
 					call syntax_eval(nd%array, state, tmp_)
@@ -840,9 +855,9 @@ module subroutine vm_run(prog, state, res)
 					state)
 				associate(nd => prog%nodes(for_iters(fi)%node_idx))
 				if (nd%is_loc) then
-					state%locs%vals(nd%id_index) = val
+					call value_move(val, state%locs%vals(nd%id_index))
 				else
-					state%vars%vals(nd%id_index) = val
+					call value_move(val, state%vars%vals(nd%id_index))
 				end if
 				end associate
 			end if
@@ -859,14 +874,14 @@ module subroutine vm_run(prog, state, res)
 		! expl, size, unif).  Rank-1 native specialization is a future perf pass.
 		case (OP_NEW_ARRAY)
 			call eval_array_expr(prog%nodes(instr%a), state, val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- M8: slice/complex LHS assignment ------------------------------------
 		! Handles slice-range LHS (a[1:3] = x) and subscript-less compound
 		! assignments by delegating to eval_assignment_expr.
 		case (OP_STORE_SLICE)
 			call eval_assignment_expr(prog%nodes(instr%a), state, val)
-			call vm_push_copy(stack, val)
+			call vm_push_move(stack, val)
 
 		! --- M8: top-level return (halt) ------------------------------------------
 		! Exits the VM loop immediately; TOS is the return value.

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -126,7 +126,10 @@ end subroutine vm_stack_grow
 subroutine do_compound(lhs, rhs, op_kind)
 
 	! Call compound_assign with just an integer op_kind (no full token needed).
-	! op%text is only used for error messages, so an empty string is safe.
+	! op%text is only used for error messages, so an empty string is fine.
+	!
+	! The token is declared save so %text is allocated exactly once (on the first
+	! call) instead of on every call — avoids a per-operation heap alloc/free.
 
 	type(value_t), intent(inout) :: lhs
 	type(value_t), intent(in)    :: rhs
@@ -134,10 +137,14 @@ subroutine do_compound(lhs, rhs, op_kind)
 
 	!*******
 
-	type(syntax_token_t) :: op_tok
+	type(syntax_token_t), save :: op_tok
+	logical,              save :: first_call = .true.
 
+	if (first_call) then
+		op_tok%text = ''   ! single heap allocation; persists via save
+		first_call  = .false.
+	end if
 	op_tok%kind = op_kind
-	op_tok%text = ''
 	call compound_assign(lhs, rhs, op_tok)
 
 end subroutine do_compound
@@ -384,7 +391,10 @@ module subroutine vm_run(prog, state, res)
 
 	type(value_vector_t) :: stack
 	type(value_t) :: left, right, val
-	type(value_t), allocatable :: params_tmp(:)
+	! params_pool: reusable buffer for fn-call / return parameter passing.
+	! Grows on demand; avoids allocate/deallocate on every OP_CALL / OP_RET.
+	type(value_t), allocatable :: params_pool(:)
+	integer :: params_pool_cap
 	integer :: ip, next_ip
 	integer :: i, fn_id, nparams, node_idx_call
 	integer :: id, type_, n_mem
@@ -404,9 +414,10 @@ module subroutine vm_run(prog, state, res)
 
 	!print *, "starting vm_run()"
 
-	nframes = 0
-	nfor    = 0
-	stack   = new_value_vector()
+	nframes         = 0
+	nfor            = 0
+	params_pool_cap = 0
+	stack           = new_value_vector()
 
 	ip = prog%entry_main
 	do while (ip <= prog%len_)
@@ -434,10 +445,14 @@ module subroutine vm_run(prog, state, res)
 					associate(fr => frames(nframes), &
 					          cn => prog%nodes(frames(nframes)%node_idx))
 					nparams = size(cn%params)
-					allocate(params_tmp(nparams))
+					if (nparams > params_pool_cap) then
+						if (allocated(params_pool)) deallocate(params_pool)
+						allocate(params_pool(nparams))
+						params_pool_cap = nparams
+					end if
 					do i = 1, nparams
 						if (cn%is_ref(i)) then
-							call value_move(state%locs%vals(cn%params(i)), params_tmp(i))
+							call value_move(state%locs%vals(cn%params(i)), params_pool(i))
 						end if
 					end do
 					! Save callee locs to pool, then restore caller locs.
@@ -450,17 +465,16 @@ module subroutine vm_run(prog, state, res)
 					do i = 1, nparams
 						if (.not. cn%is_ref(i)) cycle
 						if (cn%args(i)%is_loc) then
-							call value_move(params_tmp(i), &
+							call value_move(params_pool(i), &
 								state%locs%vals(cn%args(i)%id_index))
 						else
-							call value_move(params_tmp(i), &
+							call value_move(params_pool(i), &
 								state%vars%vals(cn%args(i)%id_index))
 						end if
 					end do
 					next_ip = fr%return_ip
 					end associate
 					nframes = nframes - 1
-					deallocate(params_tmp)
 					state%returned = .false.
 					call vm_push_move(stack, val)
 				else
@@ -547,16 +561,21 @@ module subroutine vm_run(prog, state, res)
 			associate(cn => prog%nodes(node_idx_call))
 			nparams = 0
 			if (allocated(cn%params)) nparams = size(cn%params)
-			allocate(params_tmp(nparams))
+			! Grow params_pool if needed (amortised; avoids alloc/dealloc per call).
+			if (nparams > params_pool_cap) then
+				if (allocated(params_pool)) deallocate(params_pool)
+				allocate(params_pool(nparams))
+				params_pool_cap = nparams
+			end if
 
 			! Pop by-ref args in reverse param-index order.
 			do i = nparams, 1, -1
-				if (cn%is_ref(i)) call vm_pop_copy(stack, params_tmp(i))
+				if (cn%is_ref(i)) call vm_pop_copy(stack, params_pool(i))
 			end do
 
 			! Pop by-val args in reverse param-index order.
 			do i = nparams, 1, -1
-				if (.not. cn%is_ref(i)) call vm_pop_copy(stack, params_tmp(i))
+				if (.not. cn%is_ref(i)) call vm_pop_copy(stack, params_pool(i))
 			end do
 
 			! Push a new call frame; save caller's local vars and for-iter depth.
@@ -589,10 +608,9 @@ module subroutine vm_run(prog, state, res)
 
 			! Move params into the callee's local slots.
 			do i = 1, nparams
-				call value_move(params_tmp(i), state%locs%vals(cn%params(i)))
+				call value_move(params_pool(i), state%locs%vals(cn%params(i)))
 			end do
 
-			deallocate(params_tmp)
 			end associate
 
 			next_ip = prog%fn_entry(fn_id)
@@ -607,12 +625,17 @@ module subroutine vm_run(prog, state, res)
 			          cn => prog%nodes(frames(nframes)%node_idx))
 			nparams = 0
 			if (allocated(cn%params)) nparams = size(cn%params)
-			allocate(params_tmp(nparams))
+			! Grow params_pool if needed (amortised; avoids alloc/dealloc per return).
+			if (nparams > params_pool_cap) then
+				if (allocated(params_pool)) deallocate(params_pool)
+				allocate(params_pool(nparams))
+				params_pool_cap = nparams
+			end if
 
-			! Move by-ref params from callee locs into params_tmp for writeback.
+			! Move by-ref params from callee locs into params_pool for writeback.
 			do i = 1, nparams
 				if (cn%is_ref(i)) then
-					call value_move(state%locs%vals(cn%params(i)), params_tmp(i))
+					call value_move(state%locs%vals(cn%params(i)), params_pool(i))
 				end if
 			end do
 
@@ -631,10 +654,10 @@ module subroutine vm_run(prog, state, res)
 			do i = 1, nparams
 				if (.not. cn%is_ref(i)) cycle
 				if (cn%args(i)%is_loc) then
-					call value_move(params_tmp(i), &
+					call value_move(params_pool(i), &
 						state%locs%vals(cn%args(i)%id_index))
 				else
-					call value_move(params_tmp(i), &
+					call value_move(params_pool(i), &
 						state%vars%vals(cn%args(i)%id_index))
 				end if
 			end do
@@ -643,7 +666,6 @@ module subroutine vm_run(prog, state, res)
 			nfor    = fr%nfor_saved   ! clean up any for-iters the callee leaked (e.g. via return)
 			end associate
 			nframes = nframes - 1
-			deallocate(params_tmp)
 
 			! Push the return value onto the caller's operand stack.
 			call vm_push_move(stack, val)
@@ -1284,6 +1306,128 @@ module subroutine vm_run(prog, state, res)
 			call vm_pop_copy(stack, left)
 			call do_array_binop_typed(left, right, instr%a, instr%b, val)
 			call vm_push_move(stack, val)
+
+		! --- M9: native scalar array element read ------------------------------------
+		! Stack before: [sub_1][sub_2]...[sub_nsub]
+		! Stack after:  [element_value]
+		! a=id_index, b=nsub, c=is_local (0=global, 1=local).
+		! Computes the linear index inline — no syntax_eval call per subscript.
+		case (OP_INDEX_NAT)
+			block
+			integer :: nsub_, k_, base_
+			integer(kind=8) :: lin_, prod_
+
+			nsub_ = instr%b
+			base_ = stack%len_ - nsub_   ! subs at base_+1..base_+nsub_; result → base_+1
+			lin_  = 0_8
+			prod_ = 1_8
+
+			if (instr%c == 1_8) then
+				associate(arr => state%locs%vals(instr%a)%array)
+				do k_ = 1, nsub_
+					select case (stack%v(base_+k_)%type)
+					case (i32_type); lin_ = lin_ + prod_ * int(stack%v(base_+k_)%sca%i32, 8)
+					case (i64_type); lin_ = lin_ + prod_ * stack%v(base_+k_)%sca%i64
+					end select
+					prod_ = prod_ * arr%size(k_)
+				end do
+				stack%v(base_+1)%type = arr%type
+				select case (arr%type)
+				case (bool_type); stack%v(base_+1)%sca%bool = arr%bool(lin_+1)
+				case (i32_type);  stack%v(base_+1)%sca%i32  = arr%i32(lin_+1)
+				case (i64_type);  stack%v(base_+1)%sca%i64  = arr%i64(lin_+1)
+				case (f32_type);  stack%v(base_+1)%sca%f32  = arr%f32(lin_+1)
+				case (f64_type);  stack%v(base_+1)%sca%f64  = arr%f64(lin_+1)
+				end select
+				end associate
+			else
+				associate(arr => state%vars%vals(instr%a)%array)
+				do k_ = 1, nsub_
+					select case (stack%v(base_+k_)%type)
+					case (i32_type); lin_ = lin_ + prod_ * int(stack%v(base_+k_)%sca%i32, 8)
+					case (i64_type); lin_ = lin_ + prod_ * stack%v(base_+k_)%sca%i64
+					end select
+					prod_ = prod_ * arr%size(k_)
+				end do
+				stack%v(base_+1)%type = arr%type
+				select case (arr%type)
+				case (bool_type); stack%v(base_+1)%sca%bool = arr%bool(lin_+1)
+				case (i32_type);  stack%v(base_+1)%sca%i32  = arr%i32(lin_+1)
+				case (i64_type);  stack%v(base_+1)%sca%i64  = arr%i64(lin_+1)
+				case (f32_type);  stack%v(base_+1)%sca%f32  = arr%f32(lin_+1)
+				case (f64_type);  stack%v(base_+1)%sca%f64  = arr%f64(lin_+1)
+				end select
+				end associate
+			end if
+
+			stack%len_ = base_ + 1
+			end block
+
+		! --- M9: native scalar array element write (plain '=' only) ------------------
+		! Stack before: [sub_1]...[sub_nsub][rhs]
+		! Stack after:  [rhs]   (leaves stored value on top, matching OP_STORE_IDX)
+		! a=id_index, b=nsub, c=is_local (0=global, 1=local).
+		! Only emitted for numeric/bool element types and op == '='.
+		case (OP_STORE_IDX_NAT)
+			block
+			integer :: nsub_, k_, base_
+			integer(kind=8) :: lin_, prod_
+
+			nsub_ = instr%b
+			! Stack layout: subs at len_-nsub_-1+1..len_-1, RHS at len_
+			base_ = stack%len_ - nsub_ - 1   ! base_+1..base_+nsub_ are subs; base_+nsub_+1 is RHS
+			lin_  = 0_8
+			prod_ = 1_8
+
+			if (instr%c == 1_8) then
+				do k_ = 1, nsub_
+					select case (stack%v(base_+k_)%type)
+					case (i32_type); lin_ = lin_ + prod_ * int(stack%v(base_+k_)%sca%i32, 8)
+					case (i64_type); lin_ = lin_ + prod_ * stack%v(base_+k_)%sca%i64
+					end select
+					prod_ = prod_ * state%locs%vals(instr%a)%array%size(k_)
+				end do
+				! Use to_*() for type-safe reads — handles RHS type != array element type
+			! (e.g. h is i64 from size(), but s is an i32 array).
+			select case (state%locs%vals(instr%a)%array%type)
+				case (bool_type)
+					state%locs%vals(instr%a)%array%bool(lin_+1) = stack%v(base_+nsub_+1)%sca%bool
+				case (i32_type)
+					state%locs%vals(instr%a)%array%i32(lin_+1) = stack%v(base_+nsub_+1)%to_i32()
+				case (i64_type)
+					state%locs%vals(instr%a)%array%i64(lin_+1) = stack%v(base_+nsub_+1)%to_i64()
+				case (f32_type)
+					state%locs%vals(instr%a)%array%f32(lin_+1) = stack%v(base_+nsub_+1)%to_f32()
+				case (f64_type)
+					state%locs%vals(instr%a)%array%f64(lin_+1) = stack%v(base_+nsub_+1)%to_f64()
+				end select
+			else
+				do k_ = 1, nsub_
+					select case (stack%v(base_+k_)%type)
+					case (i32_type); lin_ = lin_ + prod_ * int(stack%v(base_+k_)%sca%i32, 8)
+					case (i64_type); lin_ = lin_ + prod_ * stack%v(base_+k_)%sca%i64
+					end select
+					prod_ = prod_ * state%vars%vals(instr%a)%array%size(k_)
+				end do
+				select case (state%vars%vals(instr%a)%array%type)
+				case (bool_type)
+					state%vars%vals(instr%a)%array%bool(lin_+1) = stack%v(base_+nsub_+1)%sca%bool
+				case (i32_type)
+					state%vars%vals(instr%a)%array%i32(lin_+1) = stack%v(base_+nsub_+1)%to_i32()
+				case (i64_type)
+					state%vars%vals(instr%a)%array%i64(lin_+1) = stack%v(base_+nsub_+1)%to_i64()
+				case (f32_type)
+					state%vars%vals(instr%a)%array%f32(lin_+1) = stack%v(base_+nsub_+1)%to_f32()
+				case (f64_type)
+					state%vars%vals(instr%a)%array%f64(lin_+1) = stack%v(base_+nsub_+1)%to_f64()
+				end select
+			end if
+
+			! Leave stored value (RHS) on top: copy POD fields from RHS slot → base_+1
+			stack%v(base_+1)%type = stack%v(base_+nsub_+1)%type
+			stack%v(base_+1)%sca  = stack%v(base_+nsub_+1)%sca
+			stack%len_ = base_ + 1
+			end block
 
 		! Comparisons: result type is bool; TOS-1 type updated to bool_type.
 		case (OP_LT_I32)

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -65,6 +65,27 @@ end subroutine vm_pop_discard
 
 !===============================================================================
 
+subroutine do_compound(lhs, rhs, op_kind)
+
+	! Call compound_assign with just an integer op_kind (no full token needed).
+	! op%text is only used for error messages, so an empty string is safe.
+
+	type(value_t), intent(inout) :: lhs
+	type(value_t), intent(in)    :: rhs
+	integer, intent(in)          :: op_kind
+
+	!*******
+
+	type(syntax_token_t) :: op_tok
+
+	op_tok%kind = op_kind
+	op_tok%text = ''
+	call compound_assign(lhs, rhs, op_tok)
+
+end subroutine do_compound
+
+!===============================================================================
+
 subroutine do_binop(left, right, op_kind, res)
 
 	! Compute a binary operation on two values, mirroring eval_binary_expr.
@@ -185,6 +206,8 @@ module subroutine vm_run(prog, state, res)
 	type(value_t), allocatable :: params_tmp(:)
 	integer :: ip, next_ip
 	integer :: i, fn_id, nparams, node_idx_call
+	integer :: id, type_
+	integer(kind = 8) :: i8
 
 	! Call-frame stack
 	type(frame_t) :: frames(MAX_FRAMES)
@@ -395,6 +418,85 @@ module subroutine vm_run(prog, state, res)
 
 			! Push the return value onto the caller's operand stack.
 			call vm_push_copy(stack, val)
+
+		! --- scalar subscript read: a[i] or s[i] -----------------------------------
+		! Evaluates subscript indices via subscript_eval (which calls syntax_eval
+		! on each index expression), then reads the element with get_val.
+		! For strings: extracts a single character.
+		case (OP_INDEX)
+			associate(n => prog%nodes(instr%a))
+			id = n%id_index
+			if (n%is_loc) then
+				type_ = state%locs%vals(id)%type
+			else
+				type_ = state%vars%vals(id)%type
+			end if
+
+			i8 = subscript_eval(n, state)
+
+			if (type_ == str_type) then
+				val%type = str_type
+				if (n%is_loc) then
+					val%sca%str%s = state%locs%vals(id)%sca%str%s(i8+1: i8+1)
+				else
+					val%sca%str%s = state%vars%vals(id)%sca%str%s(i8+1: i8+1)
+				end if
+			else
+				if (n%is_loc) then
+					call get_val(n, state%locs%vals(id), state, val, index_ = i8)
+				else
+					call get_val(n, state%vars%vals(id), state, val, index_ = i8)
+				end if
+			end if
+
+			call vm_push_copy(stack, val)
+			end associate
+
+		! --- slice / non-scalar subscript read: a[i:j], a[:], a[[0,2,4]] ---------
+		! Delegates to eval_name_expr which handles all slice kinds, array
+		! subscripts, step subscripts, and multi-rank combinations.
+		case (OP_SLICE)
+			call eval_name_expr(prog%nodes(instr%a), state, val)
+			call vm_push_copy(stack, val)
+
+		! --- scalar subscript write: a[i] = x  or  a[i] += x -------------------
+		! TOS holds the already-evaluated RHS.  Uses subscript_eval to find the
+		! linear index, reads the current element, applies the compound op, stores
+		! back.  For strings: direct character replacement (only plain = is valid).
+		case (OP_STORE_IDX)
+			call vm_pop_copy(stack, right)   ! RHS (already evaluated by compiler)
+			associate(n => prog%nodes(instr%a))
+			id = n%id_index
+			if (n%is_loc) then
+				type_ = state%locs%vals(id)%type
+			else
+				type_ = state%vars%vals(id)%type
+			end if
+
+			i8 = subscript_eval(n, state)
+
+			if (type_ == str_type) then
+				! String character assignment: s[i] = char_expr
+				if (n%is_loc) then
+					state%locs%vals(id)%sca%str%s(i8+1: i8+1) = right%sca%str%s
+				else
+					state%vars%vals(id)%sca%str%s(i8+1: i8+1) = right%sca%str%s
+				end if
+				call vm_push_copy(stack, right)
+			else
+				! Array element assignment (including compound ops)
+				if (n%is_loc) then
+					call get_val(n, state%locs%vals(id), state, val, index_ = i8)
+					call do_compound(val, right, instr%b)
+					call set_val(n, state%locs%vals(id), state, val, index_ = i8)
+				else
+					call get_val(n, state%vars%vals(id), state, val, index_ = i8)
+					call do_compound(val, right, instr%b)
+					call set_val(n, state%vars%vals(id), state, val, index_ = i8)
+				end if
+				call vm_push_copy(stack, val)
+			end if
+			end associate
 
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -465,6 +465,7 @@ module subroutine vm_run(prog, state, res)
 	stack           = new_value_vector()
 	allocate(frames(INIT_FRAMES_CAP))
 	allocate(for_iters(INIT_FORS_CAP))
+	allocate(iargs_pool(0))   ! pre-allocate so iargs_pool(1:0) is valid for nullary intrinsics
 
 	ip = prog%entry_main
 	do while (ip <= prog%len_)

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -206,7 +206,7 @@ module subroutine vm_run(prog, state, res)
 	type(value_t), allocatable :: params_tmp(:)
 	integer :: ip, next_ip
 	integer :: i, fn_id, nparams, node_idx_call
-	integer :: id, type_
+	integer :: id, type_, n_mem
 	integer(kind = 8) :: i8
 
 	! Call-frame stack
@@ -496,6 +496,55 @@ module subroutine vm_run(prog, state, res)
 				end if
 				call vm_push_copy(stack, val)
 			end if
+			end associate
+
+		! --- struct instance construction -----------------------------------------
+		! M5: pops nmembers values from stack in reverse order, builds a struct
+		! value_t (struct_name from the stored node), and pushes the result.
+		case (OP_MAKE_STRUCT)
+			associate(sn => prog%nodes(instr%a))
+			n_mem = size(sn%members)
+			val%type = struct_type
+			if (allocated(sn%struct_name)) val%struct_name = sn%struct_name
+			if (allocated(val%struct)) deallocate(val%struct)
+			allocate(val%struct(n_mem))
+			do i = n_mem, 1, -1
+				call vm_pop_copy(stack, val%struct(i))
+			end do
+			call vm_push_copy(stack, val)
+			end associate
+
+		! --- dot member read ------------------------------------------------------
+		! M5: calls get_val with the stored dot_expr node to handle simple,
+		! nested, and subscripted member access chains.
+		case (OP_LOAD_MEMBER)
+			associate(n => prog%nodes(instr%a))
+			id = n%id_index
+			if (n%is_loc) then
+				call get_val(n, state%locs%vals(id), state, val)
+			else
+				call get_val(n, state%vars%vals(id), state, val)
+			end if
+			call vm_push_copy(stack, val)
+			end associate
+
+		! --- dot member write -----------------------------------------------------
+		! M5: pops RHS from stack, reads current member via get_val, applies the
+		! compound op, writes back via set_val, and pushes the new member value.
+		case (OP_STORE_MEMBER)
+			call vm_pop_copy(stack, right)
+			associate(n => prog%nodes(instr%a))
+			id = n%id_index
+			if (n%is_loc) then
+				call get_val(n, state%locs%vals(id), state, val)
+				call do_compound(val, right, instr%b)
+				call set_val(n, state%locs%vals(id), state, val)
+			else
+				call get_val(n, state%vars%vals(id), state, val)
+				call do_compound(val, right, instr%b)
+				call set_val(n, state%vars%vals(id), state, val)
+			end if
+			call vm_push_copy(stack, val)
 			end associate
 
 		case default

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -25,6 +25,10 @@ submodule (syntran__vm_m) syntran__vm_exec
 		integer :: node_idx   = 0   ! index into prog%nodes for the fn_call_expr node
 		integer :: nfor_saved = 0   ! for-iter stack depth on function entry (restore at RET)
 		type(value_t), allocatable :: caller_locs(:)
+		! Locals pool buffer: retained across RET so the NEXT OP_CALL at this
+		! frame depth can reuse the allocation.  Avoids allocate/deallocate on
+		! every recursive call.  Reset with value_reset() before reuse.
+		type(value_t), allocatable :: locs_buf(:)
 	end type frame_t
 
 	!------------------------------------------------------------------------
@@ -103,6 +107,22 @@ end subroutine vm_pop_discard
 
 !===============================================================================
 
+subroutine vm_stack_grow(stack)
+	! Grow the operand stack when len_ > cap.  Called from the typed-load fast
+	! path which increments len_ before checking capacity.
+	type(value_vector_t), intent(inout) :: stack
+	type(value_t), allocatable :: tmp(:)
+	integer :: i
+	stack%cap = 2 * stack%len_
+	allocate(tmp(stack%cap))
+	do i = 1, stack%len_ - 1
+		call value_move(stack%v(i), tmp(i))
+	end do
+	call move_alloc(tmp, stack%v)
+end subroutine vm_stack_grow
+
+!===============================================================================
+
 subroutine do_compound(lhs, rhs, op_kind)
 
 	! Call compound_assign with just an integer op_kind (no full token needed).
@@ -124,34 +144,41 @@ end subroutine do_compound
 
 !===============================================================================
 
-subroutine do_binop(left, right, op_kind, res)
+subroutine do_binop(left, right, op_kind, restype, res)
 
 	! Compute a binary operation on two values, mirroring eval_binary_expr.
+	! restype: pre-computed result type from the compiler (node%val%type).
+	!   When restype /= unknown_type the expensive get_binary_op_kind call is
+	!   skipped.  The compiler always supplies this for OP_BINOP (instr%b).
 	! The math routines (add, subtract, etc.) are available because
 	! syntran__vm_m uses syntran__eval_m which uses syntran__math_m and
 	! syntran__bool_m.
 
 	type(value_t), intent(in) :: left, right
-	integer, intent(in) :: op_kind
+	integer, intent(in) :: op_kind, restype
 	type(value_t), intent(out) :: res
 
 	!*******
 
 	integer :: larrtype, rarrtype
 
-	larrtype = unknown_type
-	rarrtype = unknown_type
-	if (left %type == array_type) larrtype = left %array%type
-	if (right%type == array_type) rarrtype = right%array%type
+	if (restype /= unknown_type) then
+		res%type = restype
+	else
+		larrtype = unknown_type
+		rarrtype = unknown_type
+		if (left %type == array_type) larrtype = left %array%type
+		if (right%type == array_type) rarrtype = right%array%type
 
-	res%type = get_binary_op_kind(left%type, op_kind, right%type, &
-		larrtype, rarrtype)
+		res%type = get_binary_op_kind(left%type, op_kind, right%type, &
+			larrtype, rarrtype)
 
-	select case (res%type)
-	case (bool_array_type, f32_array_type, f64_array_type, &
-		i32_array_type, i64_array_type, str_array_type)
-		res%type = array_type
-	end select
+		select case (res%type)
+		case (bool_array_type, f32_array_type, f64_array_type, &
+			i32_array_type, i64_array_type, str_array_type)
+			res%type = array_type
+		end select
+	end if
 
 	select case (op_kind)
 	case (plus_token)
@@ -298,10 +325,12 @@ module subroutine vm_run(prog, state, res)
 							call value_move(state%locs%vals(cn%params(i)), params_tmp(i))
 						end if
 					end do
+					! Save callee locs to pool, then restore caller locs.
+					if (allocated(state%locs%vals)) then
+						call move_alloc(state%locs%vals, frames(nframes)%locs_buf)
+					end if
 					if (allocated(fr%caller_locs)) then
 						call move_alloc(fr%caller_locs, state%locs%vals)
-					else if (allocated(state%locs%vals)) then
-						deallocate(state%locs%vals)
 					end if
 					do i = 1, nparams
 						if (.not. cn%is_ref(i)) cycle
@@ -357,7 +386,7 @@ module subroutine vm_run(prog, state, res)
 		case (OP_BINOP)
 			call vm_pop_copy(stack, right)
 			call vm_pop_copy(stack, left)
-			call do_binop(left, right, instr%a, val)
+			call do_binop(left, right, instr%a, instr%b, val)
 			call vm_push_move(stack, val)
 
 		! --- unary operation ---
@@ -375,9 +404,11 @@ module subroutine vm_run(prog, state, res)
 			next_ip = instr%a
 
 		! --- control flow: conditional jump ---
+		! Bool is a scalar (no allocatables), so read sca%bool directly and
+		! decrement len_ without going through value_move.
 		case (OP_JUMP_IF_FALSE)
-			call vm_pop_copy(stack, val)
-			if (.not. val%sca%bool) next_ip = instr%a
+			if (.not. stack%v(stack%len_)%sca%bool) next_ip = instr%a
+			stack%len_ = stack%len_ - 1
 
 		! --- by-ref arg loading: move value from variable slot onto stack -----
 		! The original slot is left in a valid-but-empty state; the value is
@@ -422,8 +453,24 @@ module subroutine vm_run(prog, state, res)
 				call move_alloc(state%locs%vals, frames(nframes)%caller_locs)
 			end if
 
-			! Allocate the callee's local variable array.
-			allocate(state%locs%vals(cn%num_locs))
+			! Locals-pool: reuse the saved buffer from the previous call at this
+			! frame depth if it is large enough; otherwise allocate fresh.
+			if (allocated(frames(nframes)%locs_buf)) then
+				if (size(frames(nframes)%locs_buf) >= cn%num_locs) then
+					! Reuse: reset all used slots to unknown_type.
+					do i = 1, cn%num_locs
+						call value_reset(frames(nframes)%locs_buf(i))
+					end do
+					call move_alloc(frames(nframes)%locs_buf, state%locs%vals)
+				else
+					! Buffer too small (function changed num_locs? shouldn't happen).
+					deallocate(frames(nframes)%locs_buf)
+					allocate(state%locs%vals(cn%num_locs))
+				end if
+			else
+				! First call at this depth: allocate fresh (default-init = unknown_type).
+				allocate(state%locs%vals(cn%num_locs))
+			end if
 
 			! Move params into the callee's local slots.
 			do i = 1, nparams
@@ -454,12 +501,16 @@ module subroutine vm_run(prog, state, res)
 				end if
 			end do
 
+			! Save callee locs to pool for reuse by the next call at this depth.
+			if (allocated(state%locs%vals)) then
+				call move_alloc(state%locs%vals, frames(nframes)%locs_buf)
+			end if
+
 			! Restore caller's local variable array.
 			if (allocated(fr%caller_locs)) then
 				call move_alloc(fr%caller_locs, state%locs%vals)
-			else if (allocated(state%locs%vals)) then
-				deallocate(state%locs%vals)
 			end if
+			! (state%locs%vals stays unallocated if the caller had none — correct.)
 
 			! Write by-ref modified values back to caller's variable slots.
 			do i = 1, nparams
@@ -889,6 +940,373 @@ module subroutine vm_run(prog, state, res)
 		! Exits the VM loop immediately; TOS is the return value.
 		case (OP_HALT)
 			next_ip = prog%len_ + 1
+
+		! --- typed scalar opcodes (Stage 2) --------------------------------------
+		! Each operates on the raw sca fields of TOS / TOS-1 with no subroutine
+		! calls, no value_move, and no get_binary_op_kind.  The compiler only
+		! emits these for same-type scalar operands.
+
+		! Arithmetic (result same type as operands, left = TOS-1, right = TOS)
+		case (OP_ADD_I32)
+			stack%v(stack%len_-1)%sca%i32 = stack%v(stack%len_-1)%sca%i32 &
+			                              + stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_ADD_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              + stack%v(stack%len_  )%sca%i64
+			stack%len_ = stack%len_ - 1
+		case (OP_ADD_F32)
+			stack%v(stack%len_-1)%sca%f32 = stack%v(stack%len_-1)%sca%f32 &
+			                              + stack%v(stack%len_  )%sca%f32
+			stack%len_ = stack%len_ - 1
+		case (OP_ADD_F64)
+			stack%v(stack%len_-1)%sca%f64 = stack%v(stack%len_-1)%sca%f64 &
+			                              + stack%v(stack%len_  )%sca%f64
+			stack%len_ = stack%len_ - 1
+
+		case (OP_SUB_I32)
+			stack%v(stack%len_-1)%sca%i32 = stack%v(stack%len_-1)%sca%i32 &
+			                              - stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_SUB_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              - stack%v(stack%len_  )%sca%i64
+			stack%len_ = stack%len_ - 1
+		case (OP_SUB_F32)
+			stack%v(stack%len_-1)%sca%f32 = stack%v(stack%len_-1)%sca%f32 &
+			                              - stack%v(stack%len_  )%sca%f32
+			stack%len_ = stack%len_ - 1
+		case (OP_SUB_F64)
+			stack%v(stack%len_-1)%sca%f64 = stack%v(stack%len_-1)%sca%f64 &
+			                              - stack%v(stack%len_  )%sca%f64
+			stack%len_ = stack%len_ - 1
+
+		case (OP_MUL_I32)
+			stack%v(stack%len_-1)%sca%i32 = stack%v(stack%len_-1)%sca%i32 &
+			                              * stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_MUL_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              * stack%v(stack%len_  )%sca%i64
+			stack%len_ = stack%len_ - 1
+		case (OP_MUL_F32)
+			stack%v(stack%len_-1)%sca%f32 = stack%v(stack%len_-1)%sca%f32 &
+			                              * stack%v(stack%len_  )%sca%f32
+			stack%len_ = stack%len_ - 1
+		case (OP_MUL_F64)
+			stack%v(stack%len_-1)%sca%f64 = stack%v(stack%len_-1)%sca%f64 &
+			                              * stack%v(stack%len_  )%sca%f64
+			stack%len_ = stack%len_ - 1
+
+		case (OP_DIV_I32)
+			stack%v(stack%len_-1)%sca%i32 = stack%v(stack%len_-1)%sca%i32 &
+			                              / stack%v(stack%len_  )%sca%i32
+			stack%len_ = stack%len_ - 1
+		case (OP_DIV_I64)
+			stack%v(stack%len_-1)%sca%i64 = stack%v(stack%len_-1)%sca%i64 &
+			                              / stack%v(stack%len_  )%sca%i64
+			stack%len_ = stack%len_ - 1
+		case (OP_DIV_F32)
+			stack%v(stack%len_-1)%sca%f32 = stack%v(stack%len_-1)%sca%f32 &
+			                              / stack%v(stack%len_  )%sca%f32
+			stack%len_ = stack%len_ - 1
+		case (OP_DIV_F64)
+			stack%v(stack%len_-1)%sca%f64 = stack%v(stack%len_-1)%sca%f64 &
+			                              / stack%v(stack%len_  )%sca%f64
+			stack%len_ = stack%len_ - 1
+
+		case (OP_MOD_I32)
+			stack%v(stack%len_-1)%sca%i32 = mod(stack%v(stack%len_-1)%sca%i32, &
+			                                     stack%v(stack%len_  )%sca%i32)
+			stack%len_ = stack%len_ - 1
+		case (OP_MOD_I64)
+			stack%v(stack%len_-1)%sca%i64 = mod(stack%v(stack%len_-1)%sca%i64, &
+			                                     stack%v(stack%len_  )%sca%i64)
+			stack%len_ = stack%len_ - 1
+		case (OP_MOD_F32)
+			stack%v(stack%len_-1)%sca%f32 = mod(stack%v(stack%len_-1)%sca%f32, &
+			                                     stack%v(stack%len_  )%sca%f32)
+			stack%len_ = stack%len_ - 1
+		case (OP_MOD_F64)
+			stack%v(stack%len_-1)%sca%f64 = mod(stack%v(stack%len_-1)%sca%f64, &
+			                                     stack%v(stack%len_  )%sca%f64)
+			stack%len_ = stack%len_ - 1
+
+		! Comparisons: result type is bool; TOS-1 type updated to bool_type.
+		case (OP_LT_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                               < stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LT_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                               < stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LT_F32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f32 &
+			                               < stack%v(stack%len_  )%sca%f32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LT_F64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f64 &
+			                               < stack%v(stack%len_  )%sca%f64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+
+		case (OP_LE_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              <= stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LE_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              <= stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LE_F32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f32 &
+			                              <= stack%v(stack%len_  )%sca%f32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_LE_F64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f64 &
+			                              <= stack%v(stack%len_  )%sca%f64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+
+		case (OP_GT_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                               > stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GT_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                               > stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GT_F32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f32 &
+			                               > stack%v(stack%len_  )%sca%f32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GT_F64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f64 &
+			                               > stack%v(stack%len_  )%sca%f64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+
+		case (OP_GE_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              >= stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GE_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              >= stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GE_F32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f32 &
+			                              >= stack%v(stack%len_  )%sca%f32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_GE_F64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f64 &
+			                              >= stack%v(stack%len_  )%sca%f64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+
+		case (OP_EQ_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              == stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_EQ_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              == stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_EQ_F32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f32 &
+			                              == stack%v(stack%len_  )%sca%f32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_EQ_F64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f64 &
+			                              == stack%v(stack%len_  )%sca%f64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_EQ_BOOL)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%bool &
+			                             .eqv. stack%v(stack%len_  )%sca%bool
+			stack%len_ = stack%len_ - 1
+
+		case (OP_NE_I32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i32 &
+			                              /= stack%v(stack%len_  )%sca%i32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_NE_I64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%i64 &
+			                              /= stack%v(stack%len_  )%sca%i64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_NE_F32)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f32 &
+			                              /= stack%v(stack%len_  )%sca%f32
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_NE_F64)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%f64 &
+			                              /= stack%v(stack%len_  )%sca%f64
+			stack%v(stack%len_-1)%type = bool_type
+			stack%len_ = stack%len_ - 1
+		case (OP_NE_BOOL)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%bool &
+			                             .neqv. stack%v(stack%len_  )%sca%bool
+			stack%len_ = stack%len_ - 1
+
+		! Bool binary
+		case (OP_AND_BOOL)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%bool &
+			                           .and. stack%v(stack%len_  )%sca%bool
+			stack%len_ = stack%len_ - 1
+		case (OP_OR_BOOL)
+			stack%v(stack%len_-1)%sca%bool = stack%v(stack%len_-1)%sca%bool &
+			                            .or. stack%v(stack%len_  )%sca%bool
+			stack%len_ = stack%len_ - 1
+
+		! Unary: operand = TOS; result replaces TOS in-place.
+		case (OP_NEG_I32)
+			stack%v(stack%len_)%sca%i32 = -stack%v(stack%len_)%sca%i32
+		case (OP_NEG_I64)
+			stack%v(stack%len_)%sca%i64 = -stack%v(stack%len_)%sca%i64
+		case (OP_NEG_F32)
+			stack%v(stack%len_)%sca%f32 = -stack%v(stack%len_)%sca%f32
+		case (OP_NEG_F64)
+			stack%v(stack%len_)%sca%f64 = -stack%v(stack%len_)%sca%f64
+		case (OP_NOT_BOOL)
+			stack%v(stack%len_)%sca%bool = .not. stack%v(stack%len_)%sca%bool
+		case (OP_BNOT_I32)
+			stack%v(stack%len_)%sca%i32 = not(stack%v(stack%len_)%sca%i32)
+		case (OP_BNOT_I64)
+			stack%v(stack%len_)%sca%i64 = not(stack%v(stack%len_)%sca%i64)
+
+		! Typed scalar loads: push without value_copy overhead.
+		! For LOAD_CONST_*: value embedded in instruction (no const pool lookup).
+		! For LOAD_LOCAL/GLOBAL_*: slot index in instr%a, direct field read.
+		case (OP_LOAD_CONST_BOOL)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = bool_type
+			stack%v(stack%len_)%sca%bool = (instr%a /= 0)
+		case (OP_LOAD_CONST_I32)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = i32_type
+			stack%v(stack%len_)%sca%i32 = instr%a
+		case (OP_LOAD_CONST_I64)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = i64_type
+			stack%v(stack%len_)%sca%i64 = instr%c
+		case (OP_LOAD_CONST_F32)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = f32_type
+			stack%v(stack%len_)%sca%f32 = transfer(instr%a, 0.0_4)
+		case (OP_LOAD_CONST_F64)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = f64_type
+			stack%v(stack%len_)%sca%f64 = transfer(instr%c, 0.0d0)
+
+		case (OP_LOAD_LOCAL_BOOL)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type     = bool_type
+			stack%v(stack%len_)%sca%bool = state%locs%vals(instr%a)%sca%bool
+		case (OP_LOAD_LOCAL_I32)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = i32_type
+			stack%v(stack%len_)%sca%i32 = state%locs%vals(instr%a)%sca%i32
+		case (OP_LOAD_LOCAL_I64)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = i64_type
+			stack%v(stack%len_)%sca%i64 = state%locs%vals(instr%a)%sca%i64
+		case (OP_LOAD_LOCAL_F32)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = f32_type
+			stack%v(stack%len_)%sca%f32 = state%locs%vals(instr%a)%sca%f32
+		case (OP_LOAD_LOCAL_F64)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = f64_type
+			stack%v(stack%len_)%sca%f64 = state%locs%vals(instr%a)%sca%f64
+
+		case (OP_LOAD_GLOBAL_BOOL)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type     = bool_type
+			stack%v(stack%len_)%sca%bool = state%vars%vals(instr%a)%sca%bool
+		case (OP_LOAD_GLOBAL_I32)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = i32_type
+			stack%v(stack%len_)%sca%i32 = state%vars%vals(instr%a)%sca%i32
+		case (OP_LOAD_GLOBAL_I64)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = i64_type
+			stack%v(stack%len_)%sca%i64 = state%vars%vals(instr%a)%sca%i64
+		case (OP_LOAD_GLOBAL_F32)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = f32_type
+			stack%v(stack%len_)%sca%f32 = state%vars%vals(instr%a)%sca%f32
+		case (OP_LOAD_GLOBAL_F64)
+			stack%len_ = stack%len_ + 1
+			if (stack%len_ > stack%cap) call vm_stack_grow(stack)
+			stack%v(stack%len_)%type    = f64_type
+			stack%v(stack%len_)%sca%f64 = state%vars%vals(instr%a)%sca%f64
+
+		! Typed scalar stores: write TOS into slot, keep TOS.
+		! Always write %type too (slot may be freshly allocated = unknown_type).
+		case (OP_STORE_LOCAL_BOOL)
+			state%locs%vals(instr%a)%type     = bool_type
+			state%locs%vals(instr%a)%sca%bool = stack%v(stack%len_)%sca%bool
+		case (OP_STORE_LOCAL_I32)
+			state%locs%vals(instr%a)%type    = i32_type
+			state%locs%vals(instr%a)%sca%i32 = stack%v(stack%len_)%sca%i32
+		case (OP_STORE_LOCAL_I64)
+			state%locs%vals(instr%a)%type    = i64_type
+			state%locs%vals(instr%a)%sca%i64 = stack%v(stack%len_)%sca%i64
+		case (OP_STORE_LOCAL_F32)
+			state%locs%vals(instr%a)%type    = f32_type
+			state%locs%vals(instr%a)%sca%f32 = stack%v(stack%len_)%sca%f32
+		case (OP_STORE_LOCAL_F64)
+			state%locs%vals(instr%a)%type    = f64_type
+			state%locs%vals(instr%a)%sca%f64 = stack%v(stack%len_)%sca%f64
+
+		case (OP_STORE_GLOBAL_BOOL)
+			state%vars%vals(instr%a)%type     = bool_type
+			state%vars%vals(instr%a)%sca%bool = stack%v(stack%len_)%sca%bool
+		case (OP_STORE_GLOBAL_I32)
+			state%vars%vals(instr%a)%type    = i32_type
+			state%vars%vals(instr%a)%sca%i32 = stack%v(stack%len_)%sca%i32
+		case (OP_STORE_GLOBAL_I64)
+			state%vars%vals(instr%a)%type    = i64_type
+			state%vars%vals(instr%a)%sca%i64 = stack%v(stack%len_)%sca%i64
+		case (OP_STORE_GLOBAL_F32)
+			state%vars%vals(instr%a)%type    = f32_type
+			state%vars%vals(instr%a)%sca%f32 = stack%v(stack%len_)%sca%f32
+		case (OP_STORE_GLOBAL_F64)
+			state%vars%vals(instr%a)%type    = f64_type
+			state%vars%vals(instr%a)%sca%f64 = stack%v(stack%len_)%sca%f64
 
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -8,8 +8,21 @@ submodule (syntran__vm_m) syntran__vm_exec
 	! M0: OP_EVAL_NODE fallback (delegates to syntax_eval).
 	! M1: native handlers for scalars, loads/stores, binop, unop.
 	! M2: OP_JUMP / OP_JUMP_IF_FALSE for if/while/block/break/continue.
+	! M3: OP_CALL / OP_RET / OP_LOAD_REF_* for user-defined function frames.
 
 	implicit none
+
+	!------------------------------------------------------------------------
+	! Call frame: one entry per active function invocation.
+	! caller_locs holds state%locs%vals saved via move_alloc at CALL time,
+	! restored via move_alloc at RET time — mirrors eval_fn_call's locs0 pattern.
+	!------------------------------------------------------------------------
+
+	type :: frame_t
+		integer :: return_ip = 0
+		integer :: node_idx  = 0   ! index into prog%nodes for the fn_call_expr node
+		type(value_t), allocatable :: caller_locs(:)
+	end type frame_t
 
 !===============================================================================
 
@@ -165,11 +178,20 @@ module subroutine vm_run(prog, state, res)
 
 	!*******
 
+	integer, parameter :: MAX_FRAMES = 256
+
 	type(value_vector_t) :: stack
 	type(value_t) :: left, right, val
+	type(value_t), allocatable :: params_tmp(:)
 	integer :: ip, next_ip
+	integer :: i, fn_id, nparams, node_idx_call
 
-	stack = new_value_vector()
+	! Call-frame stack
+	type(frame_t) :: frames(MAX_FRAMES)
+	integer :: nframes
+
+	nframes = 0
+	stack   = new_value_vector()
 
 	ip = prog%entry_main
 	do while (ip <= prog%len_)
@@ -185,9 +207,50 @@ module subroutine vm_run(prog, state, res)
 		case (OP_EVAL_NODE)
 			call syntax_eval(prog%nodes(instr%a), state, val)
 			call vm_push_copy(stack, val)
-			! If the node executed a `return` statement, stop the VM loop so
-			! that the return value (now on TOS) is the final result.
-			if (state%returned) next_ip = prog%len_ + 1
+			if (state%returned) then
+				if (nframes > 0) then
+					! A return_statement executed inside an AST-walker fallback
+					! (e.g. a for loop) while we're inside a compiled function
+					! frame.  Perform the OP_RET cleanup inline so the frame is
+					! correctly unwound.
+					call vm_pop_copy(stack, val)   ! TOS = return value
+
+					! Move by-ref params back and restore caller locs
+					associate(fr => frames(nframes), &
+					          cn => prog%nodes(frames(nframes)%node_idx))
+					nparams = size(cn%params)
+					allocate(params_tmp(nparams))
+					do i = 1, nparams
+						if (cn%is_ref(i)) then
+							call value_move(state%locs%vals(cn%params(i)), params_tmp(i))
+						end if
+					end do
+					if (allocated(fr%caller_locs)) then
+						call move_alloc(fr%caller_locs, state%locs%vals)
+					else if (allocated(state%locs%vals)) then
+						deallocate(state%locs%vals)
+					end if
+					do i = 1, nparams
+						if (.not. cn%is_ref(i)) cycle
+						if (cn%args(i)%is_loc) then
+							call value_move(params_tmp(i), &
+								state%locs%vals(cn%args(i)%id_index))
+						else
+							call value_move(params_tmp(i), &
+								state%vars%vals(cn%args(i)%id_index))
+						end if
+					end do
+					next_ip = fr%return_ip
+					end associate
+					nframes = nframes - 1
+					deallocate(params_tmp)
+					state%returned = .false.
+					call vm_push_copy(stack, val)
+				else
+					! Top-level return: exit the main VM loop.
+					next_ip = prog%len_ + 1
+				end if
+			end if
 
 		! --- constants and variable loads ---
 		case (OP_LOAD_CONST)
@@ -231,6 +294,107 @@ module subroutine vm_run(prog, state, res)
 		case (OP_JUMP_IF_FALSE)
 			call vm_pop_copy(stack, val)
 			if (.not. val%sca%bool) next_ip = instr%a
+
+		! --- by-ref arg loading: move value from variable slot onto stack -----
+		! The original slot is left in a valid-but-empty state; the value is
+		! written back from the callee's frame at OP_RET time.
+		case (OP_LOAD_REF_GLOBAL)
+			call value_move(state%vars%vals(instr%a), val)
+			call vm_push_copy(stack, val)
+
+		case (OP_LOAD_REF_LOCAL)
+			call value_move(state%locs%vals(instr%a), val)
+			call vm_push_copy(stack, val)
+
+		! --- user function call -----------------------------------------------
+		! Stack layout on entry (bottom to top):
+		!   [by-value args in param index order] [by-ref args in param index order]
+		! Both groups in ascending param-index order.
+		! We pop by-ref first (they're on top) in reverse index order, then by-val.
+		case (OP_CALL)
+			fn_id        = instr%a
+			node_idx_call = instr%b
+			associate(cn => prog%nodes(node_idx_call))
+			nparams = 0
+			if (allocated(cn%params)) nparams = size(cn%params)
+			allocate(params_tmp(nparams))
+
+			! Pop by-ref args in reverse param-index order.
+			do i = nparams, 1, -1
+				if (cn%is_ref(i)) call vm_pop_copy(stack, params_tmp(i))
+			end do
+
+			! Pop by-val args in reverse param-index order.
+			do i = nparams, 1, -1
+				if (.not. cn%is_ref(i)) call vm_pop_copy(stack, params_tmp(i))
+			end do
+
+			! Push a new call frame; save caller's local vars.
+			nframes = nframes + 1
+			frames(nframes)%return_ip = ip + 1
+			frames(nframes)%node_idx  = node_idx_call
+			if (allocated(state%locs%vals)) then
+				call move_alloc(state%locs%vals, frames(nframes)%caller_locs)
+			end if
+
+			! Allocate the callee's local variable array.
+			allocate(state%locs%vals(cn%num_locs))
+
+			! Move params into the callee's local slots.
+			do i = 1, nparams
+				call value_move(params_tmp(i), state%locs%vals(cn%params(i)))
+			end do
+
+			deallocate(params_tmp)
+			end associate
+
+			next_ip = prog%fn_entry(fn_id)
+
+		! --- return from user function ----------------------------------------
+		! TOS is the return value (or an unknown sentinel for void functions).
+		! Write back by-ref params, restore caller locs, jump to return_ip.
+		case (OP_RET)
+			call vm_pop_copy(stack, val)   ! pop return value
+
+			associate(fr => frames(nframes), &
+			          cn => prog%nodes(frames(nframes)%node_idx))
+			nparams = 0
+			if (allocated(cn%params)) nparams = size(cn%params)
+			allocate(params_tmp(nparams))
+
+			! Move by-ref params from callee locs into params_tmp for writeback.
+			do i = 1, nparams
+				if (cn%is_ref(i)) then
+					call value_move(state%locs%vals(cn%params(i)), params_tmp(i))
+				end if
+			end do
+
+			! Restore caller's local variable array.
+			if (allocated(fr%caller_locs)) then
+				call move_alloc(fr%caller_locs, state%locs%vals)
+			else if (allocated(state%locs%vals)) then
+				deallocate(state%locs%vals)
+			end if
+
+			! Write by-ref modified values back to caller's variable slots.
+			do i = 1, nparams
+				if (.not. cn%is_ref(i)) cycle
+				if (cn%args(i)%is_loc) then
+					call value_move(params_tmp(i), &
+						state%locs%vals(cn%args(i)%id_index))
+				else
+					call value_move(params_tmp(i), &
+						state%vars%vals(cn%args(i)%id_index))
+				end if
+			end do
+
+			next_ip = fr%return_ip
+			end associate
+			nframes = nframes - 1
+			deallocate(params_tmp)
+
+			! Push the return value onto the caller's operand stack.
+			call vm_push_copy(stack, val)
 
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -1,0 +1,51 @@
+
+!===============================================================================
+
+submodule (syntran__vm_m) syntran__vm_exec
+
+	! M0 VM execution loop.  For now the only opcode is OP_EVAL_NODE which
+	! delegates to the AST-walking syntax_eval.  Subsequent milestones will add
+	! real opcodes as each node kind is lowered in the compiler.
+
+	implicit none
+
+!===============================================================================
+
+contains
+
+!===============================================================================
+
+module subroutine vm_run(prog, state, res)
+
+	type(program_t), intent(in) :: prog
+	type(state_t), intent(inout) :: state
+	type(value_t), intent(out) :: res
+
+	!*******
+
+	integer :: ip
+
+	do ip = prog%entry_main, prog%len_
+
+		select case (prog%code(ip)%op)
+
+		case (OP_EVAL_NODE)
+
+			! Delegate to the AST walker.  The result of the last OP_EVAL_NODE
+			! becomes the program result, matching eval_translation_unit semantics.
+			call syntax_eval(prog%nodes(prog%code(ip)%a), state, res)
+
+		case default
+			write(*,*) 'VM: unknown opcode ', prog%code(ip)%op
+
+		end select
+
+	end do
+
+end subroutine vm_run
+
+!===============================================================================
+
+end submodule syntran__vm_exec
+
+!===============================================================================

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -7,6 +7,7 @@ submodule (syntran__vm_m) syntran__vm_exec
 	!
 	! M0: OP_EVAL_NODE fallback (delegates to syntax_eval).
 	! M1: native handlers for scalars, loads/stores, binop, unop.
+	! M2: OP_JUMP / OP_JUMP_IF_FALSE for if/while/block/break/continue.
 
 	implicit none
 
@@ -166,11 +167,15 @@ module subroutine vm_run(prog, state, res)
 
 	type(value_vector_t) :: stack
 	type(value_t) :: left, right, val
-	integer :: ip
+	integer :: ip, next_ip
 
 	stack = new_value_vector()
 
-	do ip = prog%entry_main, prog%len_
+	ip = prog%entry_main
+	do while (ip <= prog%len_)
+
+		! Default: advance to next instruction.  Jump handlers override this.
+		next_ip = ip + 1
 
 		associate(instr => prog%code(ip))
 
@@ -180,6 +185,9 @@ module subroutine vm_run(prog, state, res)
 		case (OP_EVAL_NODE)
 			call syntax_eval(prog%nodes(instr%a), state, val)
 			call vm_push_copy(stack, val)
+			! If the node executed a `return` statement, stop the VM loop so
+			! that the return value (now on TOS) is the final result.
+			if (state%returned) next_ip = prog%len_ + 1
 
 		! --- constants and variable loads ---
 		case (OP_LOAD_CONST)
@@ -215,12 +223,23 @@ module subroutine vm_run(prog, state, res)
 		case (OP_POP)
 			call vm_pop_discard(stack)
 
+		! --- control flow: unconditional jump ---
+		case (OP_JUMP)
+			next_ip = instr%a
+
+		! --- control flow: conditional jump ---
+		case (OP_JUMP_IF_FALSE)
+			call vm_pop_copy(stack, val)
+			if (.not. val%sca%bool) next_ip = instr%a
+
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op
 
 		end select
 
 		end associate
+
+		ip = next_ip
 
 	end do
 

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -209,6 +209,10 @@ module subroutine vm_run(prog, state, res)
 	integer :: id, type_, n_mem
 	integer(kind = 8) :: i8
 
+	! M6: temporary arg array for OP_CALL_INTR native dispatch
+	type(value_t), allocatable :: iargs(:)
+	integer :: nintr
+
 	! Call-frame stack
 	type(frame_t) :: frames(MAX_FRAMES)
 	integer :: nframes
@@ -546,6 +550,24 @@ module subroutine vm_run(prog, state, res)
 			end if
 			call vm_push_copy(stack, val)
 			end associate
+
+		! --- M6: intrinsic function call -----------------------------------------
+		! Native mode (b >= 0): args are on the stack; pop them, dispatch by intr_id.
+		! Fallback mode (b < 0): node is in pool at c; call eval_fn_call_intr.
+		case (OP_CALL_INTR)
+			if (instr%b < 0) then
+				! CALL_INTR_NODE fallback (readln, close)
+				call eval_fn_call_intr(prog%nodes(int(instr%c)), state, val)
+			else
+				nintr = instr%b
+				allocate(iargs(nintr))
+				do i = nintr, 1, -1
+					call vm_pop_copy(stack, iargs(i))
+				end do
+				call vm_call_intr(instr%a, nintr, iargs, state, val)
+				deallocate(iargs)
+			end if
+			call vm_push_copy(stack, val)
 
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -5,10 +5,12 @@ submodule (syntran__vm_m) syntran__vm_exec
 
 	! Stack-based bytecode VM execution loop.
 	!
-	! M0: OP_EVAL_NODE fallback (delegates to syntax_eval).
+	! M0: OP_EVAL_NODE fallback (delegates to syntax_eval; kept as debug opcode).
 	! M1: native handlers for scalars, loads/stores, binop, unop.
 	! M2: OP_JUMP / OP_JUMP_IF_FALSE for if/while/block/break/continue.
 	! M3: OP_CALL / OP_RET / OP_LOAD_REF_* for user-defined function frames.
+	! M8: OP_FOR_SETUP / OP_FOR_NEXT (for loops), OP_NEW_ARRAY, OP_STORE_SLICE,
+	!     OP_HALT; readln/close handled inline in OP_CALL_INTR.
 
 	implicit none
 
@@ -19,10 +21,33 @@ submodule (syntran__vm_m) syntran__vm_exec
 	!------------------------------------------------------------------------
 
 	type :: frame_t
-		integer :: return_ip = 0
-		integer :: node_idx  = 0   ! index into prog%nodes for the fn_call_expr node
+		integer :: return_ip  = 0
+		integer :: node_idx   = 0   ! index into prog%nodes for the fn_call_expr node
+		integer :: nfor_saved = 0   ! for-iter stack depth on function entry (restore at RET)
 		type(value_t), allocatable :: caller_locs(:)
 	end type frame_t
+
+	!------------------------------------------------------------------------
+	! For-loop iterator frame: one entry per active native for loop.
+	! Mirrors the local variables in eval_for_statement (eval_control.f90:14).
+	! for_kind uses the same constants as eval_for_statement: bound_array,
+	! step_array, len_array, expl_array, size_array, unif_array, array_expr,
+	! or str_type for string iteration.
+	!------------------------------------------------------------------------
+
+	type :: for_iter_t
+		integer :: for_kind = 0           ! array kind or str_type
+		integer :: itr_type = 0           ! element type (i32/i64/f32/f64/str)
+		integer(kind = 8) :: len8  = 0    ! total iteration count
+		integer(kind = 8) :: counter = 0  ! current 1-based counter (0 = before first)
+		integer :: node_idx = 0           ! prog%nodes index of the for_statement node
+		type(value_t) :: lbound_          ! loop lower bound / uniform value
+		type(value_t) :: step             ! loop step
+		type(value_t) :: ubound_          ! loop upper bound
+		type(value_t) :: len_             ! loop length (len_array kind)
+		type(array_t) :: array            ! materialized array (non-primary array exprs)
+		type(value_t) :: str_             ! string to iterate over (str_type)
+	end type for_iter_t
 
 !===============================================================================
 
@@ -200,6 +225,7 @@ module subroutine vm_run(prog, state, res)
 	!*******
 
 	integer, parameter :: MAX_FRAMES = 256
+	integer, parameter :: MAX_FORS   = 64
 
 	type(value_vector_t) :: stack
 	type(value_t) :: left, right, val
@@ -217,7 +243,12 @@ module subroutine vm_run(prog, state, res)
 	type(frame_t) :: frames(MAX_FRAMES)
 	integer :: nframes
 
+	! For-loop iterator stack (M8)
+	type(for_iter_t) :: for_iters(MAX_FORS)
+	integer :: nfor
+
 	nframes = 0
+	nfor    = 0
 	stack   = new_value_vector()
 
 	ip = prog%entry_main
@@ -356,9 +387,10 @@ module subroutine vm_run(prog, state, res)
 				if (.not. cn%is_ref(i)) call vm_pop_copy(stack, params_tmp(i))
 			end do
 
-			! Push a new call frame; save caller's local vars.
+			! Push a new call frame; save caller's local vars and for-iter depth.
 			nframes = nframes + 1
-			frames(nframes)%return_ip = ip + 1
+			frames(nframes)%return_ip  = ip + 1
+			frames(nframes)%nfor_saved = nfor
 			frames(nframes)%node_idx  = node_idx_call
 			if (allocated(state%locs%vals)) then
 				call move_alloc(state%locs%vals, frames(nframes)%caller_locs)
@@ -416,6 +448,7 @@ module subroutine vm_run(prog, state, res)
 			end do
 
 			next_ip = fr%return_ip
+			nfor    = fr%nfor_saved   ! clean up any for-iters the callee leaked (e.g. via return)
 			end associate
 			nframes = nframes - 1
 			deallocate(params_tmp)
@@ -552,22 +585,282 @@ module subroutine vm_run(prog, state, res)
 			end associate
 
 		! --- M6: intrinsic function call -----------------------------------------
-		! Native mode (b >= 0): args are on the stack; pop them, dispatch by intr_id.
-		! Fallback mode (b < 0): node is in pool at c; call eval_fn_call_intr.
+		! Native mode: pop args from stack, dispatch by intr_id.
+		! readln/close: inline handling with slot writeback via instr%c.
 		case (OP_CALL_INTR)
-			if (instr%b < 0) then
-				! CALL_INTR_NODE fallback (readln, close)
-				call eval_fn_call_intr(prog%nodes(int(instr%c)), state, val)
+			nintr = instr%b
+			allocate(iargs(nintr))
+			do i = nintr, 1, -1
+				call vm_pop_copy(stack, iargs(i))
+			end do
+
+			if (instr%a == INTR_READLN) then
+				! readln: read a line from the file; set eof flag on the orig slot.
+				block
+				integer :: slot_id_, io_
+				logical :: is_loc_
+				slot_id_ = int(instr%c / 2)
+				is_loc_  = (mod(instr%c, 2_8) == 1_8)
+				if (.not. iargs(1)%sca%file_%is_open) then
+					write(*,*) err_rt_prefix//'readln() was called for file "' &
+						//iargs(1)%sca%file_%name_//'" which is not open'
+					call internal_error()
+				end if
+				if (.not. iargs(1)%sca%file_%mode_read) then
+					write(*,*) err_rt_prefix//'readln() was called for file "' &
+						//iargs(1)%sca%file_%name_//'" which was not opened in read mode "r"'
+					call internal_error()
+				end if
+				val%type = str_type
+				val%sca%str%s = read_line(iargs(1)%sca%file_%unit_, io_)
+				if (io_ == iostat_end) then
+					if (is_loc_) then
+						state%locs%vals(slot_id_)%sca%file_%eof = .true.
+					else
+						state%vars%vals(slot_id_)%sca%file_%eof = .true.
+					end if
+				else if (io_ /= 0 .and. io_ /= iostat_eor) then
+					write(*,*) err_rt_prefix//'cannot readln() from file "' &
+						//iargs(1)%sca%file_%name_//'"'
+					call internal_error()
+				end if
+				end block
+
+			else if (instr%a == INTR_CLOSE) then
+				! close: close the file unit; set is_open=false on the orig slot.
+				block
+				integer :: slot_id_
+				logical :: is_loc_
+				slot_id_ = int(instr%c / 2)
+				is_loc_  = (mod(instr%c, 2_8) == 1_8)
+				if (.not. iargs(1)%sca%file_%is_open) then
+					write(*,*) err_rt_prefix//'close() was called for file "' &
+						//iargs(1)%sca%file_%name_//'" which is not open'
+					call internal_error()
+				end if
+				if (is_loc_) then
+					state%locs%vals(slot_id_)%sca%file_%is_open = .false.
+				else
+					state%vars%vals(slot_id_)%sca%file_%is_open = .false.
+				end if
+				close(iargs(1)%sca%file_%unit_)
+				val%type = unknown_type
+				end block
+
 			else
-				nintr = instr%b
-				allocate(iargs(nintr))
-				do i = nintr, 1, -1
-					call vm_pop_copy(stack, iargs(i))
-				end do
 				call vm_call_intr(instr%a, nintr, iargs, state, val)
-				deallocate(iargs)
 			end if
+
+			deallocate(iargs)
 			call vm_push_copy(stack, val)
+
+		! --- M8: for-loop setup ---------------------------------------------------
+		! Evaluates loop bounds / computes len8; pushes a for_iter_t onto the
+		! for-iterator stack.  Mirrors eval_for_statement setup (eval_control.f90:31-205).
+		case (OP_FOR_SETUP)
+			block
+			integer :: fi, rk_
+			type(value_t) :: tmp_
+
+			nfor = nfor + 1
+			fi = nfor
+			for_iters(fi)%node_idx = instr%a
+			for_iters(fi)%counter  = 0
+			for_iters(fi)%len8     = 0
+			for_iters(fi)%itr_type = unknown_type
+
+			associate(nd => prog%nodes(instr%a))
+
+			if (allocated(nd%array%lbound)) &
+				call syntax_eval(nd%array%lbound, state, for_iters(fi)%lbound_)
+			if (allocated(nd%array%step  )) &
+				call syntax_eval(nd%array%step,   state, for_iters(fi)%step   )
+			if (allocated(nd%array%ubound)) &
+				call syntax_eval(nd%array%ubound, state, for_iters(fi)%ubound_)
+			if (allocated(nd%array%len_  )) &
+				call syntax_eval(nd%array%len_,   state, for_iters(fi)%len_   )
+
+			select case (nd%array%kind)
+			case (array_expr)
+				for_iters(fi)%for_kind = nd%array%val%array%kind
+
+				select case (nd%array%val%array%kind)
+				case (bound_array)
+					! Promote bounds to i64 if either is i64
+					if (any(i64_type == [for_iters(fi)%lbound_%type, &
+					                      for_iters(fi)%ubound_%type])) then
+						call promote_i32_i64(for_iters(fi)%lbound_)
+						call promote_i32_i64(for_iters(fi)%ubound_)
+						for_iters(fi)%itr_type = i64_type
+					else
+						for_iters(fi)%itr_type = i32_type
+					end if
+					if (.not. any(for_iters(fi)%itr_type == [i32_type, i64_type])) then
+						write(*,*) err_int_prefix//'unit step array type not implemented'//color_reset
+						call internal_error()
+					end if
+					for_iters(fi)%len8 = for_iters(fi)%ubound_%to_i64() &
+					                   - for_iters(fi)%lbound_%to_i64()
+
+				case (step_array)
+					! Promote all to i64 if any is i64
+					if (any(i64_type == [for_iters(fi)%lbound_%type, &
+					                      for_iters(fi)%step%type, &
+					                      for_iters(fi)%ubound_%type])) then
+						call promote_i32_i64(for_iters(fi)%lbound_)
+						call promote_i32_i64(for_iters(fi)%step)
+						call promote_i32_i64(for_iters(fi)%ubound_)
+						for_iters(fi)%itr_type = i64_type
+					else
+						for_iters(fi)%itr_type = for_iters(fi)%lbound_%type
+					end if
+					select case (for_iters(fi)%itr_type)
+					case (i32_type)
+						if (for_iters(fi)%step%sca%i32 == 0) then
+							write(*,*) err_rt_prefix//'for loop step is 0'//color_reset
+							call internal_error()
+						end if
+						for_iters(fi)%len8 = ( &
+							for_iters(fi)%ubound_%sca%i32 - for_iters(fi)%lbound_%sca%i32 &
+							+ for_iters(fi)%step%sca%i32  &
+							- sign(1, for_iters(fi)%step%sca%i32) ) / for_iters(fi)%step%sca%i32
+					case (i64_type)
+						if (for_iters(fi)%step%sca%i64 == 0) then
+							write(*,*) err_rt_prefix//'for loop step is 0'//color_reset
+							call internal_error()
+						end if
+						for_iters(fi)%len8 = ( &
+							for_iters(fi)%ubound_%sca%i64 - for_iters(fi)%lbound_%sca%i64 &
+							+ for_iters(fi)%step%sca%i64  &
+							- sign(int(1,8), for_iters(fi)%step%sca%i64) ) / for_iters(fi)%step%sca%i64
+					case (f32_type)
+						if (for_iters(fi)%step%sca%f32 == 0.0) then
+							write(*,*) err_rt_prefix//'for loop step is 0.0'//color_reset
+							call internal_error()
+						end if
+						for_iters(fi)%len8 = ceiling( &
+							(for_iters(fi)%ubound_%sca%f32 - for_iters(fi)%lbound_%sca%f32) &
+							/ for_iters(fi)%step%sca%f32)
+					case (f64_type)
+						if (for_iters(fi)%step%sca%f64 == 0.0d0) then
+							write(*,*) err_rt_prefix//'for loop step is 0.0'//color_reset
+							call internal_error()
+						end if
+						for_iters(fi)%len8 = ceiling( &
+							(for_iters(fi)%ubound_%sca%f64 - for_iters(fi)%lbound_%sca%f64) &
+							/ for_iters(fi)%step%sca%f64)
+					case default
+						write(*,*) err_int_prefix//'step array type not implemented'//color_reset
+						call internal_error()
+					end select
+
+				case (len_array)
+					for_iters(fi)%itr_type = nd%array%val%array%type
+					select case (for_iters(fi)%itr_type)
+					case (f32_type, f64_type)
+						for_iters(fi)%len8 = for_iters(fi)%len_%to_i64()
+					case default
+						write(*,*) err_int_prefix//'bound/len array type not implemented'//color_reset
+						call internal_error()
+					end select
+
+				case (expl_array)
+					for_iters(fi)%len8 = nd%array%val%array%len_
+
+				case (size_array)
+					rk_ = size(nd%array%size)
+					for_iters(fi)%len8 = 1
+					do i = 1, rk_
+						call syntax_eval(nd%array%size(i), state, tmp_)
+						for_iters(fi)%len8 = for_iters(fi)%len8 * tmp_%to_i64()
+					end do
+
+				case (unif_array)
+					rk_ = size(nd%array%size)
+					for_iters(fi)%len8 = 1
+					do i = 1, rk_
+						call syntax_eval(nd%array%size(i), state, tmp_)
+						for_iters(fi)%len8 = for_iters(fi)%len8 * tmp_%to_i64()
+					end do
+
+				case default
+					write(*,*) err_int_prefix//'for loop: unknown array kind'//color_reset
+					call internal_error()
+				end select
+
+			case default
+				! Non-primary array expression
+				if (nd%array%val%type == str_type) then
+					for_iters(fi)%for_kind = str_type
+					for_iters(fi)%itr_type = str_type
+					call syntax_eval(nd%array, state, tmp_)
+					call value_move(tmp_, for_iters(fi)%str_)
+					for_iters(fi)%len8 = len(for_iters(fi)%str_%sca%str%s, 8)
+				else
+					for_iters(fi)%for_kind = array_expr
+					call syntax_eval(nd%array, state, tmp_)
+					for_iters(fi)%array = tmp_%array
+					for_iters(fi)%len8  = for_iters(fi)%array%len_
+				end if
+			end select
+
+			end associate
+			end block
+
+		! --- M8: for-loop advance --------------------------------------------------
+		! Increments counter; if exhausted: pop iter stack and jump to loop end.
+		! Otherwise: call array_at to produce the next iterator value and write
+		! it to the loop variable slot, then fall through to the body.
+		case (OP_FOR_NEXT)
+			! Advance counter; if exhausted: jump to L_pop (does NOT pop nfor here —
+			! OP_FOR_POP does that for both exhaustion and break).
+			block
+			integer :: fi
+			fi = nfor
+			for_iters(fi)%counter = for_iters(fi)%counter + 1
+			if (for_iters(fi)%counter > for_iters(fi)%len8) then
+				next_ip = instr%a   ! jump to FOR_POP; no nfor decrement here
+			else
+				val%type = for_iters(fi)%itr_type
+				call array_at(val, for_iters(fi)%for_kind, for_iters(fi)%counter, &
+					for_iters(fi)%lbound_, for_iters(fi)%step, for_iters(fi)%ubound_, &
+					for_iters(fi)%len_, for_iters(fi)%array, &
+					prog%nodes(for_iters(fi)%node_idx)%array%elems, for_iters(fi)%str_, &
+					state)
+				associate(nd => prog%nodes(for_iters(fi)%node_idx))
+				if (nd%is_loc) then
+					state%locs%vals(nd%id_index) = val
+				else
+					state%vars%vals(nd%id_index) = val
+				end if
+				end associate
+			end if
+			end block
+
+		! --- M8: for-loop exit (all paths: exhaustion and break) -------------------
+		! Emitted once at L_pop, after the loop's back-edge JUMP.
+		! Both FOR_NEXT's exhaustion jump and break-statement jumps target here.
+		case (OP_FOR_POP)
+			nfor = nfor - 1
+
+		! --- M8: array construction -----------------------------------------------
+		! Delegates to eval_array_expr for all array kinds (bound, step, len,
+		! expl, size, unif).  Rank-1 native specialization is a future perf pass.
+		case (OP_NEW_ARRAY)
+			call eval_array_expr(prog%nodes(instr%a), state, val)
+			call vm_push_copy(stack, val)
+
+		! --- M8: slice/complex LHS assignment ------------------------------------
+		! Handles slice-range LHS (a[1:3] = x) and subscript-less compound
+		! assignments by delegating to eval_assignment_expr.
+		case (OP_STORE_SLICE)
+			call eval_assignment_expr(prog%nodes(instr%a), state, val)
+			call vm_push_copy(stack, val)
+
+		! --- M8: top-level return (halt) ------------------------------------------
+		! Exits the VM loop immediately; TOS is the return value.
+		case (OP_HALT)
+			next_ip = prog%len_ + 1
 
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -59,6 +59,55 @@ contains
 
 !===============================================================================
 
+! --- call-frame and for-iterator grow helpers ---------------------------------
+!
+! Both frames(:) and for_iters(:) start at a small initial capacity and double
+! on demand (move-on-grow).  This gives the VM unbounded recursion / loop depth,
+! matching the AST walker which is bounded only by OS stack / memory.
+
+subroutine grow_frames(frames)
+	! Double the call-frame stack.  Allocatable components (caller_locs,
+	! locs_buf) are moved cheaply; scalar fields are plain assigned.
+	type(frame_t), allocatable, intent(inout) :: frames(:)
+	type(frame_t), allocatable :: tmp(:)
+	integer :: i, n
+	n = size(frames)
+	allocate(tmp(2 * n))
+	do i = 1, n
+		tmp(i)%return_ip  = frames(i)%return_ip
+		tmp(i)%node_idx   = frames(i)%node_idx
+		tmp(i)%nfor_saved = frames(i)%nfor_saved
+		if (allocated(frames(i)%caller_locs)) &
+			call move_alloc(frames(i)%caller_locs, tmp(i)%caller_locs)
+		if (allocated(frames(i)%locs_buf)) &
+			call move_alloc(frames(i)%locs_buf, tmp(i)%locs_buf)
+	end do
+	call move_alloc(tmp, frames)
+end subroutine grow_frames
+
+!===============================================================================
+
+subroutine grow_fors(for_iters)
+	! Double the for-iterator stack.  for_iter_t has no allocatable components
+	! at the top level (its value_t/array_t members have allocatables inside),
+	! so we use elementwise deep copy via the project's standard copy pattern.
+	type(for_iter_t), allocatable, intent(inout) :: for_iters(:)
+	type(for_iter_t), allocatable :: tmp(:)
+	integer :: i, n
+	n = size(for_iters)
+	allocate(tmp(n))		! stage into a same-sized tmp first
+	do i = 1, n
+		tmp(i) = for_iters(i)
+	end do
+	deallocate(for_iters)
+	allocate(for_iters(2 * n))
+	do i = 1, n
+		for_iters(i) = tmp(i)
+	end do
+end subroutine grow_fors
+
+!===============================================================================
+
 ! --- operand-stack helpers ----------------------------------------------------
 !
 ! vm_push_copy: push a deep copy; source remains live (LOAD_CONST, LOAD_GLOBAL,
@@ -127,9 +176,8 @@ subroutine do_compound(lhs, rhs, op_kind)
 
 	! Call compound_assign with just an integer op_kind (no full token needed).
 	! op%text is only used for error messages, so an empty string is fine.
-	!
-	! The token is declared save so %text is allocated exactly once (on the first
-	! call) instead of on every call — avoids a per-operation heap alloc/free.
+	! Note: the VM dispatch loop is single-threaded; module-level compiler state
+	! in compile_ctrl.f90 is similarly non-reentrant by design.
 
 	type(value_t), intent(inout) :: lhs
 	type(value_t), intent(in)    :: rhs
@@ -137,13 +185,9 @@ subroutine do_compound(lhs, rhs, op_kind)
 
 	!*******
 
-	type(syntax_token_t), save :: op_tok
-	logical,              save :: first_call = .true.
+	type(syntax_token_t) :: op_tok
 
-	if (first_call) then
-		op_tok%text = ''   ! single heap allocation; persists via save
-		first_call  = .false.
-	end if
+	op_tok%text = ''
 	op_tok%kind = op_kind
 	call compound_assign(lhs, rhs, op_tok)
 
@@ -386,8 +430,10 @@ module subroutine vm_run(prog, state, res)
 
 	!*******
 
-	integer, parameter :: MAX_FRAMES = 256
-	integer, parameter :: MAX_FORS   = 64
+	! Initial capacities for the growable stacks.  Both double on demand so
+	! there is no hard recursion or loop-nesting limit (parity with AST walker).
+	integer, parameter :: INIT_FRAMES_CAP = 64
+	integer, parameter :: INIT_FORS_CAP   = 16
 
 	type(value_vector_t) :: stack
 	type(value_t) :: left, right, val
@@ -404,12 +450,12 @@ module subroutine vm_run(prog, state, res)
 	type(value_t), allocatable :: iargs(:)
 	integer :: nintr
 
-	! Call-frame stack
-	type(frame_t) :: frames(MAX_FRAMES)
+	! Call-frame stack (growable; no hard recursion limit)
+	type(frame_t), allocatable :: frames(:)
 	integer :: nframes
 
-	! For-loop iterator stack (M8)
-	type(for_iter_t) :: for_iters(MAX_FORS)
+	! For-loop iterator stack (growable; no hard loop-nesting limit)
+	type(for_iter_t), allocatable :: for_iters(:)
 	integer :: nfor
 
 	!print *, "starting vm_run()"
@@ -418,6 +464,8 @@ module subroutine vm_run(prog, state, res)
 	nfor            = 0
 	params_pool_cap = 0
 	stack           = new_value_vector()
+	allocate(frames(INIT_FRAMES_CAP))
+	allocate(for_iters(INIT_FORS_CAP))
 
 	ip = prog%entry_main
 	do while (ip <= prog%len_)
@@ -579,6 +627,8 @@ module subroutine vm_run(prog, state, res)
 			end do
 
 			! Push a new call frame; save caller's local vars and for-iter depth.
+			! Grow the frame stack if needed (no hard recursion limit).
+			if (nframes + 1 > size(frames)) call grow_frames(frames)
 			nframes = nframes + 1
 			frames(nframes)%return_ip  = ip + 1
 			frames(nframes)%nfor_saved = nfor
@@ -878,6 +928,8 @@ module subroutine vm_run(prog, state, res)
 			integer :: fi, rk_
 			type(value_t) :: tmp_
 
+			! Grow the for-iterator stack if needed (no hard loop-nesting limit).
+			if (nfor + 1 > size(for_iters)) call grow_fors(for_iters)
 			nfor = nfor + 1
 			fi = nfor
 			for_iters(fi)%node_idx = instr%a
@@ -1707,6 +1759,7 @@ module subroutine vm_run(prog, state, res)
 
 		case default
 			write(*,*) 'VM: unknown opcode ', instr%op
+			call internal_error()
 
 		end select
 

--- a/src/vm_intr.f90
+++ b/src/vm_intr.f90
@@ -1,0 +1,719 @@
+
+!===============================================================================
+
+submodule (syntran__vm_m) syntran__vm_intr
+
+	! M6: integer-id intrinsic dispatch for the bytecode VM.
+	!
+	! vm_call_intr is called by vm_exec when OP_CALL_INTR fires in native mode
+	! (b >= 0).  Args have already been popped from the operand stack in reverse
+	! order and collected into args(1:nargs).
+	!
+	! CALL_INTR_NODE fallback cases (readln, close) are NOT routed here; they are
+	! handled directly in vm_exec by calling eval_fn_call_intr with the stored node.
+
+	implicit none
+
+!===============================================================================
+
+contains
+
+!===============================================================================
+
+module subroutine vm_call_intr(intr_id, nargs, args, state, res)
+
+	integer, intent(in) :: intr_id, nargs
+	type(value_t), intent(in) :: args(:)
+	type(state_t), intent(inout) :: state
+	type(value_t), intent(out) :: res
+
+	!*******
+
+	integer :: i, io
+
+	character :: char_
+
+	character(len = :), allocatable :: mode_, status_, resolved_path_
+
+	type(char_vector_t) :: str_
+
+	double precision, parameter :: LOG_E_2  = log(2.d0)
+	real,             parameter :: LOG_E_2F = log(2.0)
+
+	res%type = unknown_type		! default for void/sentinel results
+
+	select case (intr_id)
+
+	!==== Math ==================================================================
+
+	case (INTR_EXP_F32)
+		res%type = f32_type; res%sca%f32 = exp(args(1)%sca%f32)
+
+	case (INTR_EXP_F64)
+		res%type = f64_type; res%sca%f64 = exp(args(1)%sca%f64)
+
+	case (INTR_EXP_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = exp(args(1)%array%f32)
+
+	case (INTR_EXP_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = exp(args(1)%array%f64)
+
+	!****
+	case (INTR_LOG_F32)
+		res%type = f32_type; res%sca%f32 = log(args(1)%sca%f32)
+
+	case (INTR_LOG_F64)
+		res%type = f64_type; res%sca%f64 = log(args(1)%sca%f64)
+
+	case (INTR_LOG_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = log(args(1)%array%f32)
+
+	case (INTR_LOG_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = log(args(1)%array%f64)
+
+	!****
+	case (INTR_LOG10_F32)
+		res%type = f32_type; res%sca%f32 = log10(args(1)%sca%f32)
+
+	case (INTR_LOG10_F64)
+		res%type = f64_type; res%sca%f64 = log10(args(1)%sca%f64)
+
+	case (INTR_LOG10_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = log10(args(1)%array%f32)
+
+	case (INTR_LOG10_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = log10(args(1)%array%f64)
+
+	!****
+	case (INTR_LOG2_F32)
+		res%type = f32_type; res%sca%f32 = log(args(1)%sca%f32) / LOG_E_2F
+
+	case (INTR_LOG2_F64)
+		res%type = f64_type; res%sca%f64 = log(args(1)%sca%f64) / LOG_E_2
+
+	case (INTR_LOG2_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = log(args(1)%array%f32) / LOG_E_2F
+
+	case (INTR_LOG2_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = log(args(1)%array%f64) / LOG_E_2
+
+	!****
+	case (INTR_SQRT_F32)
+		res%type = f32_type; res%sca%f32 = sqrt(args(1)%sca%f32)
+
+	case (INTR_SQRT_F64)
+		res%type = f64_type; res%sca%f64 = sqrt(args(1)%sca%f64)
+
+	case (INTR_SQRT_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = sqrt(args(1)%array%f32)
+
+	case (INTR_SQRT_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = sqrt(args(1)%array%f64)
+
+	!****
+	case (INTR_ABS_F32)
+		res%type = f32_type; res%sca%f32 = abs(args(1)%sca%f32)
+
+	case (INTR_ABS_F64)
+		res%type = f64_type; res%sca%f64 = abs(args(1)%sca%f64)
+
+	case (INTR_ABS_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = abs(args(1)%array%f32)
+
+	case (INTR_ABS_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = abs(args(1)%array%f64)
+
+	case (INTR_ABS_I32)
+		res%type = i32_type; res%sca%i32 = abs(args(1)%sca%i32)
+
+	case (INTR_ABS_I64)
+		res%type = i64_type; res%sca%i64 = abs(args(1)%sca%i64)
+
+	case (INTR_ABS_I32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, i32_type)
+		res%array%i32 = abs(args(1)%array%i32)
+
+	case (INTR_ABS_I64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, i64_type)
+		res%array%i64 = abs(args(1)%array%i64)
+
+	!==== Trig ==================================================================
+
+	case (INTR_COS_F32)
+		res%type = f32_type; res%sca%f32 = cos(args(1)%sca%f32)
+
+	case (INTR_COS_F64)
+		res%type = f64_type; res%sca%f64 = cos(args(1)%sca%f64)
+
+	case (INTR_COS_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = cos(args(1)%array%f32)
+
+	case (INTR_COS_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = cos(args(1)%array%f64)
+
+	!****
+	case (INTR_SIN_F32)
+		res%type = f32_type; res%sca%f32 = sin(args(1)%sca%f32)
+
+	case (INTR_SIN_F64)
+		res%type = f64_type; res%sca%f64 = sin(args(1)%sca%f64)
+
+	case (INTR_SIN_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = sin(args(1)%array%f32)
+
+	case (INTR_SIN_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = sin(args(1)%array%f64)
+
+	!****
+	case (INTR_TAN_F32)
+		res%type = f32_type; res%sca%f32 = tan(args(1)%sca%f32)
+
+	case (INTR_TAN_F64)
+		res%type = f64_type; res%sca%f64 = tan(args(1)%sca%f64)
+
+	case (INTR_TAN_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = tan(args(1)%array%f32)
+
+	case (INTR_TAN_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = tan(args(1)%array%f64)
+
+	!****
+	case (INTR_COSD_F32)
+		res%type = f32_type; res%sca%f32 = cosd(args(1)%sca%f32)
+
+	case (INTR_COSD_F64)
+		res%type = f64_type; res%sca%f64 = cosd(args(1)%sca%f64)
+
+	case (INTR_COSD_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = cosd(args(1)%array%f32)
+
+	case (INTR_COSD_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = cosd(args(1)%array%f64)
+
+	!****
+	case (INTR_SIND_F32)
+		res%type = f32_type; res%sca%f32 = sind(args(1)%sca%f32)
+
+	case (INTR_SIND_F64)
+		res%type = f64_type; res%sca%f64 = sind(args(1)%sca%f64)
+
+	case (INTR_SIND_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = sind(args(1)%array%f32)
+
+	case (INTR_SIND_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = sind(args(1)%array%f64)
+
+	!****
+	case (INTR_TAND_F32)
+		res%type = f32_type; res%sca%f32 = tand(args(1)%sca%f32)
+
+	case (INTR_TAND_F64)
+		res%type = f64_type; res%sca%f64 = tand(args(1)%sca%f64)
+
+	case (INTR_TAND_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = tand(args(1)%array%f32)
+
+	case (INTR_TAND_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = tand(args(1)%array%f64)
+
+	!****
+	case (INTR_ACOS_F32)
+		res%type = f32_type; res%sca%f32 = acos(args(1)%sca%f32)
+
+	case (INTR_ACOS_F64)
+		res%type = f64_type; res%sca%f64 = acos(args(1)%sca%f64)
+
+	case (INTR_ACOS_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = acos(args(1)%array%f32)
+
+	case (INTR_ACOS_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = acos(args(1)%array%f64)
+
+	!****
+	case (INTR_ASIN_F32)
+		res%type = f32_type; res%sca%f32 = asin(args(1)%sca%f32)
+
+	case (INTR_ASIN_F64)
+		res%type = f64_type; res%sca%f64 = asin(args(1)%sca%f64)
+
+	case (INTR_ASIN_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = asin(args(1)%array%f32)
+
+	case (INTR_ASIN_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = asin(args(1)%array%f64)
+
+	!****
+	case (INTR_ATAN_F32)
+		res%type = f32_type; res%sca%f32 = atan(args(1)%sca%f32)
+
+	case (INTR_ATAN_F64)
+		res%type = f64_type; res%sca%f64 = atan(args(1)%sca%f64)
+
+	case (INTR_ATAN_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = atan(args(1)%array%f32)
+
+	case (INTR_ATAN_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = atan(args(1)%array%f64)
+
+	!****
+	case (INTR_ACOSD_F32)
+		res%type = f32_type; res%sca%f32 = acosd(args(1)%sca%f32)
+
+	case (INTR_ACOSD_F64)
+		res%type = f64_type; res%sca%f64 = acosd(args(1)%sca%f64)
+
+	case (INTR_ACOSD_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = acosd(args(1)%array%f32)
+
+	case (INTR_ACOSD_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = acosd(args(1)%array%f64)
+
+	!****
+	case (INTR_ASIND_F32)
+		res%type = f32_type; res%sca%f32 = asind(args(1)%sca%f32)
+
+	case (INTR_ASIND_F64)
+		res%type = f64_type; res%sca%f64 = asind(args(1)%sca%f64)
+
+	case (INTR_ASIND_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = asind(args(1)%array%f32)
+
+	case (INTR_ASIND_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = asind(args(1)%array%f64)
+
+	!****
+	case (INTR_ATAND_F32)
+		res%type = f32_type; res%sca%f32 = atand(args(1)%sca%f32)
+
+	case (INTR_ATAND_F64)
+		res%type = f64_type; res%sca%f64 = atand(args(1)%sca%f64)
+
+	case (INTR_ATAND_F32_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f32_type)
+		res%array%f32 = atand(args(1)%array%f32)
+
+	case (INTR_ATAND_F64_ARR)
+		res%type = array_type
+		res%array = mold(args(1)%array, f64_type)
+		res%array%f64 = atand(args(1)%array%f64)
+
+	!==== Minmax (variadic) =====================================================
+
+	case (INTR_MIN_I32)
+		res%type = i32_type
+		res%sca%i32 = args(1)%sca%i32
+		do i = 2, nargs
+			res%sca%i32 = min(res%sca%i32, args(i)%sca%i32)
+		end do
+
+	case (INTR_MIN_I64)
+		res%type = i64_type
+		res%sca%i64 = args(1)%sca%i64
+		do i = 2, nargs
+			res%sca%i64 = min(res%sca%i64, args(i)%sca%i64)
+		end do
+
+	case (INTR_MIN_F32)
+		res%type = f32_type
+		res%sca%f32 = args(1)%sca%f32
+		do i = 2, nargs
+			res%sca%f32 = min(res%sca%f32, args(i)%sca%f32)
+		end do
+
+	case (INTR_MIN_F64)
+		res%type = f64_type
+		res%sca%f64 = args(1)%sca%f64
+		do i = 2, nargs
+			res%sca%f64 = min(res%sca%f64, args(i)%sca%f64)
+		end do
+
+	!****
+	case (INTR_MAX_I32)
+		res%type = i32_type
+		res%sca%i32 = args(1)%sca%i32
+		do i = 2, nargs
+			res%sca%i32 = max(res%sca%i32, args(i)%sca%i32)
+		end do
+
+	case (INTR_MAX_I64)
+		res%type = i64_type
+		res%sca%i64 = args(1)%sca%i64
+		do i = 2, nargs
+			res%sca%i64 = max(res%sca%i64, args(i)%sca%i64)
+		end do
+
+	case (INTR_MAX_F32)
+		res%type = f32_type
+		res%sca%f32 = args(1)%sca%f32
+		do i = 2, nargs
+			res%sca%f32 = max(res%sca%f32, args(i)%sca%f32)
+		end do
+
+	case (INTR_MAX_F64)
+		res%type = f64_type
+		res%sca%f64 = args(1)%sca%f64
+		do i = 2, nargs
+			res%sca%f64 = max(res%sca%f64, args(i)%sca%f64)
+		end do
+
+	!==== String / conversion ===================================================
+
+	case (INTR_PRINTLN)
+		res%type = void_type
+		do i = 1, nargs
+			write(output_unit, '(a)', advance = 'no') args(i)%to_str()
+		end do
+		write(output_unit, *)
+
+	case (INTR_STR)
+		res%type = str_type
+		str_ = new_char_vector()
+		do i = 1, nargs
+			call str_%push(args(i)%to_str())
+		end do
+		res%sca%str%s = str_%trim()
+
+	case (INTR_LEN)
+		res%type = i64_type
+		res%sca%i64 = len(args(1)%sca%str%s, 8)
+
+	case (INTR_REPEAT)
+		res%type = str_type
+		res%sca%str%s = repeat(args(1)%sca%str%s, args(2)%sca%i32)
+
+	case (INTR_PARSE_I32)
+		res%type = i32_type
+		read(args(1)%sca%str%s, *, iostat = io) res%sca%i32
+		if (io /= 0) then
+			write(*,*) err_rt_prefix//" cannot parse_i32() for argument `"// &
+				args(1)%sca%str%s//"`"//color_reset
+			call internal_error()
+		end if
+
+	case (INTR_PARSE_I64)
+		res%type = i64_type
+		read(args(1)%sca%str%s, *, iostat = io) res%sca%i64
+		if (io /= 0) then
+			write(*,*) err_rt_prefix//" cannot parse_i64() for argument `"// &
+				args(1)%sca%str%s//"`"//color_reset
+			call internal_error()
+		end if
+
+	case (INTR_PARSE_F32)
+		res%type = f32_type
+		read(args(1)%sca%str%s, *, iostat = io) res%sca%f32
+		if (io /= 0) then
+			write(*,*) err_rt_prefix//" cannot parse_f32() for argument `"// &
+				args(1)%sca%str%s//"`"//color_reset
+			call internal_error()
+		end if
+
+	case (INTR_PARSE_F64)
+		res%type = f64_type
+		read(args(1)%sca%str%s, *, iostat = io) res%sca%f64
+		if (io /= 0) then
+			write(*,*) err_rt_prefix//" cannot parse_f64() for argument `"// &
+				args(1)%sca%str%s//"`"//color_reset
+			call internal_error()
+		end if
+
+	case (INTR_CHAR)
+		res%type = str_type
+		res%sca%str%s = achar(args(1)%sca%i32)
+
+	case (INTR_I32_SCA)
+		res%type = i32_type
+		res%sca%i32 = args(1)%to_i32()
+
+	case (INTR_I32_ARR)
+		res%type = array_type
+		res%array = args(1)%to_i32_array()
+
+	case (INTR_I64_SCA)
+		res%type = i64_type
+		res%sca%i64 = args(1)%to_i64()
+
+	case (INTR_I64_ARR)
+		res%type = array_type
+		res%array = args(1)%to_i64_array()
+
+	!==== I/O (native-able) =====================================================
+
+	case (INTR_OPEN)
+		! args(1) = filename (str), args(2) = mode (str)
+		res%type = file_type
+		res%sca%file_%mode_read  = .false.
+		res%sca%file_%mode_write = .false.
+		mode_ = args(2)%sca%str%s
+		do i = 1, len(mode_)
+			char_ = mode_(i: i)
+			select case (char_)
+			case ("r")
+				res%sca%file_%mode_read = .true.
+			case ("w")
+				res%sca%file_%mode_write = .true.
+			case default
+				write(*,*) err_rt_prefix//"bad file mode character """// &
+					char_//""""//color_reset
+				call internal_error()
+			end select
+		end do
+		if (res%sca%file_%mode_read .and. res%sca%file_%mode_write) then
+			write(*,*) err_rt_prefix//"cannot open file """//args(1)%sca%str%s// &
+				""" in combined read/write mode """//mode_//""""
+			call internal_error()
+		end if
+		if (res%sca%file_%mode_read) then
+			status_ = "old"
+		else
+			status_ = "unknown"
+		end if
+		resolved_path_ = resolve_path(state%src_dir, args(1)%sca%str%s)
+		open(newunit = res%sca%file_%unit_, file = resolved_path_, &
+			status = status_, iostat = io)
+		if (io /= 0) then
+			write(*,*) err_rt_prefix//"cannot open file """//resolved_path_//""""
+			write(*,*) "iostat = ", str(io)
+			call internal_error()
+		end if
+		res%sca%file_%name_ = args(1)%sca%str%s
+		res%sca%file_%eof   = .false.
+		res%sca%file_%is_open = .true.
+
+	case (INTR_WRITELN)
+		! args(1) = file handle, args(2:) = values to write
+		res%type = void_type
+		if (.not. args(1)%sca%file_%is_open) then
+			write(*,*) err_rt_prefix//"writeln() was called for file """// &
+				args(1)%sca%file_%name_//""" which is not open"
+			call internal_error()
+		end if
+		if (.not. args(1)%sca%file_%mode_write) then
+			write(*,*) err_rt_prefix//"writeln() was called for file """// &
+				args(1)%sca%file_%name_//""" which was not opened in write mode ""w"""
+			call internal_error()
+		end if
+		do i = 2, nargs
+			write(args(1)%sca%file_%unit_, '(a)', advance = 'no') args(i)%to_str()
+		end do
+		write(args(1)%sca%file_%unit_, *)
+
+	case (INTR_EOF)
+		! args(1) = file handle (read only — no writeback needed)
+		res%type = bool_type
+		if (.not. args(1)%sca%file_%is_open) then
+			write(*,*) err_rt_prefix//"eof() was called for file """// &
+				args(1)%sca%file_%name_//""" which is not open"
+			call internal_error()
+		end if
+		if (.not. args(1)%sca%file_%mode_read) then
+			write(*,*) err_rt_prefix//"eof() was called for file """// &
+				args(1)%sca%file_%name_//""" which was not opened in read mode ""r"""
+			call internal_error()
+		end if
+		res%sca%bool = args(1)%sca%file_%eof
+
+	!==== Misc ==================================================================
+
+	case (INTR_EXIT)
+		io = args(1)%sca%i32
+		if (io == 0) then
+			write(*,*) fg_bright_green//'Exiting syntran with status '// &
+				str(io)//color_reset
+		else
+			write(*,*) fg_bold_bright_red//'Exiting syntran with status '// &
+				str(io)//color_reset
+		end if
+		call exit(io)
+
+	case (INTR_SIZE)
+		res%type = i64_type
+		if (nargs == 2) then
+			if (args(2)%sca%i32 < 0 .or. args(2)%sca%i32 >= args(1)%array%rank) then
+				write(*,*) err_rt_prefix//"rank mismatch in size() call"//color_reset
+				call internal_error()
+			end if
+			res%sca%i64 = int(args(1)%array%size(args(2)%sca%i32 + 1))
+		else
+			res%sca%i64 = int(args(1)%array%len_)
+		end if
+
+	case (INTR_COUNT)
+		res%type = i64_type
+		res%sca%i64 = count(args(1)%array%bool)
+
+	!==== Reductions ============================================================
+
+	case (INTR_MINVAL_I32)
+		res%type = i32_type; res%sca%i32 = minval(args(1)%array%i32)
+
+	case (INTR_MINVAL_I64)
+		res%type = i64_type; res%sca%i64 = minval(args(1)%array%i64)
+
+	case (INTR_MINVAL_F32)
+		res%type = f32_type; res%sca%f32 = minval(args(1)%array%f32)
+
+	case (INTR_MINVAL_F64)
+		res%type = f64_type; res%sca%f64 = minval(args(1)%array%f64)
+
+	case (INTR_MAXVAL_I32)
+		res%type = i32_type; res%sca%i32 = maxval(args(1)%array%i32)
+
+	case (INTR_MAXVAL_I64)
+		res%type = i64_type; res%sca%i64 = maxval(args(1)%array%i64)
+
+	case (INTR_MAXVAL_F32)
+		res%type = f32_type; res%sca%f32 = maxval(args(1)%array%f32)
+
+	case (INTR_MAXVAL_F64)
+		res%type = f64_type; res%sca%f64 = maxval(args(1)%array%f64)
+
+	case (INTR_SUM_I32)
+		res%type = i32_type; res%sca%i32 = sum(args(1)%array%i32)
+
+	case (INTR_SUM_I64)
+		res%type = i64_type; res%sca%i64 = sum(args(1)%array%i64)
+
+	case (INTR_SUM_F32)
+		res%type = f32_type; res%sca%f32 = sum(args(1)%array%f32)
+
+	case (INTR_SUM_F64)
+		res%type = f64_type; res%sca%f64 = sum(args(1)%array%f64)
+
+	case (INTR_PRODUCT_I32)
+		res%type = i32_type; res%sca%i32 = product(args(1)%array%i32)
+
+	case (INTR_PRODUCT_I64)
+		res%type = i64_type; res%sca%i64 = product(args(1)%array%i64)
+
+	case (INTR_PRODUCT_F32)
+		res%type = f32_type; res%sca%f32 = product(args(1)%array%f32)
+
+	case (INTR_PRODUCT_F64)
+		res%type = f64_type; res%sca%f64 = product(args(1)%array%f64)
+
+	case (INTR_NORM2_F32)
+		res%type = f32_type; res%sca%f32 = norm2(args(1)%array%f32)
+
+	case (INTR_NORM2_F64)
+		res%type = f64_type; res%sca%f64 = norm2(args(1)%array%f64)
+
+	case (INTR_DOT_F32)
+		res%type = f32_type
+		res%sca%f32 = dot_product(args(1)%array%f32, args(2)%array%f32)
+
+	case (INTR_DOT_F64)
+		res%type = f64_type
+		res%sca%f64 = dot_product(args(1)%array%f64, args(2)%array%f64)
+
+	case (INTR_DOT_I32)
+		res%type = i32_type
+		res%sca%i32 = dot_product(args(1)%array%i32, args(2)%array%i32)
+
+	case (INTR_DOT_I64)
+		res%type = i64_type
+		res%sca%i64 = dot_product(args(1)%array%i64, args(2)%array%i64)
+
+	case (INTR_ALL)
+		res%type = bool_type; res%sca%bool = all(args(1)%array%bool)
+
+	case (INTR_ANY)
+		res%type = bool_type; res%sca%bool = any(args(1)%array%bool)
+
+	case (INTR_ARGS)
+		res%type = array_type
+		allocate(res%array)
+		res%array%type = str_type
+		res%array%rank = 1
+		res%array%len_ = state%script_args%len_
+		allocate(res%array%size(1))
+		res%array%size(1) = res%array%len_
+		allocate(res%array%str(res%array%len_))
+		do i = 1, state%script_args%len_
+			res%array%str(i) = state%script_args%v(i)
+		end do
+
+	case default
+		write(*,*) 'VM: unknown intr_id in vm_call_intr: ', intr_id
+		call internal_error()
+
+	end select
+
+end subroutine vm_call_intr
+
+!===============================================================================
+
+end submodule syntran__vm_intr
+
+!===============================================================================

--- a/src/vm_intr.f90
+++ b/src/vm_intr.f90
@@ -442,55 +442,58 @@ module subroutine vm_call_intr(intr_id, nargs, args, state, res)
 		do i = 1, nargs
 			call str_%push(args(i)%to_str())
 		end do
-		res%sca%str%s = str_%trim()
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = str_%trim()
 
 	case (INTR_LEN)
 		res%type = i64_type
-		res%sca%i64 = len(args(1)%sca%str%s, 8)
+		res%sca%i64 = len(args(1)%str%s, 8)
 
 	case (INTR_REPEAT)
 		res%type = str_type
-		res%sca%str%s = repeat(args(1)%sca%str%s, args(2)%sca%i32)
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = repeat(args(1)%str%s, args(2)%sca%i32)
 
 	case (INTR_PARSE_I32)
 		res%type = i32_type
-		read(args(1)%sca%str%s, *, iostat = io) res%sca%i32
+		read(args(1)%str%s, *, iostat = io) res%sca%i32
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_i32() for argument `"// &
-				args(1)%sca%str%s//"`"//color_reset
+				args(1)%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
 	case (INTR_PARSE_I64)
 		res%type = i64_type
-		read(args(1)%sca%str%s, *, iostat = io) res%sca%i64
+		read(args(1)%str%s, *, iostat = io) res%sca%i64
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_i64() for argument `"// &
-				args(1)%sca%str%s//"`"//color_reset
+				args(1)%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
 	case (INTR_PARSE_F32)
 		res%type = f32_type
-		read(args(1)%sca%str%s, *, iostat = io) res%sca%f32
+		read(args(1)%str%s, *, iostat = io) res%sca%f32
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_f32() for argument `"// &
-				args(1)%sca%str%s//"`"//color_reset
+				args(1)%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
 	case (INTR_PARSE_F64)
 		res%type = f64_type
-		read(args(1)%sca%str%s, *, iostat = io) res%sca%f64
+		read(args(1)%str%s, *, iostat = io) res%sca%f64
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//" cannot parse_f64() for argument `"// &
-				args(1)%sca%str%s//"`"//color_reset
+				args(1)%str%s//"`"//color_reset
 			call internal_error()
 		end if
 
 	case (INTR_CHAR)
 		res%type = str_type
-		res%sca%str%s = achar(args(1)%sca%i32)
+		if (.not. allocated(res%str)) allocate(res%str)
+		res%str%s = achar(args(1)%sca%i32)
 
 	case (INTR_I32_SCA)
 		res%type = i32_type
@@ -513,76 +516,77 @@ module subroutine vm_call_intr(intr_id, nargs, args, state, res)
 	case (INTR_OPEN)
 		! args(1) = filename (str), args(2) = mode (str)
 		res%type = file_type
-		res%sca%file_%mode_read  = .false.
-		res%sca%file_%mode_write = .false.
-		mode_ = args(2)%sca%str%s
+		if (.not. allocated(res%file_)) allocate(res%file_)
+		res%file_%mode_read  = .false.
+		res%file_%mode_write = .false.
+		mode_ = args(2)%str%s
 		do i = 1, len(mode_)
 			char_ = mode_(i: i)
 			select case (char_)
 			case ("r")
-				res%sca%file_%mode_read = .true.
+				res%file_%mode_read = .true.
 			case ("w")
-				res%sca%file_%mode_write = .true.
+				res%file_%mode_write = .true.
 			case default
 				write(*,*) err_rt_prefix//"bad file mode character """// &
 					char_//""""//color_reset
 				call internal_error()
 			end select
 		end do
-		if (res%sca%file_%mode_read .and. res%sca%file_%mode_write) then
-			write(*,*) err_rt_prefix//"cannot open file """//args(1)%sca%str%s// &
+		if (res%file_%mode_read .and. res%file_%mode_write) then
+			write(*,*) err_rt_prefix//"cannot open file """//args(1)%str%s// &
 				""" in combined read/write mode """//mode_//""""
 			call internal_error()
 		end if
-		if (res%sca%file_%mode_read) then
+		if (res%file_%mode_read) then
 			status_ = "old"
 		else
 			status_ = "unknown"
 		end if
-		resolved_path_ = resolve_path(state%src_dir, args(1)%sca%str%s)
-		open(newunit = res%sca%file_%unit_, file = resolved_path_, &
+		resolved_path_ = resolve_path(state%src_dir, args(1)%str%s)
+		open(newunit = res%file_%unit_, file = resolved_path_, &
 			status = status_, iostat = io)
 		if (io /= 0) then
 			write(*,*) err_rt_prefix//"cannot open file """//resolved_path_//""""
 			write(*,*) "iostat = ", str(io)
 			call internal_error()
 		end if
-		res%sca%file_%name_ = args(1)%sca%str%s
-		res%sca%file_%eof   = .false.
-		res%sca%file_%is_open = .true.
+		res%file_%name_ = args(1)%str%s
+		res%file_%eof   = .false.
+		res%file_%is_open = .true.
 
 	case (INTR_WRITELN)
 		! args(1) = file handle, args(2:) = values to write
 		res%type = void_type
-		if (.not. args(1)%sca%file_%is_open) then
+		if (.not. args(1)%file_%is_open) then
 			write(*,*) err_rt_prefix//"writeln() was called for file """// &
-				args(1)%sca%file_%name_//""" which is not open"
+				args(1)%file_%name_//""" which is not open"
 			call internal_error()
 		end if
-		if (.not. args(1)%sca%file_%mode_write) then
+		if (.not. args(1)%file_%mode_write) then
 			write(*,*) err_rt_prefix//"writeln() was called for file """// &
-				args(1)%sca%file_%name_//""" which was not opened in write mode ""w"""
+				args(1)%file_%name_//""" which was not opened in write mode ""w"""
 			call internal_error()
 		end if
 		do i = 2, nargs
-			write(args(1)%sca%file_%unit_, '(a)', advance = 'no') args(i)%to_str()
+			write(args(1)%file_%unit_, '(a)', advance = 'no') args(i)%to_str()
 		end do
-		write(args(1)%sca%file_%unit_, *)
+		write(args(1)%file_%unit_, *)
 
 	case (INTR_EOF)
 		! args(1) = file handle (read only — no writeback needed)
 		res%type = bool_type
-		if (.not. args(1)%sca%file_%is_open) then
+		if (.not. args(1)%file_%is_open) then
 			write(*,*) err_rt_prefix//"eof() was called for file """// &
-				args(1)%sca%file_%name_//""" which is not open"
+				args(1)%file_%name_//""" which is not open"
 			call internal_error()
 		end if
-		if (.not. args(1)%sca%file_%mode_read) then
+		if (.not. args(1)%file_%mode_read) then
 			write(*,*) err_rt_prefix//"eof() was called for file """// &
-				args(1)%sca%file_%name_//""" which was not opened in read mode ""r"""
+				args(1)%file_%name_//""" which was not opened in read mode ""r"""
 			call internal_error()
 		end if
-		res%sca%bool = args(1)%sca%file_%eof
+		res%sca%bool = args(1)%file_%eof
 
 	!==== Misc ==================================================================
 


### PR DESCRIPTION
## Overview

Adds a stack-based bytecode VM as the primary evaluation backend, replacing the AST-walking interpreter. The VM is incrementally built through a series of milestones (M0–M9), each lowering more AST node kinds to native opcodes.

The AST walker is retained as a legacy fallback selectable via `SYNTRAN_BACKEND=ast` (with a deprecation warning), and CI now tests both backends.

## Milestones

| Milestone | What was added |
|-----------|---------------|
| M0 | Scaffolding: `bytecode.f90`, `compile_ctrl.f90`, `vm_exec.f90`; OP_EVAL_NODE fallback for all nodes |
| M1 | Scalars: literals, name_expr, binary_expr, unary_expr, let_expr, simple assignment, translation_unit |
| M2 | Control flow: if/while/block/break/continue via JUMP/JUMP_IF_FALSE |
| M3 | Functions and frames: OP_CALL/OP_RET, by-reference args, call-frame stack |
| M4 | Arrays: OP_INDEX/OP_SLICE/OP_STORE_IDX |
| M5 | Structs |
| M6 | Intrinsic functions (OP_CALL_INTR + integer dispatch table) |
| M7 | Module imports: transitively-compiled module fn bodies |
| M8 | Specialized same-type scalar opcodes (OP_ADD_I32, OP_MUL_F64, etc.) — bypass do_binop dispatch entirely for the hot path |
| M9 | Native array indexing (OP_INDEX_NAT / OP_STORE_IDX_NAT) — scalar subscript reads/writes without AST fallback |

## Key design points

- **Single flat code array**: all function bodies and top-level code concatenated; `fn_entry(:)` holds per-function entry offsets.
- **Constant pool** (`consts(:)`): literal values referenced by OP_LOAD_CONST.
- **Node pool** (`nodes(:)`): AST nodes stored by opcodes that need full node context at VM runtime (OP_INDEX, OP_SLICE, OP_FOR_SETUP, OP_NEW_ARRAY, OP_MAKE_STRUCT, OP_LOAD_MEMBER, OP_CALL, etc.).
- **Operand stack**: `value_vector_t` with move semantics where possible.
- **Call frames**: growable `frames(:)` stack saving return IP + caller locals; no static depth limit.
- **Compiler state** (`compiler_state_t`): fully encapsulated, passed explicitly — compiler is reentrant.
- **Backend selection**: `SYNTRAN_BACKEND=ast` env var selects the legacy AST walker; default is bytecode.

## Performance

Benchmark: largest prime below 60000 via trial division (`src/benchmarks/primes-1.syntran`).
Release build (gfortran, `fpm build --profile release`), 5 runs each, WSL2/Ubuntu, Python 3.10.12.

| Run | Bytecode VM (s) | Python 3.10 (s) | AST walker (s) |
|-----|-----------------|-----------------|----------------|
| 1   | 7.830           | 12.435          | 36.370         |
| 2   | 5.358           | 9.833           | 39.516         |
| 3   | 7.745           | 12.546          | 39.685         |
| 4   | 7.716           | 13.923          | 36.815         |
| 5   | 7.749           | 10.831          | 39.746         |
| **median** | **7.7** | **12.4** | **39.5** |

The bytecode VM is ~5× faster than the old AST walker and ~1.6× faster than equivalent Python 3 on this workload.

## Review comments addressed

- `target` Fortran keyword: renamed to `tgt` in `patch_jump` / `backpatch_breaks`
- `move_alloc` in pool growth: `add_const` / `add_node` now use a single copy + `move_alloc` (matching `emit`)
- Global mutable state: moved into `compiler_state_t`; each compilation starts fresh
- Hard-coded limits removed: `MAX_FRAMES`, `MAX_LOOP_DEPTH`, `MAX_BREAK_FIXUPS` all replaced with growable arrays
- Runtime type dispatch: `do_binop` accepts compiler-supplied `restype` to skip `get_binary_op_kind`; M8 specialized opcodes bypass it entirely
- CI: both backends now run the short test suite on every push
