### PR TITLE
Hash maps for parse-time dictionaries

### DIFF
--- a/src/core.f90
+++ b/src/core.f90
@@ -34,6 +34,9 @@ module syntran__core_m
 	!  - do we have/need spellchecking for struct names? apparently fns_t has a
 	!    closest() levenshtein method but structs don't
 	!  - speedup intel aoc tests since it's the ci/cd bottleneck
+	!    * unrelated, windows pack ci stage seems to rebuild when maybe it
+	!      should re-use a cached build from one of the tests
+	!    * unrelated, long tests do not run on mac ci but they pass locally
 	!    * intel is around 14 minutes compared to 6 for gfortran
 	!    * would add -ipo/-Qipo for interprocedural optimization between files,
 	!      but fpm fails at linking because it defaults to ar/ld but it needs
@@ -45,23 +48,6 @@ module syntran__core_m
 	!  - callbacks, fn pointers, i.e. passing one function as an argument to
 	!    another function
 	!    * this could be a big change to the type system
-	!  - replace ternary tree dicts with hash maps? might be simpler, but there
-	!    might be zero perf benefit because the dicts are only used at parse
-	!    time, then mapped to efficient arrays at eval time
-	!    * existing map_i32_t class could be a template
-	!    * claude claims not worth it. although returning pointers from ternary
-	!      trees instead of copying var/fn/struct by value might perform better.
-	!    * i'm still suspecting hash maps might provide a cleaner api. rather
-	!      than a special-purpose tree traverser just for things like "is_const"
-	!      we could have a core routine that searches and returns an index into
-	!      the hash array, then pull out whatever data we want
-	!    * start small -- just one of fns, vars, or structs, then the remainder
-	!    * done for structs (structs_t in types.f90/types_dict.f90): it's now
-	!      a flat open-addressing hash table (find() returns an index, get()/
-	!      id_at() pull fields), reusing fnv_1a() but not map_i32_t itself
-	!      (wrapping map_i32_t would've meant two tables: its own key->int
-	!      table plus a parallel struct_t payload array). fns and vars/locs
-	!      still use ternary trees
 	!  - enums
 	!  - recursive data structs
 	!    * recursive fns are available, but not structs
@@ -527,9 +513,7 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 	type(value_t) :: var_val
 
 	! This no longer seems to make a difference.  Previously, without `save`,
-	! gfortran crashes when this goes out of scope.  Maybe I need to work on a
-	! manual finalizer to deallocate ternary trees, not just for structs but for
-	! the vars_t trees contained within
+	! gfortran crashes when this goes out of scope.
 	type(parser_t) :: parser
 	!type(parser_t), save :: parser
 
@@ -585,28 +569,29 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 	!print *, ''
 	!print *, 'size(vars%vals) = ', size(vars%vals)
 
-	!print *, 'allocated 1 = ', allocated(vars%dicts(1)%root)
-	!print *, 'allocated 2 = ', allocated(vars%dicts(2)%root)
-	!print *, 'allocated 3 = ', allocated(vars%dicts(3)%root)
+	!print *, 'allocated 1 = ', allocated(vars%dicts(1)%table)
+	!print *, 'allocated 2 = ', allocated(vars%dicts(2)%table)
+	!print *, 'allocated 3 = ', allocated(vars%dicts(3)%table)
 
-	if (allocated(vars%dicts(1)%root)) then
-	!if (any(allocated(vars%dicts(:)%root))) then
+	if (allocated(vars%dicts(1)%table)) then
+	!if (any(allocated(vars%dicts(:)%table))) then
 
 		if (allow_continuel) then
 			! Backup existing vars.  Only copy for interactive interpreter.
 			! This logic is slightly redundant as allow_continuel should _only_
 			! be set true for the interactive interpreter with stdin, which is
-			! also the only case where vars%root will be allocated.
+			! also the only case where vars%dicts(1)%table will be allocated.
 			! Calling syntran_interpret() on a multi-line string is deprecated,
 			! since syntran_eval() can parse it all in one syntax_parse() call.
 
-			! The root type has an overloaded assignment op, but the vars
-			! type itself does not (and I don't want to expose or encourage
-			! copying)
+			! var_entry_t's val component has an overloaded assignment op, but
+			! the vars type itself does not (and I don't want to expose or
+			! encourage copying)
 
 			allocate(vars0%dicts(1))
-			allocate(vars0%dicts(1)%root)
-			vars0%dicts(1)%root = vars%dicts(1)%root
+			vars0%dicts(1)%table    = vars%dicts(1)%table
+			vars0%dicts(1)%capacity = vars%dicts(1)%capacity
+			vars0%dicts(1)%count    = vars%dicts(1)%count
 
 			!print *, 'vars%vals = '
 			!do i = 1, size(vars%vals)
@@ -621,7 +606,11 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 		! Only the 1st scope level matters from interpreter.  It doesn't
 		! evaluate until the block is finished
-		call move_alloc(vars%dicts(1)%root, parser%vars%dicts(1)%root)
+		call move_alloc(vars%dicts(1)%table, parser%vars%dicts(1)%table)
+		parser%vars%dicts(1)%capacity = vars%dicts(1)%capacity
+		parser%vars%dicts(1)%count    = vars%dicts(1)%count
+		vars%dicts(1)%capacity = 0
+		vars%dicts(1)%count    = 0
 		call move_alloc(vars%vals         , parser%vars%vals)
 
 	!else if (parser%num_vars > 0) then
@@ -689,7 +678,7 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	! Pre-seed std:: constants into a fresh vars dict.
 	! REPL: dict was moved in above and already contains std:: constants -- skip.
-	if (.not. allocated(parser%vars%dicts(1)%root)) then
+	if (.not. allocated(parser%vars%dicts(1)%table)) then
 		call declare_intr_vars(parser%vars)
 		parser%num_vars = NUM_INTR_VARS
 	end if
@@ -716,8 +705,10 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 		! parsing the current stdin line from its start again.
 
 		if (allocated(vars0%dicts)) then
-			if (allocated(vars0%dicts(1)%root)) then
-				call move_alloc(vars0%dicts(1)%root, vars%dicts(1)%root)
+			if (allocated(vars0%dicts(1)%table)) then
+				call move_alloc(vars0%dicts(1)%table, vars%dicts(1)%table)
+				vars%dicts(1)%capacity = vars0%dicts(1)%capacity
+				vars%dicts(1)%count    = vars0%dicts(1)%count
 			end if
 		end if
 
@@ -746,9 +737,11 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	! Move back.  It's possible that vars were empty before this call but not
 	! anymore
-	if (allocated(parser%vars%dicts(1)%root)) then
+	if (allocated(parser%vars%dicts(1)%table)) then
 	!if (parser%num_vars > 0) then
-		call move_alloc(parser%vars%dicts(1)%root, vars%dicts(1)%root)
+		call move_alloc(parser%vars%dicts(1)%table, vars%dicts(1)%table)
+		vars%dicts(1)%capacity = parser%vars%dicts(1)%capacity
+		vars%dicts(1)%count    = parser%vars%dicts(1)%count
 	end if
 
 	! TODO: if num_fns instead?

--- a/src/core.f90
+++ b/src/core.f90
@@ -46,6 +46,7 @@ module syntran__core_m
 	!  - replace ternary tree dicts with hash maps? might be simpler, but there
 	!    might be zero perf benefit because the dicts are only used at parse
 	!    time, then mapped to efficient arrays at eval time
+	!    * existing map_i32_t class could be a template
 	!    * claude claims not worth it. although returning pointers from ternary
 	!      trees instead of copying var/fn/struct by value might perform better.
 	!    * i'm still suspecting hash maps might provide a cleaner api. rather
@@ -53,6 +54,12 @@ module syntran__core_m
 	!      we could have a core routine that searches and returns an index into
 	!      the hash array, then pull out whatever data we want
 	!    * start small -- just one of fns, vars, or structs, then the remainder
+	!    * done for structs (structs_t in types.f90/types_dict.f90): it's now
+	!      a flat open-addressing hash table (find() returns an index, get()/
+	!      id_at() pull fields), reusing fnv_1a() but not map_i32_t itself
+	!      (wrapping map_i32_t would've meant two tables: its own key->int
+	!      table plus a parallel struct_t payload array). fns and vars/locs
+	!      still use ternary trees
 	!  - enums
 	!  - recursive data structs
 	!    * recursive fns are available, but not structs
@@ -202,6 +209,9 @@ module syntran__core_m
 	!      worse than ubuntu.  it would be nice if everything was truly
 	!      statically bundled into one file
 	!    * is appimage the standard tool for this?  how does fpm do it?
+	!  - REPL improvements:
+	!    * allow structs in repl -- currently they don't work
+	!    * any other functionality gaps in repl -- fns?
 	!  - REPL styling
 	!    * any other ideas from julia?  got their green prompt
 	!    * could later extend with hint levels (off, semicolon-only, or fully on)
@@ -687,11 +697,6 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 	! Parse the tokens
 	call parser%parse_unit(tree)
 
-	!print *, ""
-	!print *, "in core.f90:"
-	!print *, "parser structs root     = ", parser%structs%dict%root%split_char
-	!print *, "parser structs root mid = ", parser%structs%dict%root%mid%split_char
-
 	!*******************************
 
 	tree%expecting       = parser%expecting
@@ -803,17 +808,6 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	end do
 	!print *, "done looking up fns"
-
-	!if (allocated(parser%structs)) then
-	!	! TODO: manually finalize recursively?
-	!	deallocate(parser%structs)
-	!end if
-	!print *, "size = ", size(parser%structs%structs)
-	!print *, "allocated = ", allocated(parser%structs%structs)
-	!print *, "size = ", size(parser%structs%dicts)
-	!print *, "allocated = ", allocated(parser%structs%dict%root)
-	!deallocate(parser%structs%dict%root)
-	!call struct_ternary_tree_final(parser%structs%dict%root)
 
 	if (debug > 0) print *, 'done syntax_parse'
 

--- a/src/core.f90
+++ b/src/core.f90
@@ -31,6 +31,8 @@ module syntran__core_m
 		syntran_patch =  0
 
 	! TODO:
+	!  - do we have/need spellchecking for struct names? apparently fns_t has a
+	!    closest() levenshtein method but structs don't
 	!  - speedup intel aoc tests since it's the ci/cd bottleneck
 	!    * intel is around 14 minutes compared to 6 for gfortran
 	!    * would add -ipo/-Qipo for interprocedural optimization between files,
@@ -514,7 +516,7 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	character(len = :), allocatable :: src_filel, fn_name, var_name
 
-	integer :: i, io, dummy, unit_
+	integer :: i, slot, unit_
 
 	logical :: allow_continuel, repll
 
@@ -537,12 +539,6 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 	if (debug > 0) print *, 'syntax_parse'
 	if (debug > 1) print *, 'str_ = ', str_
-
-	!! "exp"
-	!print *, 'key = ', &
-	!	fns%dict%root%split_char, &
-	!	fns%dict%root%mid%split_char, &
-	!	fns%dict%root%mid%mid%split_char
 
 	src_filel = '<stdin>'
 	if (present(src_file)) src_filel = src_file
@@ -648,10 +644,11 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 	end if
 
 	!print *, 'moving fns'
-	if (allocated(fns%dict%root)) then
+	if (allocated(fns%table)) then
 
-		allocate(fns0%dict%root)
-		fns0%dict%root = fns%dict%root
+		fns0%table          = fns%table
+		fns0%capacity       = fns%capacity
+		fns0%count          = fns%count
 
 		!print *, 'fns%fns = '
 		!do i = 1, size(fns%fns)
@@ -678,7 +675,11 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 		! Only the 1st scope level matters from interpreter.  It doesn't
 		! evaluate until the block is finished
-		call move_alloc(fns%dict%root, parser%fns%dict%root)
+		call move_alloc(fns%table, parser%fns%table)
+		parser%fns%capacity = fns%capacity
+		parser%fns%count    = fns%count
+		fns%capacity = 0
+		fns%count    = 0
 		if (allocated(fns%fns)) call move_alloc(fns%fns          , parser%fns%fns)
 
 	end if
@@ -725,8 +726,10 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 			call move_alloc(vars0%vals         , vars%vals)
 		end if
 
-		if (allocated(fns0%dict%root)) then
-			call move_alloc(fns0%dict%root, fns%dict%root)
+		if (allocated(fns0%table)) then
+			call move_alloc(fns0%table, fns%table)
+			fns%capacity = fns0%capacity
+			fns%count    = fns0%count
 			call move_alloc(fns0%fns          , fns%fns)
 		end if
 
@@ -749,8 +752,10 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 	end if
 
 	! TODO: if num_fns instead?
-	if (allocated(parser%fns%dict%root)) then
-		call move_alloc(parser%fns%dict%root, fns%dict%root)
+	if (allocated(parser%fns%table)) then
+		call move_alloc(parser%fns%table, fns%table)
+		fns%capacity = parser%fns%capacity
+		fns%count    = parser%fns%count
 
 		!! I tried adding this while working on recursive fn lookup but it's not
 		!! the way
@@ -803,7 +808,8 @@ function syntax_parse(str_, vars, fns, src_file, allow_continue, repl) result(tr
 
 		! User-defined fns are in the table after all of the intrinsic fns, so
 		! shift its index by num_intr_fns
-		fn = fns%search(fn_name, dummy, io)
+		slot = fns%find(fn_name)
+		fn = fns%get(slot)
 		fns%fns( fns%num_intr_fns + i ) = fn
 
 	end do

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -129,7 +129,7 @@ module subroutine parse_use_statement(parser, statement)
 	type(fn_t), pointer :: fn
 	type(value_t) :: var_val
 	type(struct_t), pointer :: struct_val
-	integer :: i, io, iostat, mod_unit_, id_index, struct_slot
+	integer :: i, io, iostat, mod_unit_, id_index, struct_slot, fn_slot
 	logical :: qualified_import, is_const_var
 	character(len = :), allocatable :: qualified_prefix
 
@@ -425,8 +425,10 @@ module subroutine parse_use_statement(parser, statement)
 		fn_name = mod_parser%fn_names%v(i)%s
 
 		! Look up the function in the module parser
-		fn => mod_parser%fns%search(fn_name, id_index, iostat)
-		if (iostat /= exit_success) cycle
+		fn_slot = mod_parser%fns%find(fn_name)
+		if (fn_slot == 0) cycle
+		fn => mod_parser%fns%get(fn_slot)
+		id_index = mod_parser%fns%id_at(fn_slot)
 
 		! Determine the name to insert: qualified (module::fn) or unqualified (fn)
 		! For qualified imports, convert path separators to namespace separators

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -129,7 +129,7 @@ module subroutine parse_use_statement(parser, statement)
 	type(fn_t), pointer :: fn
 	type(value_t) :: var_val
 	type(struct_t), pointer :: struct_val
-	integer :: i, io, iostat, mod_unit_, id_index
+	integer :: i, io, iostat, mod_unit_, id_index, struct_slot
 	logical :: qualified_import, is_const_var
 	character(len = :), allocatable :: qualified_prefix
 
@@ -500,8 +500,10 @@ module subroutine parse_use_statement(parser, statement)
 		struct_name = mod_parser%struct_names%v(i)%s
 
 		! Look up the struct in the module parser
-		call mod_parser%structs%search(struct_name, id_index, iostat, struct_val)
-		if (iostat /= exit_success) cycle
+		struct_slot = mod_parser%structs%find(struct_name)
+		if (struct_slot == 0) cycle
+		struct_val => mod_parser%structs%get(struct_slot)
+		id_index    = mod_parser%structs%id_at(struct_slot)
 
 		! Determine insert name (qualified or unqualified)
 		if (qualified_import) then

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -888,7 +888,7 @@ recursive module subroutine parse_dot(parser, expr)
 
 	!********
 
-	integer :: io, struct_id, member_id, pos0, pos1, method_i, method_fn_id, method_io, i
+	integer :: io, struct_id, member_id, pos0, pos1, method_i, method_fn_id, method_io, i, method_slot
 
 	logical :: call_arg_is_ref, is_ok, param_is_ref, param_is_const_ref, &
 		is_const_var, is_const_receiver
@@ -963,9 +963,15 @@ recursive module subroutine parse_dot(parser, expr)
 	! Check if the identifier is a method name on this struct.
 	! Strip the module prefix from struct_name (e.g. "mod::Type" → "Type") so
 	! that methods resolve the same way under both glob and qualified imports.
-	method_fn => parser%fns%search( &
-		"0" // unqualified_name(expr%val%struct_name) // "::" // identifier%text, &
-		method_fn_id, method_io)
+	method_slot = parser%fns%find( &
+		"0" // unqualified_name(expr%val%struct_name) // "::" // identifier%text)
+	if (method_slot == 0) then
+		method_io = exit_failure
+	else
+		method_io = exit_success
+		method_fn => parser%fns%get(method_slot)
+		method_fn_id = parser%fns%id_at(method_slot)
+	end if
 
 	if (method_io == exit_success) then
 
@@ -1183,12 +1189,18 @@ recursive module subroutine parse_dot(parser, expr)
 			! receiver_cand%id_index / is_loc / identifier → root variable (s).
 			! receiver_cand%val%struct_name → the struct type that owns the method.
 			block
-				integer :: fn_id_check, fn_io_check
+				integer :: fn_id_check, fn_io_check, fn_slot_check
 				type(fn_t), pointer :: fn_check
-				fn_check => parser%fns%search( &
+				fn_slot_check = parser%fns%find( &
 					"0" // unqualified_name(receiver_cand%val%struct_name) // &
-					"::" // expr%identifier%text, &
-					fn_id_check, fn_io_check)
+					"::" // expr%identifier%text)
+				if (fn_slot_check == 0) then
+					fn_io_check = exit_failure
+				else
+					fn_io_check = exit_success
+					fn_check => parser%fns%get(fn_slot_check)
+					fn_id_check = parser%fns%id_at(fn_slot_check)
+				end if
 				! fn_check is a pointer into the shared fn dict, disassociated
 				! when fn_io_check /= exit_success.  Fortran's .and. does not
 				! guarantee short-circuit evaluation, so the io check must be

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -951,13 +951,14 @@ recursive module subroutine parse_dot(parser, expr)
 	!print *, "struct_name = """, expr%val%struct_name, """"
 
 	! Is there a better way than looking up every struct by name again?
-	call parser%structs%search(expr%val%struct_name, struct_id, io, struct)
-	if (io /= 0) then
+	struct_id = parser%structs%find(expr%val%struct_name)
+	if (struct_id == 0) then
 		! Type is already confirmed as struct_type above, so I'm fairly sure
 		! this is unreachable
 		write(*,*) err_int(IC_UNREACHABLE_STRUCT_LOOKUP, "unreachable struct lookup failure")
 		call internal_error()
 	end if
+	struct => parser%structs%get(struct_id)
 
 	! Check if the identifier is a method name on this struct.
 	! Strip the module prefix from struct_name (e.g. "mod::Type" → "Type") so

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -944,8 +944,6 @@ module subroutine parse_struct_declaration(parser, decl)
 			identifier%text))
 	end if
 
-	!print *, "parser structs root     = ", parser%structs%dict%root%split_char
-	!print *, "parser structs root mid = ", parser%structs%dict%root%mid%split_char
 	!call ternary_tree_final(struct%vars%dicts(1)%root)
 
 	decl%kind = struct_declaration
@@ -1214,13 +1212,8 @@ recursive module subroutine parse_struct_instance(parser, inst, struct_name)
 
 	!print *, "parsing struct instance of lookup_name = ", lookup_name
 
-	!print *, ""
-	!print *, "in parse_struct_instance():"
-	!print *, "parser structs root     = ", parser%structs%dict%root%split_char
-	!print *, "parser structs root mid = ", parser%structs%dict%root%mid%split_char
-
-	call parser%structs%search(lookup_name, struct_id, io, struct)
-	!print *, "struct io = ", io
+	struct_id = parser%structs%find(lookup_name)
+	struct => parser%structs%get(struct_id)
 
 	call parser%match(lbrace_token, lbrace)
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -29,7 +29,7 @@ recursive module subroutine parse_fn_call(parser, module_prefix, identifier, fn_
 	character(len = :), allocatable :: exp_type, act_type, param_name, &
 		lookup_name, display_name
 
-	integer :: i, io, io_std, id_index, id_index_tmp, pos0, rank, arr_type_result
+	integer :: i, io, io_std, id_index, id_index_tmp, pos0, rank, arr_type_result, slot
 
 	logical :: has_rank, has_arr_type, param_is_ref, param_is_const_ref, &
 		arg_is_ref, is_ok, is_const_var
@@ -146,22 +146,30 @@ recursive module subroutine parse_fn_call(parser, module_prefix, identifier, fn_
 		if (module_prefix == "std") then
 			! For std::, first try std-only functions (registered with "std::" prefix)
 			lookup_name = "std::" // fn_call%identifier%text
-			fn => parser%fns%search(lookup_name, id_index, io)
-			if (io /= exit_success) then
+			slot = parser%fns%find(lookup_name)
+			if (slot == 0) then
 				! Fall back to regular intrinsic lookup without prefix (legacy intrinsics)
 				lookup_name = fn_call%identifier%text
-				fn => parser%fns%search(lookup_name, id_index, io)
+				slot = parser%fns%find(lookup_name)
 			end if
 		else
 			! For user modules, look up with qualified name
 			lookup_name = module_prefix // "::" // fn_call%identifier%text
-			fn => parser%fns%search(lookup_name, id_index, io)
+			slot = parser%fns%find(lookup_name)
 		end if
 		display_name = module_prefix // "::" // identifier_%text
 	else
 		lookup_name = fn_call%identifier%text
 		display_name = identifier_%text
-		fn => parser%fns%search(lookup_name, id_index, io)
+		slot = parser%fns%find(lookup_name)
+	end if
+
+	if (slot == 0) then
+		io = exit_failure
+	else
+		io = exit_success
+		fn => parser%fns%get(slot)
+		id_index = parser%fns%id_at(slot)
 	end if
 
 	!print *, "fn id_index = ", id_index
@@ -171,7 +179,14 @@ recursive module subroutine parse_fn_call(parser, module_prefix, identifier, fn_
 		! Do this before the ipass==0 early return so the type is set correctly
 		! in both passes, preventing cascading errors.
 		if (.not. present(module_prefix)) then
-			fn => parser%fns%search("std::" // fn_call%identifier%text, id_index, io_std)
+			slot = parser%fns%find("std::" // fn_call%identifier%text)
+			if (slot == 0) then
+				io_std = exit_failure
+			else
+				io_std = exit_success
+				fn => parser%fns%get(slot)
+				id_index = parser%fns%id_at(slot)
+			end if
 			if (io_std == exit_success) then
 				! Set the return type from the found function to prevent
 				! cascading errors from the untyped result

--- a/src/types.f90
+++ b/src/types.f90
@@ -59,36 +59,28 @@ module syntran__types_m
 
 	!********
 
-	type fn_ternary_tree_node_t
+	type fn_entry_t
+		! One slot of the fns_t hash table.  An unallocated `key` marks an
+		! empty (never-used) slot
 
-		character :: split_char = ''
-		type(fn_ternary_tree_node_t), allocatable :: left, mid, right
-
+		character(len = :), allocatable :: key
 		type(fn_t), allocatable :: val
-		integer :: id_index
+		integer :: id_index = 0
 
-		contains
-#ifndef SYNTRAN_INTEL
-			procedure, pass(dst) :: copy => fn_ternary_tree_copy
-			generic, public :: assignment(=) => copy
-#endif
-
-	end type fn_ternary_tree_node_t
-
-	!********
-
-	type fn_dict_t
-		! This is the fn dictionary of a single scope
-		type(fn_ternary_tree_node_t), allocatable :: root
-	end type fn_dict_t
+	end type fn_entry_t
 
 	!********
 
 	type fns_t
 
-		! A list of function dictionaries for each scope level used during
-		! parsing
-		type(fn_dict_t) :: dict
+		! Open-addressing hash table (FNV-1a + linear probing, like
+		! structs_t in this same module) mapping fn name -> fn_t.  Entries
+		! carry the fn_t payload directly instead of indirecting through a
+		! parallel array, so there is only one table
+
+		type(fn_entry_t), allocatable :: table(:)
+		integer :: capacity = 0, count = 0
+		real :: load_factor_threshold = 0.75
 
 		! Flat array of fns from all scopes, used for efficient interpreted
 		! evaluation
@@ -104,7 +96,9 @@ module syntran__types_m
 		contains
 			procedure :: &
 				insert  => fn_insert, &
-				search  => fn_search, &
+				find    => fn_find, &
+				get     => fn_get, &
+				id_at   => fn_id_at, &
 				closest => fn_closest
 		!		push_scope, pop_scope
 
@@ -386,11 +380,6 @@ module syntran__types_m
 			class(fn_t), intent(in)    :: src
 		end subroutine fn_copy
 
-		recursive module subroutine fn_ternary_tree_copy(dst, src)
-			class(fn_ternary_tree_node_t), intent(inout) :: dst
-			class(fn_ternary_tree_node_t), intent(in)    :: src
-		end subroutine fn_ternary_tree_copy
-
 		recursive module subroutine syntax_node_vector_copy(dst, src)
 			class(syntax_node_vector_t), intent(inout) :: dst
 			class(syntax_node_vector_t), intent(in)    :: src
@@ -424,13 +413,27 @@ module syntran__types_m
 		! types_dict.f90 procedures
 		!***************************************
 
-		module function fn_search(dict, key, id_index, iostat) result(val)
-			class(fns_t), intent(in), target :: dict
+		module function fn_find(dict, key) result(slot)
+			! Returns the table slot for `key`, or 0 if not present.  The slot
+			! is only valid until the next insert() (a resize rehashes the
+			! table), so callers must read get()/id_at() before any
+			! subsequent insert()
+			class(fns_t), intent(in) :: dict
 			character(len = *), intent(in) :: key
-			integer, intent(out) :: id_index
+			integer :: slot
+		end function fn_find
+
+		module function fn_get(dict, slot) result(val)
+			class(fns_t), intent(in), target :: dict
+			integer, intent(in) :: slot
 			type(fn_t), pointer :: val
-			integer, intent(out), optional :: iostat
-		end function fn_search
+		end function fn_get
+
+		module function fn_id_at(dict, slot) result(id_index)
+			class(fns_t), intent(in) :: dict
+			integer, intent(in) :: slot
+			integer :: id_index
+		end function fn_id_at
 
 		module subroutine fn_insert(dict, key, val, id_index, iostat, overwrite)
 			class(fns_t) :: dict
@@ -524,14 +527,6 @@ module syntran__types_m
 			character(len = :), allocatable, intent(inout) :: closest
 		end subroutine ternary_closest
 
-		recursive module subroutine fn_ternary_closest(node, prefix, target_low, &
-				target_unqual_low, min_dist, min_qdist, closest)
-			type(fn_ternary_tree_node_t), intent(in), allocatable :: node
-			character(len = *), intent(in) :: prefix, target_low, target_unqual_low
-			integer, intent(inout) :: min_dist, min_qdist
-			character(len = :), allocatable, intent(inout) :: closest
-		end subroutine fn_ternary_closest
-
 		recursive module subroutine ternary_insert(node, key, val, id_index, iostat, overwrite, is_const)
 			type(ternary_tree_node_t), intent(inout), allocatable :: node
 			character(len = *), intent(in) :: key
@@ -541,23 +536,6 @@ module syntran__types_m
 			logical, intent(in) :: overwrite
 			logical, intent(in), optional :: is_const
 		end subroutine ternary_insert
-
-		recursive module function fn_ternary_search(node, key, id_index, iostat) result(val)
-			type(fn_ternary_tree_node_t), intent(in), allocatable, target :: node
-			character(len = *), intent(in) :: key
-			integer, intent(out) :: id_index
-			integer, intent(out) :: iostat
-			type(fn_t), pointer :: val
-		end function fn_ternary_search
-
-		recursive module subroutine fn_ternary_insert(node, key, val, id_index, iostat, overwrite)
-			type(fn_ternary_tree_node_t), intent(inout), allocatable :: node
-			character(len = *), intent(in) :: key
-			type(fn_t), intent(in) :: val
-			integer, intent(in) :: id_index
-			integer, intent(out) :: iostat
-			logical, intent(in) :: overwrite
-		end subroutine fn_ternary_insert
 
 		module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 			class(structs_t) :: dict

--- a/src/types.f90
+++ b/src/types.f90
@@ -300,47 +300,36 @@ module syntran__types_m
 
 	!********
 
-	type struct_ternary_tree_node_t
+	type struct_entry_t
+		! One slot of the structs_t hash table.  An unallocated `key` marks an
+		! empty (never-used) slot
 
-		character :: split_char = ''
-		type(struct_ternary_tree_node_t), allocatable :: left, mid, right
-
+		character(len = :), allocatable :: key
 		type(struct_t), allocatable :: val
-		integer :: id_index
+		integer :: id_index = 0
 
-		contains
-			! This is also required unfortunately too
-#ifndef SYNTRAN_INTEL
-			procedure, pass(dst) :: copy => struct_ternary_tree_copy
-			generic, public :: assignment(=) => copy
-#endif
-			!final :: struct_ternary_tree_final
-
-	end type struct_ternary_tree_node_t
-
-	!********
-
-	type struct_dict_t
-		! This is the struct dictionary of a single scope
-		type(struct_ternary_tree_node_t), allocatable :: root
-	end type struct_dict_t
+	end type struct_entry_t
 
 	!********
 
 	type structs_t
 
-		! A list of struct dictionaries used during parsing
-		!type(struct_dict_t) :: dicts(scope_max)
-		type(struct_dict_t) :: dict
+		! Open-addressing hash table (FNV-1a + linear probing, like
+		! map_i32_t in utils.f90) mapping struct name -> struct_t.  Unlike
+		! map_i32_t, entries carry the struct_t payload directly instead of
+		! indirecting through a parallel array, so there is only one table
 
-		!! Flat array of structs, used for efficient interpreted evaluation
-		!type(struct_t), allocatable :: structs(:)
+		type(struct_entry_t), allocatable :: table(:)
+		integer :: capacity = 0, count = 0
+		real :: load_factor_threshold = 0.75
 
 		contains
 			procedure :: &
 				insert => struct_insert, &
-				exists => struct_exists, &
-				search => struct_search
+				find   => struct_find, &
+				get    => struct_get, &
+				id_at  => struct_id_at, &
+				exists => struct_exists
 
 	end type structs_t
 
@@ -425,11 +414,6 @@ module syntran__types_m
 			class(ternary_tree_node_t), intent(inout) :: dst
 			class(ternary_tree_node_t), intent(in)    :: src
 		end subroutine ternary_tree_copy
-
-		recursive module subroutine struct_ternary_tree_copy(dst, src)
-			class(struct_ternary_tree_node_t), intent(inout) :: dst
-			class(struct_ternary_tree_node_t), intent(in)    :: src
-		end subroutine struct_ternary_tree_copy
 
 		recursive module subroutine syntax_nodes_copy(dst, src)
 			type(syntax_node_t), allocatable, intent(inout) :: dst(:)
@@ -575,29 +559,6 @@ module syntran__types_m
 			logical, intent(in) :: overwrite
 		end subroutine fn_ternary_insert
 
-		recursive module function struct_ternary_exists(node, key) result(exists)
-			type(struct_ternary_tree_node_t), intent(in), allocatable :: node
-			character(len = *), intent(in) :: key
-			logical :: exists
-		end function struct_ternary_exists
-
-		recursive module subroutine struct_ternary_search(node, key, id_index, iostat, val)
-			type(struct_ternary_tree_node_t), intent(in), allocatable, target :: node
-			character(len = *), intent(in) :: key
-			integer, intent(out) :: id_index
-			integer, intent(out) :: iostat
-			type(struct_t), pointer, intent(out) :: val
-		end subroutine struct_ternary_search
-
-		recursive module subroutine struct_ternary_insert(node, key, val, id_index, iostat, overwrite)
-			type(struct_ternary_tree_node_t), intent(inout), allocatable :: node
-			character(len = *), intent(in) :: key
-			type(struct_t), intent(in) :: val
-			integer, intent(in) :: id_index
-			integer, intent(out) :: iostat
-			logical, intent(in) :: overwrite
-		end subroutine struct_ternary_insert
-
 		module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 			class(structs_t) :: dict
 			character(len = *), intent(in) :: key
@@ -607,19 +568,33 @@ module syntran__types_m
 			logical, intent(in), optional :: overwrite
 		end subroutine struct_insert
 
+		module function struct_find(dict, key) result(slot)
+			! Returns the table slot for `key`, or 0 if not present.  The slot
+			! is only valid until the next insert() (a resize rehashes the
+			! table), so callers must read get()/id_at() before any
+			! subsequent insert()
+			class(structs_t), intent(in) :: dict
+			character(len = *), intent(in) :: key
+			integer :: slot
+		end function struct_find
+
+		module function struct_get(dict, slot) result(val)
+			class(structs_t), intent(in), target :: dict
+			integer, intent(in) :: slot
+			type(struct_t), pointer :: val
+		end function struct_get
+
+		module function struct_id_at(dict, slot) result(id_index)
+			class(structs_t), intent(in) :: dict
+			integer, intent(in) :: slot
+			integer :: id_index
+		end function struct_id_at
+
 		module function struct_exists(dict, key) result(exists)
 			class(structs_t), intent(in) :: dict
 			character(len = *), intent(in) :: key
 			logical :: exists
 		end function struct_exists
-
-		module subroutine struct_search(dict, key, id_index, iostat, val)
-			class(structs_t), intent(in), target :: dict
-			character(len = *), intent(in) :: key
-			integer, intent(out) :: id_index
-			type(struct_t), pointer, intent(out) :: val
-			integer, intent(out), optional :: iostat
-		end subroutine struct_search
 
 		!***************************************
 		! types_ops.f90 procedures

--- a/src/types.f90
+++ b/src/types.f90
@@ -209,29 +209,26 @@ module syntran__types_m
 	! Dependencies between types could make this module difficult to split into
 	! separate files.  I think I like the monolithic design anyway
 
-	type ternary_tree_node_t
+	type var_entry_t
+		! One slot of a var_dict_t hash table.  An unallocated `key` marks an
+		! empty (never-used) slot
 
-		character :: split_char = ''
-		type(ternary_tree_node_t), allocatable :: left, mid, right
-
+		character(len = :), allocatable :: key
 		type(value_t), allocatable :: val
-		integer :: id_index
+		integer :: id_index = 0
 		logical :: is_const = .false.
 
-		contains
-			!procedure :: print => ternary_node_print
-#ifndef SYNTRAN_INTEL
-			procedure, pass(dst) :: copy => ternary_tree_copy
-			generic, public :: assignment(=) => copy
-#endif
-
-	end type ternary_tree_node_t
+	end type var_entry_t
 
 	!********
 
 	type var_dict_t
-		! This is the variable dictionary of a single scope
-		type(ternary_tree_node_t), allocatable :: root
+		! This is the variable dictionary of a single scope.  Open-addressing
+		! hash table (FNV-1a + linear probing, like structs_t/fns_t)
+
+		type(var_entry_t), allocatable :: table(:)
+		integer :: capacity = 0, count = 0
+		real :: load_factor_threshold = 0.75
 	end type var_dict_t
 
 	!********
@@ -399,10 +396,9 @@ module syntran__types_m
 			type(syntax_node_t), intent(inout) :: src, dst
 		end subroutine syntax_node_move_into
 
-		recursive module subroutine ternary_tree_copy(dst, src)
-			class(ternary_tree_node_t), intent(inout) :: dst
-			class(ternary_tree_node_t), intent(in)    :: src
-		end subroutine ternary_tree_copy
+		! ternary_tree_copy() was here.  It's no longer needed: var_dict_t is
+		! now a flat hash table (var_entry_t table(:) in this module) instead
+		! of a ternary tree, so intrinsic assignment suffices in vars_copy()
 
 		recursive module subroutine syntax_nodes_copy(dst, src)
 			type(syntax_node_t), allocatable, intent(inout) :: dst(:)
@@ -504,38 +500,12 @@ module syntran__types_m
 			type(syntax_node_t), intent(inout) :: val
 		end subroutine push_node_move
 
-		recursive module subroutine ternary_search(node, key, id_index, iostat, val, is_const)
-			type(ternary_tree_node_t), intent(in), allocatable :: node
-			character(len = *), intent(in) :: key
-			integer, intent(out) :: id_index
-			integer, intent(out) :: iostat
-			type(value_t), intent(out) :: val
-			logical, intent(out), optional :: is_const
-		end subroutine ternary_search
-
-		recursive module subroutine ternary_is_const(node, key, is_const, found)
-			type(ternary_tree_node_t), intent(in), allocatable :: node
-			character(len = *), intent(in) :: key
-			logical, intent(out) :: is_const, found
-		end subroutine ternary_is_const
-
-		recursive module subroutine ternary_closest(node, prefix, target_low, &
-				target_unqual_low, min_dist, min_qdist, closest)
-			type(ternary_tree_node_t), intent(in), allocatable :: node
-			character(len = *), intent(in) :: prefix, target_low, target_unqual_low
-			integer, intent(inout) :: min_dist, min_qdist
-			character(len = :), allocatable, intent(inout) :: closest
-		end subroutine ternary_closest
-
-		recursive module subroutine ternary_insert(node, key, val, id_index, iostat, overwrite, is_const)
-			type(ternary_tree_node_t), intent(inout), allocatable :: node
-			character(len = *), intent(in) :: key
-			type(value_t), intent(in) :: val
-			integer, intent(in) :: id_index
-			integer, intent(out) :: iostat
-			logical, intent(in) :: overwrite
-			logical, intent(in), optional :: is_const
-		end subroutine ternary_insert
+		! ternary_search(), ternary_is_const(), ternary_closest(), and
+		! ternary_insert() were here.  var_dict_t is now a flat hash table
+		! (var_entry_t table(:)), so these tree walkers were replaced by
+		! var_grow() (a submodule-local helper in types_dict.f90, not part of
+		! the public API, mirroring struct_grow()/fn_grow()) plus the
+		! var_insert/var_search/var_is_const/var_closest bodies below
 
 		module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 			class(structs_t) :: dict

--- a/src/types_copy.f90
+++ b/src/types_copy.f90
@@ -160,50 +160,11 @@ end subroutine fn_copy
 
 !===============================================================================
 
-recursive module subroutine fn_ternary_tree_copy(dst, src)
-
-	! Deep copy.  This overwrites dst with src.  If dst had keys that weren't in
-	! source, they will be gone!
-	!
-	! This should be avoided for efficient compilation, but the interactive
-	! interpreter uses it to backup and restore the variable dict for
-	! partially-evaluated continuation lines
-
-	class(fn_ternary_tree_node_t), intent(inout) :: dst
-	class(fn_ternary_tree_node_t), intent(in)    :: src
-
-	!********
-
-	!print *, 'starting fn_ternary_tree_node_t()'
-
-	dst%split_char = src%split_char
-
-	dst%id_index = src%id_index
-
-	if (allocated(src%val)) then
-		if (.not. allocated(dst%val)) allocate(dst%val)
-		call fn_copy(dst%val, src%val)
-	! TODO: else deallocate?  Other tree copiers too
-	end if
-
-	if (allocated(src%left)) then
-		if (.not. allocated(dst%left)) allocate(dst%left)
-		dst%left = src%left
-	end if
-
-	if (allocated(src%mid)) then
-		if (.not. allocated(dst%mid)) allocate(dst%mid)
-		dst%mid = src%mid
-	end if
-
-	if (allocated(src%right)) then
-		if (.not. allocated(dst%right)) allocate(dst%right)
-		dst%right = src%right
-	end if
-
-	!print *, 'done fn_ternary_tree_node_t()'
-
-end subroutine fn_ternary_tree_copy
+! fn_ternary_tree_copy() was here.  It's no longer needed: fns_t is now a flat
+! hash table (fn_entry_t table(:) in types.f90) instead of a ternary tree, so
+! default (intrinsic) assignment suffices -- it recurses elementwise over
+! table(:), and each fn_entry_t's allocatable val component already uses
+! fn_copy() via fn_t's own defined assignment(=)
 
 !===============================================================================
 

--- a/src/types_copy.f90
+++ b/src/types_copy.f90
@@ -58,13 +58,12 @@ recursive module subroutine vars_copy(dst, src)
 		if (allocated(dst%dicts)) deallocate(dst%dicts)
 		allocate(dst%dicts( size(src%dicts) ))
 
+		! var_dict_t is a flat hash table (var_entry_t table(:)), so
+		! intrinsic assignment suffices here -- it recurses elementwise over
+		! table(:), and each var_entry_t's allocatable val component already
+		! uses value_t's own defined assignment(=)
 		do i = 1, size(src%dicts)
-			if (allocated(src%dicts(i)%root)) then
-				if (.not. allocated(dst%dicts(i)%root)) allocate(dst%dicts(i)%root)
-				dst%dicts(i)%root = src%dicts(i)%root
-			else if (allocated(dst%dicts(i)%root)) then
-				deallocate(dst%dicts(i)%root)
-			end if
+			dst%dicts(i) = src%dicts(i)
 		end do
 
 	else if (allocated(dst%dicts)) then
@@ -573,48 +572,11 @@ end subroutine syntax_node_move_into
 
 !===============================================================================
 
-recursive module subroutine ternary_tree_copy(dst, src)
-
-	! Deep copy.  This overwrites dst with src.  If dst had keys that weren't in
-	! source, they will be gone!
-	!
-	! This should be avoided for efficient compilation, but the interactive
-	! interpreter uses it to backup and restore the variable dict for
-	! partially-evaluated continuation lines
-
-	class(ternary_tree_node_t), intent(inout) :: dst
-	class(ternary_tree_node_t), intent(in)    :: src
-
-	!********
-
-	!if (.not. allocated(dst)) allocate(dst)
-
-	dst%split_char = src%split_char
-
-	dst%id_index = src%id_index
-	dst%is_const = src%is_const
-
-	if (allocated(src%val)) then
-		if (.not. allocated(dst%val)) allocate(dst%val)
-		call value_copy(dst%val, src%val)
-	end if
-
-	if (allocated(src%left)) then
-		if (.not. allocated(dst%left)) allocate(dst%left)
-		dst%left = src%left
-	end if
-
-	if (allocated(src%mid)) then
-		if (.not. allocated(dst%mid)) allocate(dst%mid)
-		dst%mid = src%mid
-	end if
-
-	if (allocated(src%right)) then
-		if (.not. allocated(dst%right)) allocate(dst%right)
-		dst%right = src%right
-	end if
-
-end subroutine ternary_tree_copy
+! ternary_tree_copy() was here.  It's no longer needed: var_dict_t is now a
+! flat hash table (var_entry_t table(:) in types.f90) instead of a ternary
+! tree, so default (intrinsic) assignment suffices -- it recurses elementwise
+! over table(:), and each var_entry_t's allocatable val component already
+! uses value_t's own defined assignment(=).  See vars_copy() above
 
 !===============================================================================
 

--- a/src/types_copy.f90
+++ b/src/types_copy.f90
@@ -657,49 +657,12 @@ end subroutine ternary_tree_copy
 
 !===============================================================================
 
-recursive module subroutine struct_ternary_tree_copy(dst, src)
-
-	! Deep copy.  This overwrites dst with src.  If dst had keys that weren't in
-	! source, they will be gone!
-	!
-	! This should be avoided for efficient compilation, but the interactive
-	! interpreter uses it to backup and restore the variable dict for
-	! partially-evaluated continuation lines
-
-	class(struct_ternary_tree_node_t), intent(inout) :: dst
-	class(struct_ternary_tree_node_t), intent(in)    :: src
-
-	!********
-
-	!print *, 'starting struct_ternary_tree_node_t()'
-
-	dst%split_char = src%split_char
-
-	dst%id_index = src%id_index
-
-	if (allocated(src%val)) then
-		if (.not. allocated(dst%val)) allocate(dst%val)
-		call struct_copy(dst%val, src%val)
-	end if
-
-	if (allocated(src%left)) then
-		if (.not. allocated(dst%left)) allocate(dst%left)
-		dst%left = src%left
-	end if
-
-	if (allocated(src%mid)) then
-		if (.not. allocated(dst%mid)) allocate(dst%mid)
-		dst%mid = src%mid
-	end if
-
-	if (allocated(src%right)) then
-		if (.not. allocated(dst%right)) allocate(dst%right)
-		dst%right = src%right
-	end if
-
-	!print *, 'done struct_ternary_tree_node_t()'
-
-end subroutine struct_ternary_tree_copy
+! struct_ternary_tree_copy() was here.  It's no longer needed: structs_t is
+! now a flat hash table (struct_entry_t table(:) in types.f90) instead of a
+! ternary tree, so default (intrinsic) assignment suffices -- it recurses
+! elementwise over table(:), and each struct_entry_t's allocatable val
+! component already uses struct_copy() via struct_t's own defined
+! assignment(=)
 
 !===============================================================================
 

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -413,7 +413,7 @@ end subroutine ternary_search
 recursive module subroutine ternary_is_const(node, key, is_const, found)
 
 	! Cheap existence + const-flag check, without copying node%val out like
-	! ternary_search() does.  Mirrors struct_ternary_exists()
+	! ternary_search() does.  Mirrors struct_exists()
 
 	type(ternary_tree_node_t), intent(in), allocatable :: node
 	character(len = *), intent(in) :: key
@@ -666,188 +666,137 @@ end subroutine fn_ternary_insert
 
 !===============================================================================
 
-recursive module function struct_ternary_exists(node, key) result(exists)
+subroutine struct_grow(dict)
 
-	type(struct_ternary_tree_node_t), intent(in), allocatable :: node
+	! Double dict%table's capacity (or allocate an initial table) and rehash
+	! all existing entries into it.  Mirrors map_i32_resize() in utils.f90.
+	!
+	! This is a submodule-local helper (no "module" prefix, no interface
+	! declaration in types.f90), not part of the structs_t public API
+	!
+	! This does its own probing instead of calling struct_insert(), because
+	! struct_insert() increments id_index on every call -- appropriate for a
+	! genuinely new declaration, but not for relocating an existing entry
+	! during a rehash
+
+	class(structs_t) :: dict
+
+	!********
+
+	type(struct_entry_t), allocatable :: old_table(:)
+	integer :: old_capacity, i, new_capacity
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	old_capacity = dict%capacity
+	new_capacity = max(2 * old_capacity, 8)
+
+	if (old_capacity > 0) call move_alloc(dict%table, old_table)
+
+	dict%capacity = new_capacity
+	allocate(dict%table(new_capacity))
+	! dict%count is unchanged -- rehashing doesn't add or remove entries
+
+	do i = 1, old_capacity
+		if (.not. allocated(old_table(i)%key)) cycle
+
+		hash_val = fnv_1a(old_table(i)%key)
+		hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+		do probe = 0, dict%capacity - 1
+			idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+			if (.not. allocated(dict%table(idx)%key)) then
+				call move_alloc(old_table(i)%key, dict%table(idx)%key)
+				call move_alloc(old_table(i)%val, dict%table(idx)%val)
+				dict%table(idx)%id_index = old_table(i)%id_index
+				exit
+			end if
+		end do
+	end do
+
+end subroutine struct_grow
+
+!===============================================================================
+
+module function struct_find(dict, key) result(slot)
+
+	! Returns the table slot for `key`, or 0 if not present.  The slot is
+	! only valid until the next insert() call: a resize() (triggered by
+	! insert() growing the table) rehashes everything, invalidating
+	! previously-returned slots and pointers from get().  Every current
+	! caller reads get()/id_at() immediately after find(), with no
+	! intervening insert(), so this is safe
+
+	class(structs_t), intent(in) :: dict
 	character(len = *), intent(in) :: key
 
+	integer :: slot
+
+	!********
+
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	slot = 0
+
+	if (dict%capacity <= 0) return
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot => key not present
+			return
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			slot = idx
+			return
+		end if
+	end do
+
+end function struct_find
+
+!===============================================================================
+
+module function struct_get(dict, slot) result(val)
+
+	class(structs_t), intent(in), target :: dict
+	integer, intent(in) :: slot
+
+	type(struct_t), pointer :: val
+
+	val => dict%table(slot)%val
+
+end function struct_get
+
+!===============================================================================
+
+module function struct_id_at(dict, slot) result(id_index)
+
+	class(structs_t), intent(in) :: dict
+	integer, intent(in) :: slot
+
+	integer :: id_index
+
+	id_index = dict%table(slot)%id_index
+
+end function struct_id_at
+
+!===============================================================================
+
+module function struct_exists(dict, key) result(exists)
+
+	! Check if a key exists, without going through get() like other callers do
+
+	class(structs_t), intent(in) :: dict
+	character(len = *), intent(in) :: key
 	logical :: exists
 
-	!********
+	exists = struct_find(dict, key) > 0
 
-	character :: k
-	character(len = :), allocatable :: ey
-
-	!print *, 'searching key ', quote(key)
-
-	exists = .false.
-
-	! Search key not found
-	if (.not. allocated(node)) return
-
-	! :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (k < node%split_char) then
-		exists = struct_ternary_exists(node%left , key)
-		return
-	else if (k > node%split_char) then
-		exists = struct_ternary_exists(node%right, key)
-		return
-	else if (len(ey) > 0) then
-		exists = struct_ternary_exists(node%mid  ,  ey)
-		return
-	end if
-
-	!print *, 'setting val'
-
-	if (.not. allocated(node%val)) then
-		exists = .false.
-		return
-	end if
-
-	exists = .true.
-
-	!print *, 'done struct_ternary_exists'
-	!print *, ''
-
-end function struct_ternary_exists
-
-!===============================================================================
-
-recursive module subroutine struct_ternary_search(node, key, id_index, iostat, val)
-
-	type(struct_ternary_tree_node_t), intent(in), allocatable, target :: node
-	character(len = *), intent(in) :: key
-
-	integer, intent(out) :: id_index
-	integer, intent(out) :: iostat
-	type(struct_t), pointer, intent(out) :: val
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	!print *, 'searching key ', quote(key)
-
-	iostat = exit_success
-
-	if (.not. allocated(node)) then
-		! Search key not found
-		iostat = exit_failure
-		val => null()
-		return
-	end if
-
-	! :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (k < node%split_char) then
-		call struct_ternary_search(node%left , key, id_index, iostat, val)
-		!print *, "return left"
-		return
-	else if (k > node%split_char) then
-		call struct_ternary_search(node%right, key, id_index, iostat, val)
-		!print *, "return right"
-		return
-	else if (len(ey) > 0) then
-		call struct_ternary_search(node%mid  , ey, id_index, iostat, val)
-		!print *, "return mid"
-		return
-	end if
-
-	!print *, 'setting val'
-
-	if (.not. allocated(node%val)) then
-		iostat = exit_failure
-		val => null()
-		return
-	end if
-
-	!allocate(val)
-	val      => node%val
-	!val%vars = node%val%vars
-	id_index = node%id_index
-	!val%members = node%val%members
-
-	!print *, 'done struct_ternary_search'
-	!print *, ''
-
-end subroutine struct_ternary_search
-
-!===============================================================================
-
-recursive module subroutine struct_ternary_insert(node, key, val, id_index, iostat, overwrite)
-
-	type(struct_ternary_tree_node_t), intent(inout), allocatable :: node
-	character(len = *), intent(in) :: key
-	type(struct_t), intent(in) :: val
-	integer, intent(in) :: id_index
-
-	integer, intent(out) :: iostat
-	logical, intent(in) :: overwrite
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	iostat = exit_success
-
-	!print *, 'inserting key ', quote(key)
-
-	! key == k//ey.  Get it? :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (.not. allocated(node)) then
-		!print *, 'allocate'
-		allocate(node)
-		node%split_char = k
-	else if (k < node%split_char) then
-		!print *, 'left'
-		call struct_ternary_insert(node%left , key, val, id_index, iostat, overwrite)
-		return
-	else if (k > node%split_char) then
-		!print *, 'right'
-		call struct_ternary_insert(node%right, key, val, id_index, iostat, overwrite)
-		return
-	end if
-
-	!print *, 'mid'
-
-	if (len(ey) /= 0) then
-		call struct_ternary_insert(node%mid  , ey, val, id_index, iostat, overwrite)
-		return
-	end if
-
-	! node%val doesn't really need to be declared as allocatable (it's
-	! a scalar anyway), but it's just a convenient way to check if
-	! a duplicate key has already been inserted or not.  We could add
-	! a separate logical member to node for this instead if needed
-
-	! This is not necessarily a failure unless we don't want to overwrite.  In
-	! the evaluator, we will insert values for vars which have already been
-	! declared
-	if (allocated(node%val) .and. .not. overwrite) then
-		!print *, 'key already inserted'
-		iostat = exit_failure
-		return
-	end if
-
-	if (.not. allocated(node%val)) allocate(node%val)
-	node%val      = val
-	!node%val%vars = val%vars
-	node%id_index = id_index
-	!node%val%members = val%members
-
-	!print *, 'done inserting'
-	!print *, ''
-
-end subroutine struct_ternary_insert
+end function struct_exists
 
 !===============================================================================
 
@@ -863,7 +812,8 @@ module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 
 	!********
 
-	integer :: io
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx, io
 	logical :: overwritel
 
 	!print *, 'inserting ', quote(key)
@@ -874,54 +824,41 @@ module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 	overwritel = .true.
 	if (present(overwrite)) overwritel = overwrite
 
-	call struct_ternary_insert(dict%dict%root, key, val, id_index, io, overwritel)
+	io = exit_success
+
+	if (dict%capacity <= 0 .or. &
+			real(dict%count) / real(dict%capacity) >= dict%load_factor_threshold) then
+		call struct_grow(dict)
+	end if
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot - insert new entry
+			dict%table(idx)%key = key
+			dict%table(idx)%val = val
+			dict%table(idx)%id_index = id_index
+			dict%count = dict%count + 1
+			exit
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			! Key already inserted
+			if (.not. overwritel) then
+				io = exit_failure
+				exit
+			end if
+			dict%table(idx)%val = val
+			dict%table(idx)%id_index = id_index
+			exit
+		end if
+	end do
 
 	if (present(iostat)) iostat = io
 
 end subroutine struct_insert
-
-!===============================================================================
-
-module function struct_exists(dict, key) result(exists)
-
-	! Check if a key exists, without copying an output val unlike
-	! struct_search()
-
-	class(structs_t), intent(in) :: dict
-	character(len = *), intent(in) :: key
-	logical :: exists
-
-	exists = struct_ternary_exists(dict%dict%root, key)
-
-end function struct_exists
-
-!===============================================================================
-
-module subroutine struct_search(dict, key, id_index, iostat, val)
-
-	! An id_index is not normally part of dictionary searching, but we use it
-	! here for converting the dictionary into an array after parsing and before
-	! evaluation for better performance
-
-	class(structs_t), intent(in), target :: dict
-	character(len = *), intent(in) :: key
-	integer, intent(out) :: id_index
-	type(struct_t), pointer, intent(out) :: val
-
-	integer, intent(out), optional :: iostat
-
-	!********
-
-	integer :: io
-
-	!print *, "starting struct search"
-
-	call struct_ternary_search(dict%dict%root, key, id_index, io, val)
-	!print *, "io = ", io
-
-	if (present(iostat)) iostat = io
-
-end subroutine struct_search
 
 !===============================================================================
 

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -838,8 +838,12 @@ module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
 
 		if (.not. allocated(dict%table(idx)%key)) then
-			! Empty slot - insert new entry
+			! Empty slot - insert new entry.  struct_t has a defined
+			! assignment(=) (struct_copy), which -- unlike intrinsic
+			! assignment -- does not auto-allocate an unallocated allocatable
+			! target, so val must be explicitly allocated first
 			dict%table(idx)%key = key
+			if (.not. allocated(dict%table(idx)%val)) allocate(dict%table(idx)%val)
 			dict%table(idx)%val = val
 			dict%table(idx)%id_index = id_index
 			dict%count = dict%count + 1
@@ -850,6 +854,7 @@ module subroutine struct_insert(dict, key, val, id_index, iostat, overwrite)
 				io = exit_failure
 				exit
 			end if
+			if (.not. allocated(dict%table(idx)%val)) allocate(dict%table(idx)%val)
 			dict%table(idx)%val = val
 			dict%table(idx)%id_index = id_index
 			exit

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -11,40 +11,127 @@ contains
 
 !===============================================================================
 
-module function fn_search(dict, key, id_index, iostat) result(val)
+subroutine fn_grow(dict)
 
-	! An id_index is not normally part of dictionary searching, but we use it
-	! here for converting the dictionary into an array after parsing and before
-	! evaluation for better performance
+	! Double dict%table's capacity (or allocate an initial table) and rehash
+	! all existing entries into it.  Mirrors struct_grow() in this same file.
+	!
+	! This is a submodule-local helper (no "module" prefix, no interface
+	! declaration in types.f90), not part of the fns_t public API
+	!
+	! This does its own probing instead of calling fn_insert(), because
+	! fn_insert() takes id_index as given by the caller -- appropriate for a
+	! genuinely new declaration, but not for relocating an existing entry
+	! during a rehash
 
-	class(fns_t), intent(in), target :: dict
-	character(len = *), intent(in) :: key
-	integer, intent(out) :: id_index
-	type(fn_t), pointer :: val
-
-	integer, intent(out), optional :: iostat
+	class(fns_t) :: dict
 
 	!********
 
-	integer :: i, io
+	type(fn_entry_t), allocatable :: old_table(:)
+	integer :: old_capacity, i, new_capacity
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
 
-	i = dict%scope
+	old_capacity = dict%capacity
+	new_capacity = max(2 * old_capacity, 8)
 
-	val => fn_ternary_search(dict%dict%root, key, id_index, io)
+	if (old_capacity > 0) call move_alloc(dict%table, old_table)
 
-	! If not found in current scope, search parent scopes too
-	do while (io /= exit_success .and. i > 1)
-		i = i - 1
-		val => fn_ternary_search(dict%dict%root, key, id_index, io)
+	dict%capacity = new_capacity
+	allocate(dict%table(new_capacity))
+	! dict%count is unchanged -- rehashing doesn't add or remove entries
+
+	do i = 1, old_capacity
+		if (.not. allocated(old_table(i)%key)) cycle
+
+		hash_val = fnv_1a(old_table(i)%key)
+		hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+		do probe = 0, dict%capacity - 1
+			idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+			if (.not. allocated(dict%table(idx)%key)) then
+				call move_alloc(old_table(i)%key, dict%table(idx)%key)
+				call move_alloc(old_table(i)%val, dict%table(idx)%val)
+				dict%table(idx)%id_index = old_table(i)%id_index
+				exit
+			end if
+		end do
 	end do
 
-	if (present(iostat)) iostat = io
-
-end function fn_search
+end subroutine fn_grow
 
 !===============================================================================
 
-! TODO: ternary tree insert/search fns for vars and fns could potentially be a
+module function fn_find(dict, key) result(slot)
+
+	! Returns the table slot for `key`, or 0 if not present.  The slot is
+	! only valid until the next insert() call: a resize() (triggered by
+	! insert() growing the table) rehashes everything, invalidating
+	! previously-returned slots and pointers from get().  Every current
+	! caller reads get()/id_at() immediately after find(), with no
+	! intervening insert(), so this is safe
+
+	class(fns_t), intent(in) :: dict
+	character(len = *), intent(in) :: key
+
+	integer :: slot
+
+	!********
+
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	slot = 0
+
+	if (dict%capacity <= 0) return
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot => key not present
+			return
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			slot = idx
+			return
+		end if
+	end do
+
+end function fn_find
+
+!===============================================================================
+
+module function fn_get(dict, slot) result(val)
+
+	class(fns_t), intent(in), target :: dict
+	integer, intent(in) :: slot
+
+	type(fn_t), pointer :: val
+
+	val => dict%table(slot)%val
+
+end function fn_get
+
+!===============================================================================
+
+module function fn_id_at(dict, slot) result(id_index)
+
+	class(fns_t), intent(in) :: dict
+	integer, intent(in) :: slot
+
+	integer :: id_index
+
+	id_index = dict%table(slot)%id_index
+
+end function fn_id_at
+
+!===============================================================================
+
+! TODO: ternary tree insert/search fns for vars could potentially be a
 ! separate translation unit
 
 module subroutine fn_insert(dict, key, val, id_index, iostat, overwrite)
@@ -59,7 +146,8 @@ module subroutine fn_insert(dict, key, val, id_index, iostat, overwrite)
 
 	!********
 
-	integer :: i, io
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx, io
 	logical :: overwritel
 
 	!print *, 'inserting ', quote(key)
@@ -71,8 +159,42 @@ module subroutine fn_insert(dict, key, val, id_index, iostat, overwrite)
 	overwritel = .true.
 	if (present(overwrite)) overwritel = overwrite
 
-	i = dict%scope
-	call fn_ternary_insert(dict%dict%root, key, val, id_index, io, overwritel)
+	io = exit_success
+
+	if (dict%capacity <= 0 .or. &
+			real(dict%count) / real(dict%capacity) >= dict%load_factor_threshold) then
+		call fn_grow(dict)
+	end if
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot - insert new entry.  fn_t has a defined
+			! assignment(=) (fn_copy), which -- unlike intrinsic
+			! assignment -- does not auto-allocate an unallocated allocatable
+			! target, so val must be explicitly allocated first
+			dict%table(idx)%key = key
+			if (.not. allocated(dict%table(idx)%val)) allocate(dict%table(idx)%val)
+			dict%table(idx)%val = val
+			dict%table(idx)%id_index = id_index
+			dict%count = dict%count + 1
+			exit
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			! Key already inserted
+			if (.not. overwritel) then
+				io = exit_failure
+				exit
+			end if
+			if (.not. allocated(dict%table(idx)%val)) allocate(dict%table(idx)%val)
+			dict%table(idx)%val = val
+			dict%table(idx)%id_index = id_index
+			exit
+		end if
+	end do
 
 	if (present(iostat)) iostat = io
 
@@ -535,135 +657,6 @@ end subroutine ternary_insert
 
 !===============================================================================
 
-recursive module function fn_ternary_search(node, key, id_index, iostat) result(val)
-
-	type(fn_ternary_tree_node_t), intent(in), allocatable, target :: node
-	character(len = *), intent(in) :: key
-
-	integer, intent(out) :: id_index
-	integer, intent(out) :: iostat
-	type(fn_t), pointer :: val
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	!print *, 'searching key ', quote(key)
-
-	iostat = exit_success
-
-	if (.not. allocated(node)) then
-		! Search key not found
-		iostat = exit_failure
-		val => null()
-		return
-	end if
-
-	! :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (k < node%split_char) then
-		val => fn_ternary_search(node%left , key, id_index, iostat)
-		return
-	else if (k > node%split_char) then
-		val => fn_ternary_search(node%right, key, id_index, iostat)
-		return
-	else if (len(ey) > 0) then
-		val => fn_ternary_search(node%mid  , ey, id_index, iostat)
-		return
-	end if
-
-	!print *, 'setting val'
-
-	if (.not. allocated(node%val)) then
-		iostat = exit_failure
-		val => null()
-		return
-	end if
-
-	val      => node%val
-	id_index = node%id_index
-
-	!print *, 'done fn_ternary_search'
-	!print *, ''
-
-end function fn_ternary_search
-
-!===============================================================================
-
-recursive module subroutine fn_ternary_insert(node, key, val, id_index, iostat, overwrite)
-
-	type(fn_ternary_tree_node_t), intent(inout), allocatable :: node
-	character(len = *), intent(in) :: key
-	type(fn_t), intent(in) :: val
-	integer, intent(in) :: id_index
-
-	integer, intent(out) :: iostat
-	logical, intent(in) :: overwrite
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	iostat = exit_success
-
-	!print *, 'inserting key ', quote(key)
-
-	! key == k//ey.  Get it? :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (.not. allocated(node)) then
-		!print *, 'allocate'
-		allocate(node)
-		node%split_char = k
-	else if (k < node%split_char) then
-		!print *, 'left'
-		call fn_ternary_insert(node%left , key, val, id_index, iostat, overwrite)
-		return
-	else if (k > node%split_char) then
-		!print *, 'right'
-		call fn_ternary_insert(node%right, key, val, id_index, iostat, overwrite)
-		return
-	end if
-
-	!print *, 'mid'
-
-	if (len(ey) /= 0) then
-		call fn_ternary_insert(node%mid  , ey, val, id_index, iostat, overwrite)
-		return
-	end if
-
-	! node%val doesn't really need to be declared as allocatable (it's
-	! a scalar anyway), but it's just a convenient way to check if
-	! a duplicate key has already been inserted or not.  We could add
-	! a separate logical member to node for this instead if needed
-
-	! This is not necessarily a failure unless we don't want to overwrite.  In
-	! the evaluator, we will insert values for vars which have already been
-	! declared
-	if (allocated(node%val) .and. .not. overwrite) then
-		!print *, 'key already inserted'
-		iostat = exit_failure
-		return
-	end if
-
-	!if (.not. allocated(node%val)) allocate(node%val)
-	if (allocated(node%val)) deallocate(node%val)
-	allocate(node%val)
-
-	node%val      = val
-	node%id_index = id_index
-
-	!print *, "inserted index ", id_index
-	!print *, 'done inserting'
-	!print *, ''
-
-end subroutine fn_ternary_insert
-
 !===============================================================================
 
 subroutine struct_grow(dict)
@@ -917,55 +910,6 @@ end subroutine ternary_closest
 
 !===============================================================================
 
-recursive module subroutine fn_ternary_closest(node, prefix, target_low, &
-		target_unqual_low, min_dist, min_qdist, closest)
-
-	! Like ternary_closest but for fn_ternary_tree_node_t.
-
-	type(fn_ternary_tree_node_t), intent(in), allocatable :: node
-	character(len = *), intent(in) :: prefix, target_low, target_unqual_low
-	integer, intent(inout) :: min_dist, min_qdist
-	character(len = :), allocatable, intent(inout) :: closest
-
-	!********
-
-	character(len = :), allocatable :: key, key_low, key_unqual, display
-	integer :: dist, qdist
-
-	if (.not. allocated(node)) return
-
-	key = prefix//node%split_char
-
-	if (allocated(node%val)) then
-		key_low = to_lower(key)
-		if (key_low /= target_low) then
-			! De-mangle internal overload keys (e.g. "0tan_f32" -> "tan") so we
-			! never surface a "0"-prefixed name in a suggestion.
-			key_unqual = unqualified_name(key)
-			display    = overload_display_name(key_unqual)
-			dist = levenshtein(target_unqual_low, to_lower(key_unqual))
-			if (display /= key_unqual) &
-				dist = min(dist, levenshtein(target_unqual_low, to_lower(display)))
-			qdist = levenshtein(target_low, key_low)
-			if (dist < min_dist .or. (dist == min_dist .and. qdist < min_qdist)) then
-				min_dist  = dist
-				min_qdist = qdist
-				closest   = overload_display_name(key)
-			end if
-		end if
-	end if
-
-	call fn_ternary_closest(node%left , prefix, target_low, target_unqual_low, &
-		min_dist, min_qdist, closest)
-	call fn_ternary_closest(node%right, prefix, target_low, target_unqual_low, &
-		min_dist, min_qdist, closest)
-	call fn_ternary_closest(node%mid  , key   , target_low, target_unqual_low, &
-		min_dist, min_qdist, closest)
-
-end subroutine fn_ternary_closest
-
-!===============================================================================
-
 module function var_closest(dict, key) result(closest)
 
 	! Return the closest declared variable name to `key` across all current
@@ -1015,8 +959,9 @@ module function fn_closest(dict, key) result(closest)
 
 	!********
 
-	integer :: min_dist, min_qdist, threshold
-	character(len = :), allocatable :: target_low, target_unqual_low
+	integer :: i, min_dist, min_qdist, threshold, dist, qdist
+	character(len = :), allocatable :: target_low, target_unqual_low, &
+		key_, key_low, key_unqual, display
 
 	closest           = ""
 	min_dist          = huge(min_dist)
@@ -1024,8 +969,27 @@ module function fn_closest(dict, key) result(closest)
 	target_low        = to_lower(key)
 	target_unqual_low = to_lower(unqualified_name(key))
 
-	call fn_ternary_closest(dict%dict%root, "", target_low, &
-		target_unqual_low, min_dist, min_qdist, closest)
+	do i = 1, dict%capacity
+		if (.not. allocated(dict%table(i)%key)) cycle
+
+		key_ = dict%table(i)%key
+		key_low = to_lower(key_)
+		if (key_low == target_low) cycle
+
+		! De-mangle internal overload keys (e.g. "0tan_f32" -> "tan") so we
+		! never surface a "0"-prefixed name in a suggestion.
+		key_unqual = unqualified_name(key_)
+		display    = overload_display_name(key_unqual)
+		dist = levenshtein(target_unqual_low, to_lower(key_unqual))
+		if (display /= key_unqual) &
+			dist = min(dist, levenshtein(target_unqual_low, to_lower(display)))
+		qdist = levenshtein(target_low, key_low)
+		if (dist < min_dist .or. (dist == min_dist .and. qdist < min_qdist)) then
+			min_dist  = dist
+			min_qdist = qdist
+			closest   = overload_display_name(key_)
+		end if
+	end do
 
 	threshold = max(2, len(target_unqual_low) / 3)
 	if (min_dist > threshold) closest = ""

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -131,9 +131,6 @@ end function fn_id_at
 
 !===============================================================================
 
-! TODO: ternary tree insert/search fns for vars could potentially be a
-! separate translation unit
-
 module subroutine fn_insert(dict, key, val, id_index, iostat, overwrite)
 
 	class(fns_t) :: dict
@@ -202,19 +199,106 @@ end subroutine fn_insert
 
 !===============================================================================
 
+subroutine var_grow(dict)
+
+	! Double dict%table's capacity (or allocate an initial table) and rehash
+	! all existing entries into it.  Mirrors struct_grow()/fn_grow() below in
+	! this same file, but operates on a single scope's var_dict_t directly:
+	! vars_t keeps one hash table per scope, in dicts(:), rather than a
+	! single table
+	!
+	! This is a submodule-local helper (no "module" prefix, no interface
+	! declaration in types.f90), not part of the vars_t public API
+
+	type(var_dict_t), intent(inout) :: dict
+
+	!********
+
+	type(var_entry_t), allocatable :: old_table(:)
+	integer :: old_capacity, i, new_capacity
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	old_capacity = dict%capacity
+	new_capacity = max(2 * old_capacity, 8)
+
+	if (old_capacity > 0) call move_alloc(dict%table, old_table)
+
+	dict%capacity = new_capacity
+	allocate(dict%table(new_capacity))
+	! dict%count is unchanged -- rehashing doesn't add or remove entries
+
+	do i = 1, old_capacity
+		if (.not. allocated(old_table(i)%key)) cycle
+
+		hash_val = fnv_1a(old_table(i)%key)
+		hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+		do probe = 0, dict%capacity - 1
+			idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+			if (.not. allocated(dict%table(idx)%key)) then
+				call move_alloc(old_table(i)%key, dict%table(idx)%key)
+				call move_alloc(old_table(i)%val, dict%table(idx)%val)
+				dict%table(idx)%id_index = old_table(i)%id_index
+				dict%table(idx)%is_const = old_table(i)%is_const
+				exit
+			end if
+		end do
+	end do
+
+end subroutine var_grow
+
+!===============================================================================
+
+function var_dict_find(dict, key) result(slot)
+
+	! Returns dict%table's slot for `key`, or 0 if not present.  Mirrors
+	! struct_find()/fn_find(), but for a single scope's var_dict_t.
+	! var_search()/var_is_const() call this once per scope, walking from the
+	! innermost scope outward until a slot is found or scope 1 is exhausted
+
+	type(var_dict_t), intent(in) :: dict
+	character(len = *), intent(in) :: key
+
+	integer :: slot
+
+	!********
+
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	slot = 0
+
+	if (dict%capacity <= 0) return
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot => key not present
+			return
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			slot = idx
+			return
+		end if
+	end do
+
+end function var_dict_find
+
+!===============================================================================
+
 module subroutine var_insert(dict, key, val, id_index, iostat, overwrite, is_const)
 
 	! There are a couple reasons for having this wrapper:
 	!
-	!   - dict is not allocatable, while dict%root is.  type-bound
+	!   - dict is not allocatable, while dict%dicts(i)%table is.  type-bound
 	!     methods are not allowed for allocatable types
-	!   - it's an abstraction away from the dict implementation.
-	!     currently I'm using a ternary tree, but the dict could
-	!     alternatively be implemented using another data structure like a trie
-	!     or a radix tree
-	!   - having an allocatable root is helpful both for the ternary
-	!     insert/delete implementation and for moving the dict without
-	!     copying in syntax_parse()
+	!   - it's an abstraction away from the dict implementation: an
+	!     open-addressing hash table (FNV-1a + linear probing), like
+	!     structs_t/fns_t
 
 	class(vars_t) :: dict
 	character(len = *), intent(in) :: key
@@ -227,7 +311,8 @@ module subroutine var_insert(dict, key, val, id_index, iostat, overwrite, is_con
 
 	!********
 
-	integer :: i, io
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx, i, io
 	logical :: overwritel
 
 	!print *, 'inserting ', quote(key)
@@ -237,8 +322,48 @@ module subroutine var_insert(dict, key, val, id_index, iostat, overwrite, is_con
 	overwritel = .true.
 	if (present(overwrite)) overwritel = overwrite
 
-	i = dict%scope
-	call ternary_insert(dict%dicts(i)%root, key, val, id_index, io, overwritel, is_const)
+	i  = dict%scope
+	io = exit_success
+
+	if (dict%dicts(i)%capacity <= 0 .or. &
+			real(dict%dicts(i)%count) / real(dict%dicts(i)%capacity) >= &
+			dict%dicts(i)%load_factor_threshold) then
+		call var_grow(dict%dicts(i))
+	end if
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%dicts(i)%capacity, int64)) + 1)
+
+	do probe = 0, dict%dicts(i)%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%dicts(i)%capacity) + 1
+
+		if (.not. allocated(dict%dicts(i)%table(idx)%key)) then
+			! Empty slot - insert new entry.  value_t has a defined
+			! assignment(=), which -- unlike intrinsic assignment -- does not
+			! auto-allocate an unallocated allocatable target, so val must be
+			! explicitly allocated first
+			dict%dicts(i)%table(idx)%key = key
+			if (.not. allocated(dict%dicts(i)%table(idx)%val)) &
+				allocate(dict%dicts(i)%table(idx)%val)
+			dict%dicts(i)%table(idx)%val      = val
+			dict%dicts(i)%table(idx)%id_index = id_index
+			if (present(is_const)) dict%dicts(i)%table(idx)%is_const = is_const
+			dict%dicts(i)%count = dict%dicts(i)%count + 1
+			exit
+		else if (is_str_eq(dict%dicts(i)%table(idx)%key, key)) then
+			! Key already inserted
+			if (.not. overwritel) then
+				io = exit_failure
+				exit
+			end if
+			if (.not. allocated(dict%dicts(i)%table(idx)%val)) &
+				allocate(dict%dicts(i)%table(idx)%val)
+			dict%dicts(i)%table(idx)%val      = val
+			dict%dicts(i)%table(idx)%id_index = id_index
+			if (present(is_const)) dict%dicts(i)%table(idx)%is_const = is_const
+			exit
+		end if
+	end do
 
 	if (present(iostat)) iostat = io
 
@@ -262,17 +387,27 @@ module subroutine var_search(dict, key, id_index, iostat, val, is_const)
 
 	!********
 
-	integer :: i, io
+	integer :: i, io, slot
+
+	if (present(is_const)) is_const = .false.
 
 	i = dict%scope
-
-	call ternary_search(dict%dicts(i)%root, key, id_index, io, val, is_const)
+	slot = var_dict_find(dict%dicts(i), key)
 
 	! If not found in current scope, search parent scopes too
-	do while (io /= exit_success .and. i > 1)
+	do while (slot == 0 .and. i > 1)
 		i = i - 1
-		call ternary_search(dict%dicts(i)%root, key, id_index, io, val, is_const)
+		slot = var_dict_find(dict%dicts(i), key)
 	end do
+
+	if (slot > 0) then
+		io       = exit_success
+		val      = dict%dicts(i)%table(slot)%val
+		id_index = dict%dicts(i)%table(slot)%id_index
+		if (present(is_const)) is_const = dict%dicts(i)%table(slot)%is_const
+	else
+		io = exit_failure
+	end if
 
 	if (present(iostat)) iostat = io
 
@@ -293,18 +428,20 @@ module function var_is_const(dict, key) result(is_const)
 
 	!********
 
-	integer :: i
-	logical :: found
+	integer :: i, slot
+
+	is_const = .false.
 
 	i = dict%scope
-
-	call ternary_is_const(dict%dicts(i)%root, key, is_const, found)
+	slot = var_dict_find(dict%dicts(i), key)
 
 	! If not found in current scope, search parent scopes too
-	do while (.not. found .and. i > 1)
+	do while (slot == 0 .and. i > 1)
 		i = i - 1
-		call ternary_is_const(dict%dicts(i)%root, key, is_const, found)
+		slot = var_dict_find(dict%dicts(i), key)
 	end do
+
+	if (slot > 0) is_const = dict%dicts(i)%table(slot)%is_const
 
 end function var_is_const
 
@@ -331,9 +468,11 @@ module subroutine push_scope(dict)
 		allocate(dict%dicts( dict%scope_cap ))
 
 		do i = 1, dict%scope
-			! The `root` member is also allocatable.  Moving its pointer is
+			! The `table` member is also allocatable.  Moving its pointer is
 			! inexpensive
-			call move_alloc(tmp(i)%root, dict%dicts(i)%root)
+			call move_alloc(tmp(i)%table, dict%dicts(i)%table)
+			dict%dicts(i)%capacity = tmp(i)%capacity
+			dict%dicts(i)%count    = tmp(i)%count
 		end do
 
 		deallocate(tmp)
@@ -355,15 +494,13 @@ module subroutine pop_scope(dict)
 
 	i = dict%scope
 
-	! It's possible that a scope may not have any local vars, so its dict
+	! It's possible that a scope may not have any local vars, so its table
 	! is not allocated
-	if (allocated(dict%dicts(i)%root)) then
-
-		! Does this automatically deallocate children? (mid, left, right)  May
-		! need recursive deep destructor
-		deallocate(dict%dicts(i)%root)
-
+	if (allocated(dict%dicts(i)%table)) then
+		deallocate(dict%dicts(i)%table)
 	end if
+	dict%dicts(i)%capacity = 0
+	dict%dicts(i)%count    = 0
 
 	dict%scope = dict%scope - 1
 
@@ -473,189 +610,11 @@ end subroutine push_node_move
 
 !===============================================================================
 
-recursive module subroutine ternary_search(node, key, id_index, iostat, val, is_const)
-
-	type(ternary_tree_node_t), intent(in), allocatable :: node
-	character(len = *), intent(in) :: key
-
-	integer, intent(out) :: id_index
-	integer, intent(out) :: iostat
-	type(value_t), intent(out) :: val
-	logical, intent(out), optional :: is_const
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	!print *, 'searching key ', quote(key)
-
-	iostat = exit_success
-	if (present(is_const)) is_const = .false.
-
-	if (.not. allocated(node)) then
-		! Search key not found
-		iostat = exit_failure
-		return
-	end if
-
-	! :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (k < node%split_char) then
-		call ternary_search(node%left , key, id_index, iostat, val, is_const)
-		return
-	else if (k > node%split_char) then
-		call ternary_search(node%right, key, id_index, iostat, val, is_const)
-		return
-	else if (len(ey) > 0) then
-		call ternary_search(node%mid  , ey, id_index, iostat, val, is_const)
-		return
-	end if
-
-	!print *, 'setting val'
-
-	if (.not. allocated(node%val)) then
-		iostat = exit_failure
-		return
-	end if
-
-	val      = node%val
-	id_index = node%id_index
-	if (present(is_const)) is_const = node%is_const
-
-	!print *, 'done ternary_search'
-	!print *, ''
-
-end subroutine ternary_search
-
-!===============================================================================
-
-recursive module subroutine ternary_is_const(node, key, is_const, found)
-
-	! Cheap existence + const-flag check, without copying node%val out like
-	! ternary_search() does.  Mirrors struct_exists()
-
-	type(ternary_tree_node_t), intent(in), allocatable :: node
-	character(len = *), intent(in) :: key
-
-	logical, intent(out) :: is_const, found
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	is_const = .false.
-	found    = .false.
-
-	if (.not. allocated(node)) then
-		! Search key not found
-		return
-	end if
-
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (k < node%split_char) then
-		call ternary_is_const(node%left , key, is_const, found)
-		return
-	else if (k > node%split_char) then
-		call ternary_is_const(node%right, key, is_const, found)
-		return
-	else if (len(ey) > 0) then
-		call ternary_is_const(node%mid  , ey, is_const, found)
-		return
-	end if
-
-	if (.not. allocated(node%val)) return
-
-	found    = .true.
-	is_const = node%is_const
-
-end subroutine ternary_is_const
-
-!===============================================================================
-
-recursive module subroutine ternary_insert(node, key, val, id_index, iostat, overwrite, is_const)
-
-	type(ternary_tree_node_t), intent(inout), allocatable :: node
-	character(len = *), intent(in) :: key
-	type(value_t), intent(in) :: val
-	integer, intent(in) :: id_index
-
-	integer, intent(out) :: iostat
-	logical, intent(in) :: overwrite
-	logical, intent(in), optional :: is_const
-
-	!********
-
-	character :: k
-	character(len = :), allocatable :: ey
-
-	iostat = exit_success
-
-	!print *, 'inserting key ', quote(key)
-	!print *, 'len(key) = ', len(key)
-	!print *, 'iachar = ', iachar(key(1:1))
-
-	! This should be unreachable
-	if (len(key) <= 0) then
-		!print *, 'len <= 0, return early'
-		return
-	end if
-
-	! key == k//ey.  Get it? :)
-	k   = key(1:1)
-	 ey = key(2:)
-
-	if (.not. allocated(node)) then
-		!print *, 'allocate'
-		allocate(node)
-		node%split_char = k
-	else if (k < node%split_char) then
-		!print *, 'left'
-		call ternary_insert(node%left , key, val, id_index, iostat, overwrite, is_const)
-		return
-	else if (k > node%split_char) then
-		!print *, 'right'
-		call ternary_insert(node%right, key, val, id_index, iostat, overwrite, is_const)
-		return
-	end if
-
-	!print *, 'mid'
-
-	if (len(ey) /= 0) then
-		call ternary_insert(node%mid  , ey, val, id_index, iostat, overwrite, is_const)
-		return
-	end if
-
-	! node%val doesn't really need to be declared as allocatable (it's
-	! a scalar anyway), but it's just a convenient way to check if
-	! a duplicate key has already been inserted or not.  We could add
-	! a separate logical member to node for this instead if needed
-
-	! This is not necessarily a failure unless we don't want to overwrite.  In
-	! the evaluator, we will insert values for vars which have already been
-	! declared
-	if (allocated(node%val) .and. .not. overwrite) then
-		!print *, 'key already inserted'
-		iostat = exit_failure
-		return
-	end if
-
-	if (.not. allocated(node%val)) allocate(node%val)
-	node%val      = val
-	node%id_index = id_index
-	if (present(is_const)) node%is_const = is_const
-
-	!print *, 'done inserting'
-	!print *, ''
-
-end subroutine ternary_insert
-
-!===============================================================================
+! ternary_search(), ternary_is_const(), and ternary_insert() were here.
+! var_dict_t is now a flat hash table (var_entry_t table(:) in types.f90)
+! instead of a recursive ternary tree, so they were replaced by
+! var_dict_find() and var_grow() above, with var_search()/var_is_const()/
+! var_insert() reading/writing dict%dicts(i)%table(:) directly
 
 !===============================================================================
 
@@ -860,53 +819,9 @@ end subroutine struct_insert
 
 !===============================================================================
 
-recursive module subroutine ternary_closest(node, prefix, target_low, &
-		target_unqual_low, min_dist, min_qdist, closest)
-
-	! Walk a ternary tree accumulating the key character-by-character and
-	! track the terminal key whose *unqualified* (post "::") form has the
-	! lowest Levenshtein distance from `target_unqual_low`, breaking ties by
-	! the distance of the full qualified key from `target_low` (both already
-	! lower-cased by the caller).
-
-	type(ternary_tree_node_t), intent(in), allocatable :: node
-	character(len = *), intent(in) :: prefix, target_low, target_unqual_low
-	integer, intent(inout) :: min_dist, min_qdist
-	character(len = :), allocatable, intent(inout) :: closest
-
-	!********
-
-	character(len = :), allocatable :: key, key_low, key_unqual
-	integer :: dist, qdist
-
-	if (.not. allocated(node)) return
-
-	key = prefix//node%split_char
-
-	! Terminal node: a value is stored here
-	if (allocated(node%val)) then
-		key_low = to_lower(key)
-		if (key_low /= target_low) then
-			key_unqual = unqualified_name(key)
-			dist  = levenshtein(target_unqual_low, to_lower(key_unqual))
-			qdist = levenshtein(target_low, key_low)
-			if (dist < min_dist .or. (dist == min_dist .and. qdist < min_qdist)) then
-				min_dist  = dist
-				min_qdist = qdist
-				closest   = key
-			end if
-		end if
-	end if
-
-	! Explore all three branches
-	call ternary_closest(node%left , prefix, target_low, target_unqual_low, &
-		min_dist, min_qdist, closest)
-	call ternary_closest(node%right, prefix, target_low, target_unqual_low, &
-		min_dist, min_qdist, closest)
-	call ternary_closest(node%mid  , key   , target_low, target_unqual_low, &
-		min_dist, min_qdist, closest)
-
-end subroutine ternary_closest
+! ternary_closest() was here.  var_dict_t is now a flat hash table, so
+! var_closest() below scans dict%dicts(i)%table(:) directly, mirroring
+! fn_closest()'s scan of fns_t's single table
 
 !===============================================================================
 
@@ -916,7 +831,8 @@ module function var_closest(dict, key) result(closest)
 	! scopes, or "" when no name is close enough (threshold: edit distance <=
 	! max(2, len(unqualified key)/3)).  Candidates are ranked by the
 	! Levenshtein distance of their unqualified (post "::") name, with the
-	! full module-qualified distance as a tie-breaker.
+	! full module-qualified distance as a tie-breaker.  See fn_closest() for
+	! the same ranking over a single flat table.
 
 	class(vars_t), intent(in) :: dict
 	character(len = *), intent(in) :: key
@@ -924,8 +840,9 @@ module function var_closest(dict, key) result(closest)
 
 	!********
 
-	integer :: i, min_dist, min_qdist, threshold
-	character(len = :), allocatable :: target_low, target_unqual_low
+	integer :: i, j, min_dist, min_qdist, threshold, dist, qdist
+	character(len = :), allocatable :: target_low, target_unqual_low, &
+		key_, key_low, key_unqual
 
 	closest           = ""
 	min_dist          = huge(min_dist)
@@ -934,9 +851,22 @@ module function var_closest(dict, key) result(closest)
 	target_unqual_low = to_lower(unqualified_name(key))
 
 	do i = 1, dict%scope
-		if (.not. allocated(dict%dicts(i)%root)) cycle
-		call ternary_closest(dict%dicts(i)%root, "", target_low, &
-			target_unqual_low, min_dist, min_qdist, closest)
+		do j = 1, dict%dicts(i)%capacity
+			if (.not. allocated(dict%dicts(i)%table(j)%key)) cycle
+
+			key_ = dict%dicts(i)%table(j)%key
+			key_low = to_lower(key_)
+			if (key_low == target_low) cycle
+
+			key_unqual = unqualified_name(key_)
+			dist  = levenshtein(target_unqual_low, to_lower(key_unqual))
+			qdist = levenshtein(target_low, key_low)
+			if (dist < min_dist .or. (dist == min_dist .and. qdist < min_qdist)) then
+				min_dist  = dist
+				min_qdist = qdist
+				closest   = key_
+			end if
+		end do
 	end do
 
 	! Only keep the suggestion when it is close enough

--- a/src/types_ops.f90
+++ b/src/types_ops.f90
@@ -170,7 +170,7 @@ module integer function lookup_type(name, structs, cookie) result(type)
 
 	!********
 
-	integer :: io, struct_id
+	integer :: struct_id
 	type(struct_t), pointer :: struct_ptr
 
 	! Immo also has an "any" type.  Should I allow that?
@@ -196,11 +196,11 @@ module integer function lookup_type(name, structs, cookie) result(type)
 
 			if (present(cookie)) then
 				! Cookie is requested, so we need the actual struct_t pointer
-				call structs%search(name, struct_id, io, struct_ptr)
-				!print *, "struct search io = ", io
+				struct_id = structs%find(name)
 
-				if (io == 0) then
+				if (struct_id > 0) then
 					type = struct_type
+					struct_ptr => structs%get(struct_id)
 					cookie = struct_ptr%cookie
 					!print *, "struct num vars = ", struct_ptr%num_vars
 				else


### PR DESCRIPTION
Replace ternary trees with hash maps as the data structure backing parse-time dictionaries
- variables
- functions
- structs

The obvious benefit is a simpler implementation. This PR is a net negative number of lines of code.

Any performance impact should be small as these dictionaries are only built and used at parse-time. At evaluation time, all dictionaries are converted to efficient arrays before and after this PR. 