### PR TITLE
Feature/repl line

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,12 @@
 			}
 		},
 		"steps": [
-			{"uses": "actions/checkout@v1"},
+			{
+				"uses": "actions/checkout@v4",
+				"with": {
+					"submodules": true
+				}
+			},
 			{
 				"uses": "fortran-lang/setup-fpm@v10",
 				"with": {
@@ -319,7 +324,12 @@
 		"name": "Build on rocky linux",
 		"runs-on": "ubuntu-latest",
 		"steps": [
-			{"uses": "actions/checkout@v1"},
+			{
+				"uses": "actions/checkout@v4",
+				"with": {
+					"submodules": true
+				}
+			},
 			{
 				"name": "Build docker",
 				"run":
@@ -385,7 +395,10 @@
 		},
 		"steps": [
 			{
-				"uses": "actions/checkout@v1"
+				"uses": "actions/checkout@v4",
+				"with": {
+					"submodules": true
+				}
 			},
 			{
 				"uses": "fortran-lang/setup-fpm@v10",
@@ -440,8 +453,10 @@
 		},
 		"steps": [
 			{
-				"uses": "actions/checkout@v1"
-
+				"uses": "actions/checkout@v4",
+				"with": {
+					"submodules": true
+				}
 			},
 			{
 				"uses": "fortran-lang/setup-fpm@v10",
@@ -487,7 +502,12 @@
 		"name": "Test alpine docker build",
 		"runs-on": "ubuntu-latest",
 		"steps": [
-			{"uses": "actions/checkout@v1"},
+			{
+				"uses": "actions/checkout@v4",
+				"with": {
+					"submodules": true
+				}
+			},
 			{
 				"name": "Test alpine docker",
 				"run":

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/isocline"]
 	path = external/isocline
-	url = https://github.com/daanx/isocline
+	url = ../../JeffIrwin/isocline

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/isocline"]
+	path = external/isocline
+	url = https://github.com/daanx/isocline

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,24 +26,40 @@ else()
 endif()
 
 if(DEFINED ENV{SYNTRAN_INTEL})
-	add_compile_options(-W1 -qopenmp -qmkl -fPIC -fpp)
+	# ifort-specific flags must NOT reach the C compiler (icx doesn't
+	# understand -fpp/-qmkl/etc), so gate them to Fortran only.
+	add_compile_options(
+		"$<$<COMPILE_LANGUAGE:Fortran>:-W1>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-qopenmp>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-qmkl>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-fPIC>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-fpp>"
+	)
 	add_compile_definitions(SYNTRAN_INTEL)
 else()
 
-	add_compile_options(-Wall -Wextra -fopenmp -cpp)
+	# gfortran-specific dialect/warning flags must NOT reach the C compiler
+	# (AppleClang rejects -cpp / -fopenmp), so gate them to Fortran only.
+	add_compile_options(
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wall>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wextra>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-cpp>"
 
-	# Why would you warn about tabs in free-form Fortran?
-	add_compile_options(-Wno-tabs)
+		# Why would you warn about tabs in free-form Fortran?
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wno-tabs>"
 
-	# More false alarms than anything
-	add_compile_options(-Wno-maybe-uninitialized)
+		# More false alarms than anything
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wno-maybe-uninitialized>"
 
-	# I need to compare reals because syntran users need to be able to compare
-	# reals if they want to
-	add_compile_options(-Wno-compare-reals)
+		# I need to compare reals because syntran users need to be able to
+		# compare reals if they want to
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wno-compare-reals>"
 
-	# Suppress preprocessor warnings about apostrophes in comments (e.g. "There's")
-	add_compile_options(-Wno-cpp "-Wp,-w")
+		# Suppress preprocessor warnings about apostrophes in comments (e.g. "There's")
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wno-cpp>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-Wp,-w>"
+	)
 
 endif()
 #add_compile_options("-J ${CMAKE_CURRENT_SOURCE_DIR}/build/")
@@ -51,7 +67,12 @@ endif()
 message("")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	message("Debug")
-	add_compile_options(-pedantic -fbounds-check -fbacktrace)
+	# gfortran-specific debug flags must NOT reach the C compiler
+	add_compile_options(
+		"$<$<COMPILE_LANGUAGE:Fortran>:-pedantic>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-fbounds-check>"
+		"$<$<COMPILE_LANGUAGE:Fortran>:-fbacktrace>"
+	)
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
 	message("Release")
 	add_compile_options(-O3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 set(PROJECT syntran)
 
-project(${PROJECT} Fortran)
+project(${PROJECT} Fortran C)
 
 if(WIN32 OR CMAKE_GENERATOR MATCHES "MSYS" OR CMAKE_GENERATOR MATCHES "MinGW")
 	message("defining _WIN32 in cmake")
@@ -77,6 +77,7 @@ set(SRC_DIR "src")
 # Core library, used by main interpreter and unit tests
 set(LIB "${PROJECT}")
 set(LIB_SRC
+	${SRC_DIR}/c/isocline_wrap.c
 	${SRC_DIR}/bool.f90
 	${SRC_DIR}/bytecode.f90
 	${SRC_DIR}/compiler.F90
@@ -101,6 +102,7 @@ set(LIB_SRC
 	${SRC_DIR}/intr_fns_trig.f90
 	${SRC_DIR}/intr_vars.f90
 	${SRC_DIR}/lex.f90
+	${SRC_DIR}/line_edit.f90
 	${SRC_DIR}/math.f90
 	${SRC_DIR}/math_bin_add.f90
 	${SRC_DIR}/math_bin_div.f90

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /workdir
 
 RUN apk add gfortran musl-dev
 RUN apk add libc6-compat  # syntran needs glibc compatibility, not alpine's musl libc
+RUN apk add linux-headers # provides linux/kd.h, needed by isocline's term.c
 RUN apk add rlwrap        # nice to have
 RUN apk add curl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add rlwrap        # nice to have
 RUN apk add curl
 
 COPY src src
+COPY external external
 COPY CMakeLists.txt .
 COPY fpm.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /workdir
 RUN apk add gfortran musl-dev
 RUN apk add libc6-compat  # syntran needs glibc compatibility, not alpine's musl libc
 RUN apk add linux-headers # provides linux/kd.h, needed by isocline's term.c
-RUN apk add rlwrap        # nice to have
 RUN apk add curl
 
 COPY src src
@@ -51,5 +50,5 @@ RUN fpm test test
 #RUN cp ./build/Release/syntran /usr/bin/
 ##************
 
-ENTRYPOINT ["rlwrap", "syntran"]
+ENTRYPOINT ["syntran"]
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,12 +7,16 @@ RUN apk add --no-cache \
 	gfortran \
 	musl-dev \
 	libc6-compat \
+	linux-headers \
 	rlwrap \
 	curl \
-	expect
+	expect \
+	bash
 # - libc6-compat:  syntran needs glibc compatibility, not alpine's musl libc
+# - linux-headers: provides linux/kd.h, needed by isocline's term.c
 # - rlwrap:  nice to have
 # - expect:  drives the interactive REPL tests below through a real pty
+# - bash:  test-repl.sh uses bash-only features (BASH_SOURCE)
 
 # Beware, this does not run gen-header.sh like rocky docker. Maybe that's
 # actually a good test that I have the generated source existing locally

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,9 +8,11 @@ RUN apk add --no-cache \
 	musl-dev \
 	libc6-compat \
 	rlwrap \
-	curl
+	curl \
+	expect
 # - libc6-compat:  syntran needs glibc compatibility, not alpine's musl libc
 # - rlwrap:  nice to have
+# - expect:  drives the interactive REPL tests below through a real pty
 
 # Beware, this does not run gen-header.sh like rocky docker. Maybe that's
 # actually a good test that I have the generated source existing locally
@@ -90,4 +92,9 @@ RUN [[ "$(syntran -c 'println(std::hasenv("SYNTRAN_DEFINITELY_UNSET"));' | tr -d
 
 # getenv on an unset var is a runtime error (R29)
 RUN syntran -c 'std::getenv("SYNTRAN_DEFINITELY_UNSET");' 2>&1 | grep -q "R29"
+
+# Interactive REPL tests (isocline history, Ctrl+R search, continuation
+# hints, arrow-key editing).  These need a real pty, which none of the
+# piped/`-c` tests above provide -- see src/tests/repl/test-repl.sh
+RUN bash src/tests/repl/test-repl.sh syntran
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,13 +8,11 @@ RUN apk add --no-cache \
 	musl-dev \
 	libc6-compat \
 	linux-headers \
-	rlwrap \
 	curl \
 	expect \
 	bash
 # - libc6-compat:  syntran needs glibc compatibility, not alpine's musl libc
 # - linux-headers: provides linux/kd.h, needed by isocline's term.c
-# - rlwrap:  nice to have
 # - expect:  drives the interactive REPL tests below through a real pty
 # - bash:  test-repl.sh uses bash-only features (BASH_SOURCE)
 
@@ -60,7 +58,7 @@ RUN fpm test test
 #RUN cp ./build/Release/syntran /usr/bin/
 ##************
 
-ENTRYPOINT ["rlwrap", "syntran"]
+ENTRYPOINT ["syntran"]
 
 #===========================================================
 # Tests

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
 # Beware, this does not run gen-header.sh like rocky docker. Maybe that's
 # actually a good test that I have the generated source existing locally
 COPY src src
+COPY external external
 COPY CMakeLists.txt .
 COPY fpm.toml .
 

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -9,7 +9,8 @@ WORKDIR /workdir
 RUN dnf update -y && dnf install -y \
 	vim \
 	git \
-	gcc-toolset-13-gcc-gfortran
+	gcc-toolset-13-gcc-gfortran \
+	expect
 
 ## Static libc.a and libm.a can also be installed, but it does not remove the dependency on libc.so etc. from syntran
 #dnf --enablerepo=crb install glibc-static -y
@@ -115,4 +116,9 @@ RUN [[ "$(echo 'hello' | ./bin/syntran -c 'println(readln(std::IN));' | tr -d '[
 RUN ./bin/syntran -c 'close(std::IN);'  2>&1 | grep -q "R28"
 RUN ./bin/syntran -c 'close(std::OUT);' 2>&1 | grep -q "R28"
 RUN ./bin/syntran -c 'close(std::ERR);' 2>&1 | grep -q "R28"
+
+# Interactive REPL tests (isocline history, Ctrl+R search, continuation
+# hints, arrow-key editing).  These need a real pty, which none of the
+# piped/`-c` tests above provide -- see src/tests/repl/test-repl.sh
+RUN bash src/tests/repl/test-repl.sh ./bin/syntran
 

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -37,6 +37,7 @@ WORKDIR /workdir/syntran
 # to know the git commit for `--version` output, so we have to install git and
 # clone the whole repo
 ADD src ./src
+ADD external ./external
 ADD .git ./.git
 ADD fpm.toml .
 ADD gen-header.sh .

--- a/README.md
+++ b/README.md
@@ -240,27 +240,6 @@ the arrow keys move the cursor and scroll through history, Ctrl+R starts a rever
 
 No extra install or alias is required; this replaces the old `rlwrap`-based workaround.
 
-### Legacy: rlwrap
-
-Before isocline was added, syntran relied on the external [`rlwrap`](https://github.com/hanslub42/rlwrap) tool for this functionality, since running `syntran` by itself processes text in cooked mode (no arrow-key support, and keypresses like the up arrow show up as raw escape sequences such as `^[[A`).  `rlwrap` is no longer needed, but it still works if you prefer it:
-
-```
-sudo apt install rlwrap
-rlwrap ./build/Debug/syntran
-```
-
-Also see [`run.sh`](run.sh), which checks if you have `rlwrap` installed and then starts `syntran` appropriately.  You can make a bash function or alias in your `~/.bashrc` file to help with this:
-
-```
-alias syntran="rlwrap /path/to/bin/syntran"
-```
-
-As of rlwrap 0.43, there is a bug where it hides the `syntran$ ` prompt.  To work around it, add this to your `~/.inputrc`:
-
-```
-set enable-bracketed-paste off
-```
-
 ## Syntax highlighting
 
 I do not plan on writing any syntax highlighting plugins.

--- a/README.md
+++ b/README.md
@@ -230,28 +230,24 @@ Only single-line `// comments` are supported.  There are _no_ multi-line `/*comm
 
 In many shells such as `bash`, the up and down arrow keys can be used to scroll through the command history.  For example, hit the up arrow key and then ENTER to repeat the previous command, or hit the up arrow key twice to go two commands back.
 
-Arrow keys do _not_ work by default in syntran running within bash, but there is a simple and powerful workaround with `rlwrap`.  If you run `syntran` by itself, it processes text in cooked mode:
+Syntran's REPL supports this out of the box, on Linux, macOS, and Windows alike, using the vendored [isocline](https://github.com/daanx/isocline) line-editing library (see `external/isocline` and `src/line_edit.f90`).  When you run `syntran` interactively:
 
 ```
 ./build/Debug/syntran
 ```
 
-Cooked mode means that `syntran` does not read or process any text until after you press the ENTER key.  Further, when you use an arrow key, you will see escape sequences like this:
+the arrow keys move the cursor and scroll through history, Ctrl+R starts a reverse history search, and command history is saved across separate invocations of `syntran` in `~/.syntran_history` (`%USERPROFILE%\.syntran_history` on Windows).  Hit Ctrl+D on an empty line to exit the REPL.
 
-```
-^[[A
-```
+No extra install or alias is required; this replaces the old `rlwrap`-based workaround.
 
-These keypresses may appear like the ANSI escape sequence above or other garbled text.
+### Legacy: rlwrap
 
-To overcome this, install and run `rlwrap` with `syntran`:
+Before isocline was added, syntran relied on the external [`rlwrap`](https://github.com/hanslub42/rlwrap) tool for this functionality, since running `syntran` by itself processes text in cooked mode (no arrow-key support, and keypresses like the up arrow show up as raw escape sequences such as `^[[A`).  `rlwrap` is no longer needed, but it still works if you prefer it:
 
 ```
 sudo apt install rlwrap
 rlwrap ./build/Debug/syntran
 ```
-
-With `rlwrap`, the arrow keys work as expected within the `syntran` interpreter.  Plus, you get `rlwrap`'s other powerful features, like Ctrl+R for history search and saved history across separate invocations of `syntran`.
 
 Also see [`run.sh`](run.sh), which checks if you have `rlwrap` installed and then starts `syntran` appropriately.  You can make a bash function or alias in your `~/.bashrc` file to help with this:
 
@@ -259,11 +255,7 @@ Also see [`run.sh`](run.sh), which checks if you have `rlwrap` installed and the
 alias syntran="rlwrap /path/to/bin/syntran"
 ```
 
-The basic arrow key history should work in Windows terminal and Windows cmd out of the box, but running `rlwrap` in a Linux environment within Windows can still be advantageous.
-
-### rlwrap workaround
-
-As of rlwrap 0.43, there is a bug where it hides the `syntran$ ` prompt.  To workaround it, add this to your `~/.inputrc`:
+As of rlwrap 0.43, there is a bug where it hides the `syntran$ ` prompt.  To work around it, add this to your `~/.inputrc`:
 
 ```
 set enable-bracketed-paste off
@@ -1052,7 +1044,7 @@ let file = open("test.txt");
 writeln(file, "hello world");
 writeln(file, "here's a second line of text with a number ", 42);
 close(file);
-//// Ctrl+C to exit syntran prompt
+//// Ctrl+D to exit syntran prompt
 
 //// shell prompt
 cat test.txt

--- a/fpm.toml
+++ b/fpm.toml
@@ -15,7 +15,6 @@
 #     # `runner` is a prefix to the syntran cmd.  anything after `-- ` is a cmd
 #     # arg passed after `syntran`, e.g. the syntran filename
 #     fpm run
-#     fpm run --runner rlwrap
 #     fpm run -- samples/primes-3.syntran
 #
 #     fpm test       # all tests

--- a/run.sh
+++ b/run.sh
@@ -7,9 +7,5 @@ config="Debug"
 
 ./build.sh $config
 
-if [[ -x "$(command -v rlwrap)" ]]; then
-	time rlwrap ./build/$config/syntran "$@"
-else
-	time ./build/$config/syntran "$@"
-fi
+time ./build/$config/syntran "$@"
 

--- a/samples/betweenle.syntran
+++ b/samples/betweenle.syntran
@@ -256,10 +256,10 @@ println("Starting betweenle solver");
 // ln -s /usr/share/dict/american-english ~/.local/share/dict/
 //
 const HOME_DIR = std::getenv("HOME");
-const dict_filename = HOME_DIR + "/.local/share/dict/american-english";
-//let dict_filename = "/usr/share/dict/american-english";
+const DICT_FILENAME = HOME_DIR + "/.local/share/dict/american-english";
+//let DICT_FILENAME = "/usr/share/dict/american-english";
 
-let words = read_dict(dict_filename);
+let words = read_dict(DICT_FILENAME);
 let n = i32(size(words, 0));
 println("Loaded ", n, " 5-letter words from system dictionary");
 

--- a/samples/poople.syntran
+++ b/samples/poople.syntran
@@ -23,12 +23,12 @@ println("Starting poople solver");
 // ln -s /usr/share/dict/american-english ~/.local/share/dict/
 //
 const HOME_DIR = std::getenv("HOME");
-const dict_filename = HOME_DIR + "/.local/share/dict/american-english";
-//let dict_filename = "/usr/share/dict/american-english";
+const DICT_FILENAME = HOME_DIR + "/.local/share/dict/american-english";
+//let DICT_FILENAME = "/usr/share/dict/american-english";
 
 let blocklist = poople::BLOCKLIST;
 let allowlist = poople::ALLOWLIST;
-let dict = poople::read_dict(dict_filename, &blocklist, &allowlist);
+let dict = poople::read_dict(DICT_FILENAME, &blocklist, &allowlist);
 println("Loaded ", dict.len(),
 	" 4-letter words from system dictionary");
 

--- a/samples/wordle.syntran
+++ b/samples/wordle.syntran
@@ -352,10 +352,10 @@ println("Starting wordle solver");
 // ln -s /usr/share/dict/american-english ~/.local/share/dict/
 //
 const HOME_DIR = std::getenv("HOME");
-const dict_filename = HOME_DIR + "/.local/share/dict/american-english";
-//let dict_filename = "/usr/share/dict/american-english";
+const DICT_FILENAME = HOME_DIR + "/.local/share/dict/american-english";
+//let DICT_FILENAME = "/usr/share/dict/american-english";
 
-let cands = read_dict(dict_filename, &ALLOWLIST, &BLOCKLIST);
+let cands = read_dict(DICT_FILENAME, &ALLOWLIST, &BLOCKLIST);
 let nc = i32(size(cands, 0));
 let all_words = cands;
 let nall = nc;

--- a/src/app.f90
+++ b/src/app.f90
@@ -295,7 +295,7 @@ function parse_args() result(args)
 		if (interactive) then
 			write(*,*) 'Usage:'
 			write(*,*) tab//'#tree to toggle tree display'
-			write(*,*) tab//'`exit(0);` or Ctrl+C to exit'
+			write(*,*) tab//'`exit(0);` or Ctrl+D to exit'
 			write(*,*)
 		end if
 

--- a/src/c/isocline_wrap.c
+++ b/src/c/isocline_wrap.c
@@ -11,7 +11,7 @@
  *
  * This file also provides two small platform-specific helpers that syntran's
  * REPL needs and that don't belong in Fortran:
- *   - syntran_isatty():       is stdin a real terminal (vs. a pipe/file)?
+ *   - syntran_isatty():       are stdin AND stdout real terminals?
  *   - syntran_history_path(): where should REPL history persist?
  * Both differ by platform in ways that are simplest to resolve here, where
  * the C compiler predefines _WIN32 automatically (no build-system flag
@@ -30,12 +30,17 @@
 #include <unistd.h>
 #endif
 
+/* Isocline should only take over the terminal when BOTH stdin and stdout are
+ * real terminals.  If stdout is redirected (e.g. `syntran | tee log`),
+ * isocline's cursor-control and redraw escape sequences would otherwise leak
+ * into the pipe even though stdin is still an interactive tty.
+ */
 int syntran_isatty(void)
 {
 #ifdef _WIN32
-	return _isatty(_fileno(stdin));
+	return _isatty(_fileno(stdin)) && _isatty(_fileno(stdout));
 #else
-	return isatty(fileno(stdin));
+	return isatty(fileno(stdin)) && isatty(fileno(stdout));
 #endif
 }
 

--- a/src/c/isocline_wrap.c
+++ b/src/c/isocline_wrap.c
@@ -1,0 +1,62 @@
+/* isocline_wrap.c
+ *
+ * Thin C shim gluing the vendored isocline line-editing library (git
+ * submodule at external/isocline) into the syntran build under both FPM and
+ * CMake.
+ *
+ * Isocline builds as a single translation unit: its own src/isocline.c
+ * #includes all of its sibling .c files.  We #include that file here (via a
+ * quoted, relative path) so both build systems only need to know about this
+ * one shim file rather than isocline's whole file list.
+ *
+ * This file also provides two small platform-specific helpers that syntran's
+ * REPL needs and that don't belong in Fortran:
+ *   - syntran_isatty():       is stdin a real terminal (vs. a pipe/file)?
+ *   - syntran_history_path(): where should REPL history persist?
+ * Both differ by platform in ways that are simplest to resolve here, where
+ * the C compiler predefines _WIN32 automatically (no build-system flag
+ * needed on either FPM or CMake).
+ */
+
+#include "../../external/isocline/src/isocline.c"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+int syntran_isatty(void)
+{
+#ifdef _WIN32
+	return _isatty(_fileno(stdin));
+#else
+	return isatty(fileno(stdin));
+#endif
+}
+
+/* Platform-correct history file path, or NULL if no home dir is set (in
+ * which case history is kept in-memory only for the session).
+ *
+ * HOME is normally unset on Windows, so USERPROFILE is used there instead.
+ */
+const char *syntran_history_path(void)
+{
+	static char path[1024];
+
+	const char *home =
+#ifdef _WIN32
+		getenv("USERPROFILE");
+#else
+		getenv("HOME");
+#endif
+
+	if (home == NULL || home[0] == '\0') return NULL;
+
+	snprintf(path, sizeof(path), "%s/%s", home, ".syntran_history");
+	return path;
+}

--- a/src/core.f90
+++ b/src/core.f90
@@ -31,8 +31,6 @@ module syntran__core_m
 		syntran_patch =  0
 
 	! TODO:
-	!  - integrate rlwrap as a library dependency
-	!    * as is, it's usually only one-time setup per machine, but it's still friction
 	!  - switch/match/case
 	!  - callbacks, fn pointers, i.e. passing one function as an argument to
 	!    another function
@@ -254,11 +252,12 @@ module syntran__core_m
 	!      variable with the same name `ans`, at least within the REPL and maybe
 	!      everywhere for compatibility of being able to paste code into the
 	!      REPL
-	!    * it would be very convenient.  you can always rlwrap and up arrow,
-	!      then assign to a var if you need to save the last ans.  but this is
-	!      inconvenient, and state changers are not always idempotent (meaning
-	!      up arrow could give a different answer on 2nd execution).  and if a
-	!      statement is expensive, you may not want to have to run it again
+	!    * it would be very convenient.  you can always isocline/rlwrap and up
+	!      arrow, then assign to a var if you need to save the last ans.  but
+	!      this is inconvenient, and state changers are not always idempotent
+	!      (meaning up arrow could give a different answer on 2nd execution).
+	!      and if a statement is expensive, you may not want to have to run it
+	!      again
 	!  - structs
 	!    * post-merge TODO struct items:
 	!      + update struct sample.  include struct/array combos, nesting, etc.

--- a/src/lex.f90
+++ b/src/lex.f90
@@ -949,29 +949,9 @@ function lex(lexer) result(token)
 
 	lexer%pos = lexer%pos + 1
 
-	! FIXME: arrow keys create bad tokens in bash on Windows.  Fix that (better
-	! yet, override up arrow to do what it does in bash.  c.f. rubik-js)
-	!
-	! Actually this is somewhat difficult bc I think it requires event
-	! listening.  Currently syntran does not get any stdin until the user hits
-	! <enter>.  So if they type <up-arrow>, syntran doesn't know anything about
-	! that until they subsequently hit <enter>.  I guess we could use some 3p
-	! C(++) lib to do keypress event listening, but there's an easier solution.
-	!
-	! Just use rlwrap:
-	!
-	!     sudo apt install rlwrap
-	!     rlwrap syntran
-	!
-	! Then rlwrap does the listening, handles all arrow keys as expected, and
-	! passes stdin along to syntran.  See run.sh which checks if you have rlwrap
-	! installed.  Windows cmd works good enough without rlwrap.
-	!
-	! You can make a shell alias for that.
-	!
-	! Idris lang also makes the same recommendation:
-	!
-	!     https://github.com/idris-lang/Idris2/issues/54
+	! Note that syntran uses the isocline to read lines. Previously it used
+	! rlwrap in syntran <= 1.3 and there used to be a lengthy comment here about
+	! it
 
 end function lex
 

--- a/src/line_edit.f90
+++ b/src/line_edit.f90
@@ -43,6 +43,13 @@ module syntran__line_edit_m
 		subroutine ic_history_remove_last_c() bind(c, name = "ic_history_remove_last")
 		end subroutine ic_history_remove_last_c
 
+		subroutine ic_set_prompt_marker_c(marker, cont_marker) &
+			bind(c, name = "ic_set_prompt_marker")
+			import :: c_char
+			character(kind = c_char), intent(in) :: marker(*)
+			character(kind = c_char), intent(in) :: cont_marker(*)
+		end subroutine ic_set_prompt_marker_c
+
 		function syntran_isatty_c() bind(c, name = "syntran_isatty") result(res)
 			import :: c_int
 			integer(c_int) :: res
@@ -84,6 +91,12 @@ subroutine line_edit_init()
 	path_ptr = syntran_history_path_c()
 	call ic_set_history_c(path_ptr, -1_c_long)
 
+	! Isocline appends its own prompt marker ("> " by default) after whatever
+	! prompt text we pass to ic_readline().  Syntran manages its own prompt
+	! text (including continuation prompts), so disable isocline's marker to
+	! avoid a doubled-up "syntran$> "
+	call ic_set_prompt_marker_c(c_null_char, c_null_char)
+
 end subroutine line_edit_init
 
 !===============================================================================
@@ -103,7 +116,10 @@ function read_line_interactive(prompt, iostat) result(str_)
 
 	type(c_ptr) :: res_ptr
 
-	res_ptr = ic_readline_c(trim(prompt)//c_null_char)
+	! prompt is assumed-length, so it already matches the actual argument's
+	! length exactly (no trailing blank padding to strip) -- trim() here would
+	! wrongly strip an intentional trailing space, e.g. "syntran$ "
+	res_ptr = ic_readline_c(prompt//c_null_char)
 
 	if (.not. c_associated(res_ptr)) then
 		! EOF (ctrl-D on an empty line).  Isocline's own internal cleanup

--- a/src/line_edit.f90
+++ b/src/line_edit.f90
@@ -119,7 +119,7 @@ function read_line_interactive(prompt, iostat) result(str_)
 	! prompt is assumed-length, so it already matches the actual argument's
 	! length exactly (no trailing blank padding to strip) -- trim() here would
 	! wrongly strip an intentional trailing space, e.g. "syntran$ "
-	res_ptr = ic_readline_c(prompt//c_null_char)
+	res_ptr = ic_readline_c(bbcode_escape(prompt)//c_null_char)
 
 	if (.not. c_associated(res_ptr)) then
 		! EOF (ctrl-D on an empty line).  Isocline's own internal cleanup
@@ -146,6 +146,43 @@ function read_line_interactive(prompt, iostat) result(str_)
 	if (len(str_) > 1) call ic_history_remove_last_c()
 
 end function read_line_interactive
+
+!===============================================================================
+
+function bbcode_escape(s) result(esc)
+
+	! Isocline renders every prompt string it's given through its own bbcode
+	! markup parser (see external/isocline/src/editline.c's edit_write_prompt(),
+	! which calls bbcode_print() on the prompt text).  Bbcode treats "[...]" as
+	! a formatting tag, so a plain prompt like "[Hint `;`]> " gets parsed as an
+	! unrecognized tag and silently dropped instead of printed.
+	!
+	! Escape the chars that are special to bbcode so prompt text always renders
+	! literally.  Per bbcode_append() in external/isocline/src/bbcode.c, only
+	! '[' and '\' are ever treated specially -- a lone ']' is never parsed as
+	! part of a tag unless a preceding unescaped '[' opened one, so escaping
+	! ']' is unnecessary and would actually backfire: "\]" isn't a recognized
+	! escape sequence (only "\[" and "\\" are), so it would render as a stray
+	! literal backslash followed by "]" instead of just "]"
+
+	character(len = *), intent(in) :: s
+	character(len = :), allocatable :: esc
+
+	!********
+
+	integer :: i
+
+	esc = ""
+	do i = 1, len(s)
+		select case (s(i:i))
+			case ("\", "[")
+				esc = esc//"\"//s(i:i)
+			case default
+				esc = esc//s(i:i)
+		end select
+	end do
+
+end function bbcode_escape
 
 !===============================================================================
 

--- a/src/line_edit.f90
+++ b/src/line_edit.f90
@@ -1,0 +1,175 @@
+
+!===============================================================================
+
+module syntran__line_edit_m
+
+	! Fortran binding to the vendored isocline line-editing library (git
+	! submodule at external/isocline, glued in via src/c/isocline_wrap.c).
+	!
+	! This gives the interactive REPL history + arrow-key editing without
+	! requiring users to install `rlwrap` themselves.  See read_line() in
+	! utils.f90 for the plain, non-interactive line reader used for piped
+	! stdin, `-c` strings, and files -- that path is unaffected by this module
+
+	use iso_c_binding
+	use iso_fortran_env, only: iostat_end
+
+	implicit none
+
+	interface
+
+		function ic_readline_c(prompt_text) bind(c, name = "ic_readline") result(res)
+			import :: c_ptr, c_char
+			character(kind = c_char), intent(in) :: prompt_text(*)
+			type(c_ptr) :: res
+		end function ic_readline_c
+
+		subroutine ic_free_c(p) bind(c, name = "ic_free")
+			import :: c_ptr
+			type(c_ptr), value :: p
+		end subroutine ic_free_c
+
+		subroutine ic_set_history_c(fname, max_entries) bind(c, name = "ic_set_history")
+			import :: c_ptr, c_long
+			type(c_ptr), value :: fname
+			integer(c_long), value :: max_entries
+		end subroutine ic_set_history_c
+
+		subroutine ic_history_add_c(entry) bind(c, name = "ic_history_add")
+			import :: c_char
+			character(kind = c_char), intent(in) :: entry(*)
+		end subroutine ic_history_add_c
+
+		subroutine ic_history_remove_last_c() bind(c, name = "ic_history_remove_last")
+		end subroutine ic_history_remove_last_c
+
+		function syntran_isatty_c() bind(c, name = "syntran_isatty") result(res)
+			import :: c_int
+			integer(c_int) :: res
+		end function syntran_isatty_c
+
+		function syntran_history_path_c() bind(c, name = "syntran_history_path") result(res)
+			import :: c_ptr
+			type(c_ptr) :: res
+		end function syntran_history_path_c
+
+		function c_strlen(s) bind(c, name = "strlen") result(res)
+			import :: c_ptr, c_size_t
+			type(c_ptr), value :: s
+			integer(c_size_t) :: res
+		end function c_strlen
+
+	end interface
+
+contains
+
+!===============================================================================
+
+logical function is_tty()
+	! Is stdin a real terminal (vs. a pipe or redirected file)?  Line editing
+	! only makes sense when it is
+	is_tty = syntran_isatty_c() /= 0
+end function is_tty
+
+!===============================================================================
+
+subroutine line_edit_init()
+
+	! Enable persistent history.  The history file path (platform-specific:
+	! $USERPROFILE on Windows, $HOME elsewhere) is resolved in the C shim.  If
+	! no home dir is set, history is kept in-memory for the session only
+
+	type(c_ptr) :: path_ptr
+
+	path_ptr = syntran_history_path_c()
+	call ic_set_history_c(path_ptr, -1_c_long)
+
+end subroutine line_edit_init
+
+!===============================================================================
+
+function read_line_interactive(prompt, iostat) result(str_)
+
+	! Read one line of input with history + arrow-key editing.  Mirrors
+	! read_line() in utils.f90: returns iostat = iostat_end on EOF (ctrl-D on
+	! an empty line)
+
+	character(len = *), intent(in) :: prompt
+	integer, intent(out) :: iostat
+
+	character(len = :), allocatable :: str_
+
+	!********
+
+	type(c_ptr) :: res_ptr
+
+	res_ptr = ic_readline_c(trim(prompt)//c_null_char)
+
+	if (.not. c_associated(res_ptr)) then
+		! EOF (ctrl-D on an empty line).  Isocline's own internal cleanup
+		! (editline.c) already pushes then immediately removes its placeholder
+		! for this case, netting to no change, so there is nothing here to undo
+		str_ = ""
+		iostat = iostat_end
+		return
+	end if
+
+	str_ = c_str_to_f_str(res_ptr)
+	call ic_free_c(res_ptr)
+	iostat = 0
+
+	! ic_readline() unconditionally pushes whatever the user just typed onto
+	! isocline's history (and saves it to the history file) before returning,
+	! UNLESS the result is empty or a single character (e.g. ctrl-C, which
+	! clears the line and returns "" rather than NULL) -- in that case isocline
+	! has already undone its own placeholder push internally, same as the EOF
+	! case above.  We want full control over what becomes a history entry
+	! (e.g. joining multi-line continuations into a single entry), so undo the
+	! auto-push here -- but only when isocline actually left one in place --
+	! and let the caller opt in via line_edit_add_history()
+	if (len(str_) > 1) call ic_history_remove_last_c()
+
+end function read_line_interactive
+
+!===============================================================================
+
+subroutine line_edit_add_history(entry)
+	character(len = *), intent(in) :: entry
+	call ic_history_add_c(trim(entry)//c_null_char)
+end subroutine line_edit_add_history
+
+!===============================================================================
+
+function c_str_to_f_str(cptr) result(str_)
+
+	! Copy a null-terminated C string into an allocatable Fortran string
+
+	type(c_ptr), intent(in) :: cptr
+	character(len = :), allocatable :: str_
+
+	!********
+
+	character(kind = c_char), pointer :: chars(:)
+	integer(c_size_t) :: n, i
+
+	n = c_strlen(cptr)
+	if (n == 0) then
+		str_ = ""
+		return
+	end if
+
+	call c_f_pointer(cptr, chars, [n])
+
+	allocate(character(len = n) :: str_)
+	do i = 1, n
+		str_(i:i) = chars(i)
+	end do
+
+end function c_str_to_f_str
+
+!===============================================================================
+
+end module syntran__line_edit_m
+
+!===============================================================================
+

--- a/src/line_edit.f90
+++ b/src/line_edit.f90
@@ -80,8 +80,11 @@ contains
 !===============================================================================
 
 logical function is_tty()
-	! Is stdin a real terminal (vs. a pipe or redirected file)?  Line editing
-	! only makes sense when it is
+	! Are stdin AND stdout both real terminals (vs. a pipe or redirected
+	! file)?  Line editing only makes sense when both are: isocline needs an
+	! interactive stdin to read keystrokes from, and an interactive stdout to
+	! draw/redraw the prompt and edit buffer onto, without leaking escape
+	! sequences into a redirected pipe or file
 	is_tty = syntran_isatty_c() /= 0
 end function is_tty
 
@@ -114,7 +117,7 @@ end subroutine line_edit_init
 
 !===============================================================================
 
-function read_line_interactive(prompt, iostat) result(str_)
+function read_line_interactive(prompt, iostat, use_color) result(str_)
 
 	! Read one line of input with history + arrow-key editing.  Mirrors
 	! read_line() in utils.f90: returns iostat = iostat_end on EOF (ctrl-D on
@@ -122,17 +125,32 @@ function read_line_interactive(prompt, iostat) result(str_)
 
 	character(len = *), intent(in) :: prompt
 	integer, intent(out) :: iostat
+	logical, intent(in), optional :: use_color
 
 	character(len = :), allocatable :: str_
 
 	!********
 
 	type(c_ptr) :: res_ptr
+	logical :: use_color_
+	character(len = :), allocatable :: prompt_bb
+
+	use_color_ = .true.
+	if (present(use_color)) use_color_ = use_color
 
 	! prompt is assumed-length, so it already matches the actual argument's
 	! length exactly (no trailing blank padding to strip) -- trim() here would
-	! wrongly strip an intentional trailing space, e.g. "syntran$ "
-	res_ptr = ic_readline_c(bbcode_escape(prompt)//c_null_char)
+	! wrongly strip an intentional trailing space, e.g. "syntran$ ".  Escape it
+	! for bbcode regardless of color, then optionally wrap it in isocline's own
+	! "[b green]...[/]" bbcode markup so the prompt keeps the same bold-green
+	! styling as the non-interactive prompt (built from fg_bold//fg_green in
+	! src/syntran.f90).  use_color_ should mirror whether that caller-side
+	! color is actually enabled (e.g. off when stdout color is disabled), so
+	! that isocline's rendering matches the plain path
+	prompt_bb = bbcode_escape(prompt)
+	if (use_color_) prompt_bb = "[b green]"//prompt_bb//"[/]"
+
+	res_ptr = ic_readline_c(prompt_bb//c_null_char)
 
 	if (.not. c_associated(res_ptr)) then
 		! EOF (ctrl-D on an empty line).  Isocline's own internal cleanup

--- a/src/line_edit.f90
+++ b/src/line_edit.f90
@@ -60,6 +60,13 @@ module syntran__line_edit_m
 			type(c_ptr) :: res
 		end function syntran_history_path_c
 
+		function ic_enable_brace_insertion_c(enable) &
+			bind(c, name = "ic_enable_brace_insertion") result(was_enabled)
+			import :: c_bool
+			logical(c_bool), value :: enable
+			logical(c_bool) :: was_enabled
+		end function ic_enable_brace_insertion_c
+
 		function c_strlen(s) bind(c, name = "strlen") result(res)
 			import :: c_ptr, c_size_t
 			type(c_ptr), value :: s
@@ -87,6 +94,7 @@ subroutine line_edit_init()
 	! no home dir is set, history is kept in-memory for the session only
 
 	type(c_ptr) :: path_ptr
+	logical(c_bool) :: was_enabled
 
 	path_ptr = syntran_history_path_c()
 	call ic_set_history_c(path_ptr, -1_c_long)
@@ -96,6 +104,11 @@ subroutine line_edit_init()
 	! text (including continuation prompts), so disable isocline's marker to
 	! avoid a doubled-up "syntran$> "
 	call ic_set_prompt_marker_c(c_null_char, c_null_char)
+
+	! Isocline auto-inserts a closing bracket/paren/quote whenever the user
+	! types an opening one (enabled by default).  That's surprising for users
+	! coming from a plain terminal, so turn it off
+	was_enabled = ic_enable_brace_insertion_c(logical(.false., c_bool))
 
 end subroutine line_edit_init
 

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -208,7 +208,8 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 
 					if (interactive) then
 						line = line//line_feed//read_line_interactive( &
-							'[Hint `'//compilation%first_expected//'`]> ', io)
+							'[Hint `'//compilation%first_expected//'`]> ', io, &
+							use_color = len(prompt_color) > 0)
 					else
 						write(ou, '(a)', advance = 'no') prompt_color// &
 							'[Hint `'//compilation%first_expected//'`]> '//color_reset
@@ -217,7 +218,8 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 
 				else
 					if (interactive) then
-						line = line//line_feed//read_line_interactive('> ', io)
+						line = line//line_feed//read_line_interactive('> ', io, &
+							use_color = len(prompt_color) > 0)
 					else
 						write(ou, '(a)', advance = 'no') prompt_color//'> '//color_reset
 						line = line//line_feed//read_line(iu, iostat = io)
@@ -226,7 +228,8 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 
 			else
 				if (interactive) then
-					line = read_line_interactive(lang_name//'$ ', io)
+					line = read_line_interactive(lang_name//'$ ', io, &
+						use_color = len(prompt_color) > 0)
 				else
 					write(ou, '(a)', advance = 'no') prompt
 					line = read_line(iu, iostat = io)

--- a/src/syntran.f90
+++ b/src/syntran.f90
@@ -10,6 +10,7 @@ module syntran
 	use syntran__core_m
 	use syntran__compile_m
 	use syntran__vm_m
+	use syntran__line_edit_m
 
 	implicit none
 
@@ -103,7 +104,7 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 	integer, parameter :: iu = input_unit, ou = output_unit
 	integer :: io
 
-	logical :: continue_, show_tree
+	logical :: continue_, show_tree, interactive
 	logical, parameter :: allow_cont = .true.
 
 	type(string_view_t) :: sv
@@ -122,6 +123,12 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 	src_file = '<stdin>'
 	continue_ = .false.
 	show_tree = .false.
+
+	! Only use interactive line editing (history, arrow keys) when reading a
+	! real terminal.  Piped stdin, `-c` strings, and file interpretation all
+	! keep using the plain read_line() path in utils.f90
+	interactive = .not. present(str_) .and. is_tty()
+	if (interactive) call line_edit_init()
 
 	if (present(str_)) then
 		! Append a trailing line feed in case it does not exist
@@ -198,18 +205,32 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 					!
 					! I hint semicolons because it could be a stumbling block
 					! for users coming from python or similar languages
-					write(ou, '(a)', advance = 'no') prompt_color// &
-						'[Hint `'//compilation%first_expected//'`]> '//color_reset
+
+					if (interactive) then
+						line = line//line_feed//read_line_interactive( &
+							'[Hint `'//compilation%first_expected//'`]> ', io)
+					else
+						write(ou, '(a)', advance = 'no') prompt_color// &
+							'[Hint `'//compilation%first_expected//'`]> '//color_reset
+						line = line//line_feed//read_line(iu, iostat = io)
+					end if
 
 				else
-					write(ou, '(a)', advance = 'no') prompt_color//'> '//color_reset
+					if (interactive) then
+						line = line//line_feed//read_line_interactive('> ', io)
+					else
+						write(ou, '(a)', advance = 'no') prompt_color//'> '//color_reset
+						line = line//line_feed//read_line(iu, iostat = io)
+					end if
 				end if
 
-				line = line//line_feed//read_line(iu, iostat = io)
-
 			else
-				write(ou, '(a)', advance = 'no') prompt
-				line = read_line(iu, iostat = io)
+				if (interactive) then
+					line = read_line_interactive(lang_name//'$ ', io)
+				else
+					write(ou, '(a)', advance = 'no') prompt
+					line = read_line(iu, iostat = io)
+				end if
 			end if
 
 		end if
@@ -250,6 +271,12 @@ function syntran_interpret(str_, quiet, startup_file, script_args) result(res_st
 		if (continue_) cycle
 
 		if (compilation%is_empty) cycle
+
+		! The line is now a complete statement (possibly joined from several
+		! continuation lines).  read_line_interactive() already undid isocline's
+		! own per-call history push, so this is the one place a full logical
+		! statement becomes a single recallable history entry
+		if (interactive) call line_edit_add_history(line)
 
 		! I'm skipping the the binder that Immo implemented at this point in
 		! episode 2.  I guess I'll find out later if that's a stupid decision on

--- a/src/tests/core.f90
+++ b/src/tests/core.f90
@@ -13,6 +13,8 @@ module syntran__test_core_m
 		eval_f32  => syntran_eval_f32, &
 		eval_f64  => syntran_eval_f64
 
+	use syntran__line_edit_m, only: bbcode_escape
+
 	use syntran__utils_m, only: fg_bright_red, fg_bright_green, line_feed, &
 		findlocl1, console_color, console_color_reset, &
 		string_vector_t, new_string_vector, &

--- a/src/tests/repl/common.tcl
+++ b/src/tests/repl/common.tcl
@@ -1,0 +1,63 @@
+
+# Shared expect helpers for the REPL/isocline PTY tests in this directory.
+# Sourced by each *.exp script via:
+#
+#     source [file join [file dirname [info script]] common.tcl]
+
+proc die {msg} {
+	send_user "\nFAIL: $msg\n"
+	exit 1
+}
+
+proc wait_prompt {} {
+	expect {
+		{syntran$ } {}
+		timeout { die "timeout waiting for initial prompt" }
+		eof     { die "unexpected eof waiting for initial prompt" }
+	}
+}
+
+proc wait_hint {} {
+	expect {
+		{Hint} {}
+		timeout { die "timeout waiting for continuation hint prompt" }
+		eof     { die "unexpected eof waiting for continuation hint prompt" }
+	}
+}
+
+# Wait for a submitted line's printed result, then resync on the following
+# fresh prompt before returning.  Both parts matter:
+#
+#  - the result must be matched as "\n$text", anchored on a literal line
+#    feed, because isocline redraws the whole "prompt + typed-so-far buffer"
+#    on every keystroke using only carriage returns (never a bare '\n'); a
+#    plain substring match on $text would also fire on that per-keystroke
+#    repaint noise, or on the echoed input text itself if it happens to
+#    contain the same digits as the result (discovered the hard way: a
+#    filler statement like "999;" makes "\n999" match its own echoed input)
+#
+#  - resyncing on the prompt matters because isocline only holds the
+#    terminal in raw/character mode for the duration of a single
+#    ic_readline() call; immediately after it returns, the tty is briefly
+#    back in canonical mode until the next ic_readline() call begins.  A
+#    multi-character command sent in that window lands in the kernel's
+#    canonical input queue instead of isocline's live editor, so waiting
+#    for the next prompt to actually render (proof isocline is back and
+#    reading) avoids that race
+proc wait_result {text} {
+	expect {
+		-- "\n$text" {}
+		timeout { die "timeout waiting for output: $text" }
+		eof     { die "unexpected eof waiting for output: $text" }
+	}
+	wait_prompt
+}
+
+proc finish {} {
+	send "\004"
+	expect {
+		eof {}
+		timeout { die "timeout waiting for clean exit after ctrl-d" }
+	}
+	send_user "PASS\n"
+}

--- a/src/tests/repl/continuation-hint.exp
+++ b/src/tests/repl/continuation-hint.exp
@@ -1,0 +1,23 @@
+#!/usr/bin/env expect
+
+# A statement missing its semicolon triggers the interactive continuation
+# prompt (src/syntran.f90, the `compilation%first_expected == ";"` branch),
+# which hints the expected token as "[Hint `;`]> ".  That prompt text
+# contains a literal "[", which isocline would otherwise parse as a bbcode
+# formatting tag and silently drop -- bbcode_escape() in src/line_edit.f90
+# exists specifically to keep it rendering as-is
+
+set timeout 10
+source [file join [file dirname [info script]] common.tcl]
+
+set bin [lindex $argv 0]
+spawn $bin
+wait_prompt
+
+send "1+2\r"
+wait_hint
+
+send ";\r"
+wait_result "3"
+
+finish

--- a/src/tests/repl/ctrl-d-exit.exp
+++ b/src/tests/repl/ctrl-d-exit.exp
@@ -1,0 +1,14 @@
+#!/usr/bin/env expect
+
+# Ctrl+D on an empty prompt exits the REPL cleanly (see commit 72d008f,
+# "fix 'hints' (e.g. semicolons) for unfinished REPL lines", and the
+# "Ctrl+D to exit" usage line printed at startup)
+
+set timeout 10
+source [file join [file dirname [info script]] common.tcl]
+
+set bin [lindex $argv 0]
+spawn $bin
+wait_prompt
+
+finish

--- a/src/tests/repl/ctrl-r-search.exp
+++ b/src/tests/repl/ctrl-r-search.exp
@@ -1,0 +1,30 @@
+#!/usr/bin/env expect
+
+# Ctrl+R starts isocline's reverse history search; typing a substring of an
+# earlier entry finds it.  Isocline follows readline/libedit convention:
+# the first Enter accepts the matched entry into the edit buffer (exiting
+# search mode) without running it, and a second Enter actually submits it
+
+set timeout 10
+source [file join [file dirname [info script]] common.tcl]
+
+set bin [lindex $argv 0]
+spawn $bin
+wait_prompt
+
+send "410+1;\r"
+wait_result "411"
+
+# Filler entry.  Deliberately chosen so neither its source text nor its
+# printed result contains "410" or "411" -- see the note on wait_result in
+# common.tcl about self-matching input echo
+send "500+500;\r"
+wait_result "1000"
+
+send "\022"
+send "410"
+send "\r"
+send "\r"
+wait_result "411"
+
+finish

--- a/src/tests/repl/history-uparrow.exp
+++ b/src/tests/repl/history-uparrow.exp
@@ -1,0 +1,20 @@
+#!/usr/bin/env expect
+
+# Up arrow recalls the last history entry into the edit buffer, and Enter
+# re-submits it.  See line_edit_add_history() in src/line_edit.f90
+
+set timeout 10
+source [file join [file dirname [info script]] common.tcl]
+
+set bin [lindex $argv 0]
+spawn $bin
+wait_prompt
+
+send "1+2;\r"
+wait_result "3"
+
+send "\033\[A"
+send "\r"
+wait_result "3"
+
+finish

--- a/src/tests/repl/line-edit.exp
+++ b/src/tests/repl/line-edit.exp
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+
+# Exercises mid-line cursor movement and editing, not just history recall:
+# type "1+92", back up over the errant "9" with Left, delete it with
+# Backspace, then move past the "2" again with Right before finishing the
+# statement
+
+set timeout 10
+source [file join [file dirname [info script]] common.tcl]
+
+set bin [lindex $argv 0]
+spawn $bin
+wait_prompt
+
+send "1+92"
+send "\033\[D"
+send "\177"
+send "\033\[C"
+send ";\r"
+wait_result "3"
+
+finish

--- a/src/tests/repl/test-repl.sh
+++ b/src/tests/repl/test-repl.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Drive the interactive REPL (isocline history, Ctrl+R search, continuation
+# hints, arrow-key editing) through a real pty via `expect`.
+#
+# These features only engage when stdin is a real terminal -- see is_tty()
+# in src/line_edit.f90 and its use at src/syntran.f90:130 -- so none of the
+# piped-stdin or `-c` string Dockerfile one-liner tests exercise a single
+# line of isocline code.  `expect`'s `spawn` allocates its own pty for the
+# child process, so this works even inside a `docker build` RUN step, which
+# has no controlling terminal of its own.
+#
+# Usage: test-repl.sh <path-to-syntran-binary>
+
+set -ue
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 <path-to-syntran-binary>"
+	exit 1
+fi
+
+bin="$1"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Isolate the persistent isocline history file ($HOME/.syntran_history, see
+# syntran_history_path() in src/c/isocline_wrap.c) so these tests never
+# read or pollute a real user's history
+export HOME
+HOME="$(mktemp -d)"
+export TERM=xterm
+
+ntest=0
+for exp in "$dir"/*.exp; do
+	ntest=$((ntest + 1))
+	echo "Running $(basename "$exp") ..."
+	expect -f "$exp" "$bin"
+done
+
+echo "All $ntest REPL tests passed"

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -213,6 +213,30 @@ end subroutine unit_test_unqualified_name
 
 !===============================================================================
 
+subroutine unit_test_bbcode_escape(npass, nfail)
+
+	! Test the bbcode_escape() helper that escapes chars special to isocline's
+	! bbcode prompt markup ('\' and '['; a lone ']' is not special -- see the
+	! comment in bbcode_escape() itself), so REPL prompts like the
+	! missing-semicolon hint "[Hint `;`]> " render literally instead of being
+	! parsed (and silently dropped) as an unrecognized bbcode tag
+
+	integer, intent(inout) :: npass, nfail
+
+	logical, parameter :: quiet = .true.
+
+	call unit_test_coda( [ &
+		bbcode_escape("[Hint `;`]> ") == "\[Hint `;`]> ", &
+		bbcode_escape("syntran$ "   ) == "syntran$ "     , &
+		bbcode_escape("> "         ) == "> "             , &
+		bbcode_escape(""           ) == ""               , &
+		bbcode_escape("a\b"        ) == "a\\b"             &
+		], "bbcode_escape", npass, nfail)
+
+end subroutine unit_test_bbcode_escape
+
+!===============================================================================
+
 subroutine unit_test_bin_arith(npass, nfail)
 
 	implicit none
@@ -6403,6 +6427,7 @@ subroutine unit_tests(iostat)
 	call unit_test_levenshtein          (npass, nfail)
 	call unit_test_overload_display_name(npass, nfail)
 	call unit_test_unqualified_name     (npass, nfail)
+	call unit_test_bbcode_escape        (npass, nfail)
 	call unit_test_bin_arith            (npass, nfail)
 	call unit_test_paren_arith(npass, nfail)
 	call unit_test_unary_arith(npass, nfail)


### PR DESCRIPTION
Historically I have used `rlwrap` for readline functionality in syntran. This includes things that you would expect in a REPL, like up/down arrow keys to scroll through previous commands, Ctrl+R search, etc.

Unfortunately it causes friction for users by requiring them to manually install rlwrap, setup an alias so syntran always runs under rlwrap, and having to remember to run `fpm --runner rlwrap` instead of just bare `fpm run` 

This PR adds the [isocline](https://github.com/daanx/isocline) library as a git submodule to replace rlwrap 