### PR TITLE
Various ci/cd improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,14 @@
 				"
 			},
 			{
+				"if": "matrix.os == 'macOS-latest'",
+				"name": "Test long macOS",
+				"run":
+				"
+					time ./build/Release/long \n
+				"
+			},
+			{
 				"if": "matrix.os == 'windows-latest'",
 				"name": "Pack Windows",
 				"run":

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,17 +237,13 @@
 				"name": "Pack Windows",
 				"run":
 				"
-					#where gfortran \n
-					dir C:\\mingw64\\bin\\libquad* \n
-					#dir C:\\mingw64\\lib \n
+					# Reuse the already-built, already-tested static fpm \n
+					# release binary from the \"Test fpm windows\" step instead \n
+					# of rebuilding from scratch with cmake.  --prefix places \n
+					# it in a predictable location for packaging \n
+					fpm install --profile release --flag \"-static\" --prefix ./build/ \n
 
-					where api-ms-win-crt-time-l1-1-0.dll
-
-					bash ./build.sh release \n
-					#bash ./build.sh debug \n
-
-					copy .\\build\\Release\\syntran.exe .\\ \n
-					copy C:\\mingw64\\bin\\libwinpthread-1.dll .\\ \n
+					copy .\\build\\bin\\syntran.exe .\\ \n
 				"
 			},
 			{
@@ -299,7 +295,7 @@
 				"uses": "actions/upload-artifact@v7",
 				"if": "matrix.os == 'windows-latest'",
 				"with": {
-					"path": "./syntran.exe\n./libwinpthread-1.dll",
+					"path": "./syntran.exe",
 					"name": "syntran-windows"
 				}
 			},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -510,12 +510,10 @@
 						fpm test test --profile debug   --verbose --flag \"-DSYNTRAN_INTEL -fpp\" \n
 					fi \n
 
-					# fpm can't link -ipo (it archives/links with the default \n
-					# ar/ld, not Intel's xiar/xild -- see commit 355efcea3), so \n
-					# the optimized -Ofast/-xHost/-ipo build goes through cmake \n
-					# instead, which wires up xiar/xild (see CMakeLists.txt). \n
-					# This also builds the core lib once for both the test and \n
-					# long exes, instead of fpm's separate rebuild per target. \n
+					# The optimized -Ofast build goes through cmake instead of \n
+					# fpm (see CMakeLists.txt), which also builds the core lib \n
+					# once for both the test and long exes, instead of fpm's \n
+					# separate rebuild per target. \n
 					SYNTRAN_INTEL=1 bash ./build.sh release \n
 					./build/Release/test \n
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -514,7 +514,21 @@
 					# long exes, instead of fpm's separate rebuild per target. \n
 					SYNTRAN_INTEL=1 bash ./build.sh release \n
 					./build/Release/test \n
-					./build/Release/long \n
+
+					# Long/AOC suite is the CI bottleneck and runs single-threaded \n
+					# per process (syntran's interpreter has no internal \n
+					# parallelism), so fan out N shards across the runner's cores \n
+					# instead of running them serially in one process. \n
+					n=$(nproc) \n
+					pids=() \n
+					for i in $(seq 0 $((n-1))) ; do \n
+						./build/Release/long --shard $i/$n > long.$i.log 2>&1 & \n
+						pids+=($!) \n
+					done \n
+					rc=0 \n
+					for p in \"${pids[@]}\" ; do wait \"$p\" || rc=1 ; done \n
+					cat long.*.log \n
+					exit $rc \n
 				"
 			}
 		]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -506,12 +506,15 @@
 						fpm test test --profile debug   --verbose --flag \"-DSYNTRAN_INTEL -fpp\" \n
 					fi \n
 
-					# Use a profile name other than \"release\" so fpm does not \n
-					# silently append its own default release flags (-O3 \n
-					# -fp-model precise ...) *after* ours, which otherwise \n
-					# clobbers -Ofast/-xHost below (last flag wins) \n
-					fpm test test --verbose --flag \"-DSYNTRAN_INTEL -fpp -Ofast -xHost \" \n
-					fpm test long --verbose --flag \"-DSYNTRAN_INTEL -fpp -Ofast -xHost \" \n
+					# fpm can't link -ipo (it archives/links with the default \n
+					# ar/ld, not Intel's xiar/xild -- see commit 355efcea3), so \n
+					# the optimized -Ofast/-xHost/-ipo build goes through cmake \n
+					# instead, which wires up xiar/xild (see CMakeLists.txt). \n
+					# This also builds the core lib once for both the test and \n
+					# long exes, instead of fpm's separate rebuild per target. \n
+					SYNTRAN_INTEL=1 bash ./build.sh release \n
+					./build/Release/test \n
+					./build/Release/long \n
 				"
 			}
 		]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -517,16 +517,19 @@
 
 					# Long/AOC suite is the CI bottleneck and runs single-threaded \n
 					# per process (syntran's interpreter has no internal \n
-					# parallelism), so fan out N shards across the runner's cores \n
-					# instead of running them serially in one process. \n
+					# parallelism). A static per-process shard split leaves \n
+					# cores idle once their shard's tests finish, so instead \n
+					# use a dynamic work queue: xargs keeps N processes busy, \n
+					# handing each one the next test index as soon as it's \n
+					# free, so slow AOC problems don't bottleneck one shard. \n
 					n=$(nproc) \n
-					pids=() \n
-					for i in $(seq 0 $((n-1))) ; do \n
-						./build/Release/long --shard $i/$n > long.$i.log 2>&1 & \n
-						pids+=($!) \n
-					done \n
-					rc=0 \n
-					for p in \"${pids[@]}\" ; do wait \"$p\" || rc=1 ; done \n
+					count=$(./build/Release/long --count) \n
+					if seq 0 $((count-1)) | xargs -P \"$n\" -I{}
+						sh -c './build/Release/long --test {} > long.{}.log 2>&1' ; then \n
+						rc=0 \n
+					else \n
+						rc=$? \n
+					fi \n
 					cat long.*.log \n
 					exit $rc \n
 				"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,10 @@ endif()
 
 if(DEFINED ENV{SYNTRAN_INTEL})
 	# ifort-specific flags must NOT reach the C compiler (icx doesn't
-	# understand -fpp/-qmkl/etc), so gate them to Fortran only.
+	# understand -fpp/etc), so gate them to Fortran only.
 	add_compile_options(
 		"$<$<COMPILE_LANGUAGE:Fortran>:-W1>"
 		"$<$<COMPILE_LANGUAGE:Fortran>:-qopenmp>"
-		"$<$<COMPILE_LANGUAGE:Fortran>:-qmkl>"
 		"$<$<COMPILE_LANGUAGE:Fortran>:-fPIC>"
 		"$<$<COMPILE_LANGUAGE:Fortran>:-fpp>"
 	)
@@ -107,7 +106,11 @@ message("")
 if(APPLE)
 	add_link_options(-openmp)
 elseif(DEFINED ENV{SYNTRAN_INTEL})
-	add_link_options(-fopenmp -qmkl)
+	# No -qmkl: nothing in this codebase calls into BLAS/LAPACK (grep finds
+	# only a speculative TODO comment), and CI's Intel install doesn't
+	# provide the MKL libraries -- linking it just fails with "cannot find
+	# -lmkl_intel_lp64" et al.
+	add_link_options(-fopenmp)
 	if(CMAKE_BUILD_TYPE STREQUAL "Release")
 		# Drives whole-program IPO at link time (invokes xild internally);
 		# matches the -ipo compile flags added above and the xiar archiver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,21 +221,22 @@ endif()
 
 if(DEFINED ENV{SYNTRAN_INTEL})
 	# -ipo (added to Release flags below) emits LLVM-IR objects instead of
-	# native object code.  The default `ar`/`ranlib` can still archive them
-	# (xiar just shells out to `ar` when it doesn't see IR), but Intel's own
-	# xiar/xild are the supported way to preserve the IR through the archive
-	# so the final link can still do whole-program IPO.  This is also the
-	# reason `-ipo` doesn't work under fpm (see commit 355efcea3): fpm always
-	# links with the default ar/ld.
-	find_program(XIAR_EXECUTABLE xiar)
-	if(XIAR_EXECUTABLE)
-		set(CMAKE_AR "${XIAR_EXECUTABLE}")
-		set(CMAKE_RANLIB "${XIAR_EXECUTABLE}")
-	endif()
+	# native object code.  Archiving those into a STATIC lib needs a symbol
+	# index built by an LTO-aware archiver; xiar (set as CMAKE_AR/RANLIB) is
+	# supposed to handle that, but in practice its gold-plugin bridge fails
+	# on Intel 2025.2's bitcode ("LLVM gold plugin has failed to create LTO
+	# module: Unknown attribute kind"), silently producing an archive with a
+	# broken symbol index -- the final link then can't find symbols that are
+	# genuinely present in it (mass "undefined reference" errors).  An OBJECT
+	# library sidesteps archiving entirely: the final link gets the raw .o
+	# files directly, which need no symbol index at all.  (This is also why
+	# `-ipo` doesn't work under fpm at all -- see commit 355efcea3 -- fpm
+	# always archives with the default ar/ld.)
+	add_library(${LIB} OBJECT ${LIB_SRC})
+else()
+	#add_library(${LIB} SHARED ${LIB_SRC}) # dll
+	add_library(${LIB} STATIC ${LIB_SRC}) # static lib
 endif()
-
-#add_library(${LIB} SHARED ${LIB_SRC}) # dll
-add_library(${LIB} STATIC ${LIB_SRC}) # static lib
 
 set(LINK_LIBS "${LIB}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,14 +142,8 @@ set(SRC_DIR "src")
 set(LIB "${PROJECT}")
 set(LIB_SRC
 	${SRC_DIR}/c/isocline_wrap.c
-	# app.f90 is compiled here (once) rather than duplicated into each of
-	# EXE_SRC/TEST_SRC/LONG_SRC below: under Intel, its `module ifport` block
-	# is preprocessed out (real IFPORT is a compiler-provided module there),
-	# but cmake's Fortran dependency scanner isn't preprocessor-aware and
-	# still believes app.f90 "provides" ifport in all three executables --
-	# with per-target Fortran_MODULE_DIRECTORY, that made cmake try to copy a
-	# module file across targets that none of them actually produced.
-	# Compiling it once here removes the cross-target ambiguity.
+	# Compiled here (once), instead of duplicated into each of
+	# EXE_SRC/TEST_SRC/LONG_SRC below, to avoid recompiling it 3x per config.
 	${SRC_DIR}/app.f90
 	${SRC_DIR}/bool.f90
 	${SRC_DIR}/bytecode.f90
@@ -204,6 +198,23 @@ set(LIB_SRC
 	${SRC_DIR}/utils.f90
 	${SRC_DIR}/value.f90
 )
+
+if(NOT DEFINED ENV{SYNTRAN_INTEL})
+	# app.f90's `use ifport` (for isatty()) is Intel-only; under Intel it
+	# resolves to the compiler's own built-in IFPORT module and produces no
+	# local .mod.  ifport_shim.f90 provides an empty local module of the same
+	# name so fpm's (and, without this exclusion, cmake's) source-text-based
+	# Fortran module scanner -- which isn't preprocessor-aware and can't tell
+	# the `use` is inactive here -- has a real producer to satisfy.  Under
+	# Intel, cmake must NOT compile this file at all: if it did, the scanner
+	# would expect a real "ifport.mod" build artifact that Intel never
+	# actually writes (it comes from the compiler's own module path instead),
+	# and cmake's copy-module-between-targets step would fail trying to find
+	# it.  fpm has no per-compiler source exclusion, so it always compiles
+	# this file; ifport_shim.f90's own internal `#if defined(__GFORTRAN__)`
+	# guard keeps that safe under fpm+Intel too.
+	list(APPEND LIB_SRC ${SRC_DIR}/ifport_shim.f90)
+endif()
 
 if(DEFINED ENV{SYNTRAN_INTEL})
 	# -ipo (added to Release flags below) emits LLVM-IR objects instead of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,12 +103,6 @@ elseif(DEFINED ENV{SYNTRAN_INTEL})
 	# provide the MKL libraries -- linking it just fails with "cannot find
 	# -lmkl_intel_lp64" et al.
 	add_link_options(-fopenmp)
-	if(CMAKE_BUILD_TYPE STREQUAL "Release")
-		# Drives whole-program IPO at link time (invokes xild internally);
-		# matches the -ipo compile flags added above and the xiar archiver
-		# set for the static lib.
-		add_link_options(-ipo)
-	endif()
 else()
 	add_link_options(-fopenmp)
 endif()
@@ -212,18 +206,17 @@ if(NOT DEFINED ENV{SYNTRAN_INTEL})
 endif()
 
 if(DEFINED ENV{SYNTRAN_INTEL})
-	# -ipo (added to Release flags below) emits LLVM-IR objects instead of
-	# native object code.  Archiving those into a STATIC lib needs a symbol
-	# index built by an LTO-aware archiver; xiar (set as CMAKE_AR/RANLIB) is
-	# supposed to handle that, but in practice its gold-plugin bridge fails
-	# on Intel 2025.2's bitcode ("LLVM gold plugin has failed to create LTO
-	# module: Unknown attribute kind"), silently producing an archive with a
-	# broken symbol index -- the final link then can't find symbols that are
-	# genuinely present in it (mass "undefined reference" errors).  An OBJECT
-	# library sidesteps archiving entirely: the final link gets the raw .o
-	# files directly, which need no symbol index at all.  (This is also why
-	# `-ipo` doesn't work under fpm at all -- see commit 355efcea3 -- fpm
-	# always archives with the default ar/ld.)
+	# This build previously used -ipo, which emits LLVM-IR objects instead of
+	# native object code; archiving those into a STATIC lib needs a symbol
+	# index built by an LTO-aware archiver, and Intel's xiar was found to
+	# silently produce a broken one, causing mass "undefined reference"
+	# errors at final link.  An OBJECT library sidesteps archiving entirely:
+	# the final link gets the raw .o files directly, which need no symbol
+	# index at all.  -ipo has since been dropped (it didn't help), so a plain
+	# STATIC lib would likely work again too, but OBJECT is kept here since it
+	# already builds cleanly and there's no need to re-validate the Intel
+	# link path.  (Note fpm can't do any of this anyway -- see commit
+	# 355efcea3 -- it always archives with the default ar/ld.)
 	add_library(${LIB} OBJECT ${LIB_SRC})
 else()
 	#add_library(${LIB} SHARED ${LIB_SRC}) # dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,14 @@ cmake_minimum_required(VERSION 3.13)
 # platforms
 if(DEFINED ENV{SYNTRAN_INTEL})
 
-	set(CMAKE_Fortran_COMPILER "ifort")
+	# Honor whatever Intel compiler the caller has already selected (e.g. via
+	# setup-fortran in CI, which exports FC=ifx or FC=ifort), falling back to
+	# ifx if unset.
+	if(DEFINED ENV{FC})
+		set(CMAKE_Fortran_COMPILER "$ENV{FC}")
+	else()
+		set(CMAKE_Fortran_COMPILER "ifx")
+	endif()
 
 #elseif(NOT APPLE)
 elseif(NOT DEFINED CMAKE_Fortran_COMPILER)
@@ -75,7 +82,22 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	)
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
 	message("Release")
-	add_compile_options(-O3)
+	if(DEFINED ENV{SYNTRAN_INTEL})
+		# Match the -Ofast/-xHost already used for the Intel fpm CI build, plus
+		# -ipo for interprocedural (whole-program) optimization -- fpm can't do
+		# -ipo since it links with the default ar/ld, so this Intel-optimized
+		# path is only available via cmake.  Gate to Fortran only: icx (the C
+		# driver used for isocline_wrap.c) doesn't need these and doesn't
+		# necessarily accept them.
+		add_compile_options(
+			"$<$<COMPILE_LANGUAGE:Fortran>:-Ofast>"
+			"$<$<COMPILE_LANGUAGE:Fortran>:-xHost>"
+			"$<$<COMPILE_LANGUAGE:Fortran>:-ipo>"
+		)
+		add_compile_options("$<$<COMPILE_LANGUAGE:C>:-O2>")
+	else()
+		add_compile_options(-O3)
+	endif()
 else()
 	message("Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif()
@@ -86,6 +108,12 @@ if(APPLE)
 	add_link_options(-openmp)
 elseif(DEFINED ENV{SYNTRAN_INTEL})
 	add_link_options(-fopenmp -qmkl)
+	if(CMAKE_BUILD_TYPE STREQUAL "Release")
+		# Drives whole-program IPO at link time (invokes xild internally);
+		# matches the -ipo compile flags added above and the xiar archiver
+		# set for the static lib.
+		add_link_options(-ipo)
+	endif()
 else()
 	add_link_options(-fopenmp)
 endif()
@@ -167,6 +195,21 @@ set(LIB_SRC
 	${SRC_DIR}/utils.f90
 	${SRC_DIR}/value.f90
 )
+
+if(DEFINED ENV{SYNTRAN_INTEL})
+	# -ipo (added to Release flags below) emits LLVM-IR objects instead of
+	# native object code.  The default `ar`/`ranlib` can still archive them
+	# (xiar just shells out to `ar` when it doesn't see IR), but Intel's own
+	# xiar/xild are the supported way to preserve the IR through the archive
+	# so the final link can still do whole-program IPO.  This is also the
+	# reason `-ipo` doesn't work under fpm (see commit 355efcea3): fpm always
+	# links with the default ar/ld.
+	find_program(XIAR_EXECUTABLE xiar)
+	if(XIAR_EXECUTABLE)
+		set(CMAKE_AR "${XIAR_EXECUTABLE}")
+		set(CMAKE_RANLIB "${XIAR_EXECUTABLE}")
+	endif()
+endif()
 
 #add_library(${LIB} SHARED ${LIB_SRC}) # dll
 add_library(${LIB} STATIC ${LIB_SRC}) # static lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,16 +82,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
 	message("Release")
 	if(DEFINED ENV{SYNTRAN_INTEL})
-		# Match the -Ofast/-xHost already used for the Intel fpm CI build, plus
-		# -ipo for interprocedural (whole-program) optimization -- fpm can't do
-		# -ipo since it links with the default ar/ld, so this Intel-optimized
-		# path is only available via cmake.  Gate to Fortran only: icx (the C
-		# driver used for isocline_wrap.c) doesn't need these and doesn't
-		# necessarily accept them.
 		add_compile_options(
 			"$<$<COMPILE_LANGUAGE:Fortran>:-Ofast>"
-			"$<$<COMPILE_LANGUAGE:Fortran>:-xHost>"
-			"$<$<COMPILE_LANGUAGE:Fortran>:-ipo>"
 		)
 		add_compile_options("$<$<COMPILE_LANGUAGE:C>:-O2>")
 	else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,15 @@ set(SRC_DIR "src")
 set(LIB "${PROJECT}")
 set(LIB_SRC
 	${SRC_DIR}/c/isocline_wrap.c
+	# app.f90 is compiled here (once) rather than duplicated into each of
+	# EXE_SRC/TEST_SRC/LONG_SRC below: under Intel, its `module ifport` block
+	# is preprocessed out (real IFPORT is a compiler-provided module there),
+	# but cmake's Fortran dependency scanner isn't preprocessor-aware and
+	# still believes app.f90 "provides" ifport in all three executables --
+	# with per-target Fortran_MODULE_DIRECTORY, that made cmake try to copy a
+	# module file across targets that none of them actually produced.
+	# Compiling it once here removes the cross-target ambiguity.
+	${SRC_DIR}/app.f90
 	${SRC_DIR}/bool.f90
 	${SRC_DIR}/bytecode.f90
 	${SRC_DIR}/compiler.F90
@@ -222,7 +231,6 @@ set(LINK_LIBS "${LIB}")
 set(EXE "${PROJECT}")
 set(EXE_BIN "${EXE}-bin")
 set(EXE_SRC
-	${SRC_DIR}/app.f90
 	${SRC_DIR}/main.f90
 )
 
@@ -251,7 +259,6 @@ set_target_properties("${EXE_BIN}" PROPERTIES OUTPUT_NAME "${EXE}")
 # Unit test exe
 set(TEST_EXE "test")
 set(TEST_SRC
-	${SRC_DIR}/app.f90
 	${SRC_DIR}/tests/core.f90
 	${SRC_DIR}/tests/test.f90
 )
@@ -273,7 +280,6 @@ target_compile_options(${TEST_EXE} PRIVATE "-Wno-integer-division")
 # Long test exe
 set(LONG_EXE "long")
 set(LONG_SRC
-	${SRC_DIR}/app.f90
 	${SRC_DIR}/tests/core.f90
 	${SRC_DIR}/tests/long.f90
 )

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,9 @@ echo "machine = ${machine}"
 generator=""
 if [[ "$machine" == "MinGw" ]]; then
 	generator=(-G 'MSYS Makefiles')
-	export FC=gfortran
+	if [[ -z "${SYNTRAN_INTEL:-}" ]]; then
+		export FC=gfortran
+	fi
 	echo "FC = $FC"
 fi
 
@@ -42,7 +44,13 @@ if [[ "$machine" == "Linux" ]]; then
 	## ninja works, similar performance as gnu make
 	#generator=(-G 'Ninja')
 
-	export FC=$(which gfortran-14)
+	if [[ -z "${SYNTRAN_INTEL:-}" ]]; then
+		export FC=$(which gfortran-14)
+	elif [[ -z "${FC:-}" ]]; then
+		# Caller wants Intel but hasn't already exported FC (e.g. via
+		# setup-fortran in CI) -- default to ifx.
+		export FC=ifx
+	fi
 	echo "FC = $FC"
 fi
 

--- a/src/app.f90
+++ b/src/app.f90
@@ -1,16 +1,6 @@
 
 !===============================================================================
 
-#if defined(__GFORTRAN__)
-module ifport
-	! Unfortunately this is the only way i can get fpm to not complain about
-	! ifport with gfortran
-	!
-	! TODO: try using "external-modules" in fpm.toml, I think this is what it's
-	! for
-end module ifport
-#endif
-
 module syntran__app_m
 
 	use syntran

--- a/src/core.f90
+++ b/src/core.f90
@@ -34,16 +34,6 @@ module syntran__core_m
 	!  - cleanup misc files from top level of repo folder
 	!    * keep 1 or 2 Dockerfiles, move others
 	!    * move most *.sh scripts
-	!  - speedup intel aoc tests since it's the ci/cd bottleneck
-	!    * unrelated, windows pack ci stage seems to rebuild when maybe it
-	!      should re-use a cached build from one of the tests
-	!    * unrelated, long tests do not run on mac ci but they pass locally
-	!    * intel is around 14 minutes compared to 6 for gfortran
-	!    * would add -ipo/-Qipo for interprocedural optimization between files,
-	!      but fpm fails at linking because it defaults to ar/ld but it needs
-	!      intel's own xiar/xild linkers. tried this in commit 355efcea3
-	!    * should be able to get full build/link pipeline working in cmake
-	!      instead of fpm with whatever flags and linkers we want
 	!  - switch/match/case. needs to work with strings. would be nice to work
 	!    with arrays. basic switch/case is fine but also consider "pattern
 	!    matching" or whatever rust has
@@ -112,8 +102,7 @@ module syntran__core_m
 	!    threads within one syntran exe, maybe add cmd args to specify which
 	!    sets of tests to run, then have a bash script spawning independent
 	!    syntran test runners in parallel as separate exe's
-	!    * not really a need for this currently with bytecode and other
-	!      optimizations. ci/cd takes ~14 minutes
+	!    * done
 	!  - migrate ci from ubuntu 24 to 26. rocky should stay on version 9 for the
 	!    time-being for glibc compatibility:  https://github.com/JeffIrwin/syntran/issues/19
 	!    * updated to ubuntu 24.04 on 2026-06-06. 26 is not available yet

--- a/src/core.f90
+++ b/src/core.f90
@@ -31,6 +31,9 @@ module syntran__core_m
 		syntran_patch =  0
 
 	! TODO:
+	!  - cleanup misc files from top level of repo folder
+	!    * keep 1 or 2 Dockerfiles, move others
+	!    * move most *.sh scripts
 	!  - speedup intel aoc tests since it's the ci/cd bottleneck
 	!    * unrelated, windows pack ci stage seems to rebuild when maybe it
 	!      should re-use a cached build from one of the tests

--- a/src/ifport_shim.f90
+++ b/src/ifport_shim.f90
@@ -1,0 +1,16 @@
+
+!===============================================================================
+
+#if defined(__GFORTRAN__)
+module ifport
+	! Unfortunately this is the only way i can get fpm to not complain about
+	! ifport with gfortran (it auto-discovers and compiles every *.f90 file
+	! regardless of --compiler, so this guard is still needed even though
+	! cmake excludes this whole file for Intel builds -- see CMakeLists.txt)
+	!
+	! TODO: try using "external-modules" in fpm.toml, I think this is what it's
+	! for
+end module ifport
+#endif
+
+!===============================================================================

--- a/src/tests/long.f90
+++ b/src/tests/long.f90
@@ -5,15 +5,24 @@ module long_m
 
 	implicit none
 
-	! Shard selector for splitting the long/AOC suite across parallel
-	! processes in CI (see `program long` below for `--shard I/N` parsing).
-	! Defaults run everything in a single process, same as before sharding
-	! was added.
-	integer :: g_shard_i = 0, g_shard_n = 1
+	! Single-test selector for running one long/AOC test at a time from CI
+	! (see `program long` below for `--test I` / `--count` parsing).  -1 (the
+	! default) means run every test in this process, same as before this
+	! selection mode existed
+	integer :: g_target = -1
+
+	! Counting mode: walk every test's index without running it, so `--count`
+	! can report how many tests exist without paying to run them
+	logical :: g_dry_run = .false.
+
+	! Suppress section banners and the final summary.  Used by --count and
+	! --test so a CI work queue running many single-test processes in
+	! parallel doesn't spam per-process banners into the shared log
+	logical :: g_quiet = .false.
 
 	! Global test counter, advanced for every candidate test regardless of
-	! whether this shard runs it, so indices stay stable across shards run in
-	! different processes
+	! whether it's the one selected by g_target, so indices stay stable
+	! across single-test invocations run in different processes
 	integer :: g_itest = 0
 
 contains
@@ -22,10 +31,12 @@ contains
 
 subroutine chk(path, expected, npass, nfail)
 
-	! Run one long/AOC test if it belongs to this shard (round-robin by
-	! global test index) and tally pass/fail.  Path is relative to the repo
-	! root; chdir_ = .true. lets the syntran program's relative input.txt
-	! reads resolve inside its own day directory
+	! Run one long/AOC test if it's selected (either g_target is unset and
+	! every test runs, or this is the g_target'th test) and tally pass/fail.
+	! In g_dry_run mode, just advance the counter without running anything, so
+	! --count can report the total.  Path is relative to the repo root;
+	! chdir_ = .true. lets the syntran program's relative input.txt reads
+	! resolve inside its own day directory
 
 	implicit none
 
@@ -37,7 +48,8 @@ subroutine chk(path, expected, npass, nfail)
 	logical :: ok
 
 	g_itest = g_itest + 1
-	if (mod(g_itest - 1, g_shard_n) /= g_shard_i) return
+	if (g_dry_run) return
+	if (g_target >= 0 .and. g_itest - 1 /= g_target) return
 
 	ok = interpret_file(path, quiet = .true., chdir_ = .true.) == expected
 
@@ -51,48 +63,6 @@ subroutine chk(path, expected, npass, nfail)
 	end if
 
 end subroutine chk
-
-!===============================================================================
-
-subroutine parse_shard(str_, i, n)
-
-	! Parse a "I/N" shard spec like "0/4" into i (0-based shard index) and n
-	! (total shard count).  Exits the process with a nonzero status on any
-	! malformed input
-
-	implicit none
-
-	character(len = *), intent(in) :: str_
-	integer, intent(out) :: i, n
-
-	!********
-
-	integer :: islash, ios
-
-	islash = index(str_, '/')
-	if (islash < 2 .or. islash == len(str_)) then
-		write(*,*) 'Error: malformed --shard arg "'//str_//'", expected "I/N"'
-		call exit(1)
-	end if
-
-	read(str_(1: islash - 1), *, iostat = ios) i
-	if (ios /= 0) then
-		write(*,*) 'Error: malformed --shard index in "'//str_//'"'
-		call exit(1)
-	end if
-
-	read(str_(islash + 1:), *, iostat = ios) n
-	if (ios /= 0) then
-		write(*,*) 'Error: malformed --shard count in "'//str_//'"'
-		call exit(1)
-	end if
-
-	if (n < 1 .or. i < 0 .or. i >= n) then
-		write(*,*) 'Error: --shard I/N must satisfy 0 <= I < N and N >= 1, got "'//str_//'"'
-		call exit(1)
-	end if
-
-end subroutine parse_shard
 
 !===============================================================================
 
@@ -110,7 +80,7 @@ subroutine unit_test_aoc_2017(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2017/'
 
-	write(*,*) 'Unit testing '//label//' ...'
+	if (.not. g_quiet) write(*,*) 'Unit testing '//label//' ...'
 
 	! This one-off is included because it's the first AOC problem where I've used recursion
 	call chk(path//"6/main.syntran" , '6681:2392', npass, nfail)
@@ -134,7 +104,7 @@ subroutine unit_test_aoc_2019(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2019/'
 
-	write(*,*) 'Unit testing '//label//' ...'
+	if (.not. g_quiet) write(*,*) 'Unit testing '//label//' ...'
 
 	call chk(path//"20/main.syntran", '514:6208', npass, nfail)
 
@@ -156,7 +126,7 @@ subroutine unit_test_aoc_2023(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2023/'
 
-	write(*,*) 'Unit testing '//label//' ...'
+	if (.not. g_quiet) write(*,*) 'Unit testing '//label//' ...'
 
 	call chk(path//"01/main.syntran",        '107443',             npass, nfail)
 	call chk(path//"02/main.syntran",        '76485',              npass, nfail)
@@ -203,7 +173,7 @@ subroutine unit_test_aoc_2024(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2024/'
 
-	write(*,*) 'Unit testing '//label//' ...'
+	if (.not. g_quiet) write(*,*) 'Unit testing '//label//' ...'
 
 	call chk(path//"1/main.syntran" , '32625824',        npass, nfail)
 	call chk(path//"2/main.syntran" , '920',              npass, nfail)
@@ -249,7 +219,7 @@ subroutine unit_test_misc(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/'
 
-	write(*,*) 'Unit testing '//label//' ...'
+	if (.not. g_quiet) write(*,*) 'Unit testing '//label//' ...'
 
 	call chk(path//"poople_test.syntran", 'true', npass, nfail)
 
@@ -267,12 +237,11 @@ subroutine unit_tests_long(iostat)
 
 	integer :: npass, nfail
 
-	write(*,*) repeat('=', 60)
-	write(*,*) 'Running long syntran unit tests ...'
-	if (g_shard_n > 1) then
-		write(*, '(a,i0,a,i0,a)') ' Running shard ', g_shard_i, ' of ', g_shard_n, ' ...'
+	if (.not. g_quiet) then
+		write(*,*) repeat('=', 60)
+		write(*,*) 'Running long syntran unit tests ...'
+		write(*,*)
 	end if
-	write(*,*)
 
 	npass = 0
 	nfail = 0
@@ -283,7 +252,7 @@ subroutine unit_tests_long(iostat)
 	call unit_test_aoc_2024(npass, nfail)
 	call unit_test_misc    (npass, nfail)
 
-	call log_test_summary(npass, nfail)
+	if (.not. g_quiet) call log_test_summary(npass, nfail)
 
 	iostat = nfail
 
@@ -297,20 +266,26 @@ end module long_m
 
 program long
 
-	! Run with `fpm test long`, or pass `--shard I/N` (0-based I, e.g.
-	! `--shard 0/4`) to run only every Nth test starting at I, splitting the
-	! suite across N parallel processes for faster CI wall-time.  Omitting
-	! the flag runs the full suite in one process, as before sharding existed.
+	! Run with `fpm test long` to run the whole suite, `--count` to print the
+	! number of tests without running them, or `--test I` (0-based) to run
+	! only test I.  A CI work queue combines these: query `--count` once,
+	! then dispatch one `--test I` process per index across as many parallel
+	! workers as there are cores (e.g. `xargs -P`), which dynamically hands
+	! each worker the next index as soon as it finishes, so slow AOC problems
+	! don't bottleneck a fixed shard the way a static split would.
 
 	use syntran__app_m
 	use long_m
 	implicit none
 
 	integer :: io
-	integer :: nargs, iarg, arglen
+	integer :: nargs, iarg, arglen, ios
+	logical :: count_mode
 	character(len = :), allocatable :: arg
 
 	call set_ansi_colors(.true.)
+
+	count_mode = .false.
 
 	nargs = command_argument_count()
 	iarg = 1
@@ -320,10 +295,16 @@ program long
 		allocate(character(len = arglen) :: arg)
 		call get_command_argument(iarg, arg)
 
-		if (arg == '--shard') then
+		if (arg == '--count') then
+
+			count_mode = .true.
+			g_dry_run  = .true.
+			g_quiet    = .true.
+
+		else if (arg == '--test') then
 
 			if (iarg == nargs) then
-				write(*,*) 'Error: --shard requires an I/N argument'
+				write(*,*) 'Error: --test requires an I argument'
 				call exit(1)
 			end if
 
@@ -333,7 +314,12 @@ program long
 			allocate(character(len = arglen) :: arg)
 			call get_command_argument(iarg, arg)
 
-			call parse_shard(arg, g_shard_i, g_shard_n)
+			read(arg, *, iostat = ios) g_target
+			if (ios /= 0 .or. g_target < 0) then
+				write(*,*) 'Error: malformed --test index "'//arg//'", expected a non-negative integer'
+				call exit(1)
+			end if
+			g_quiet = .true.
 
 		else
 			write(*,*) 'Error: unrecognized arg "'//arg//'"'
@@ -346,6 +332,12 @@ program long
 	end do
 
 	call unit_tests_long(io)
+
+	if (count_mode) then
+		write(*, '(i0)') g_itest
+		call exit(0)
+	end if
+
 	call exit(io)
 
 end program long

--- a/src/tests/long.f90
+++ b/src/tests/long.f90
@@ -5,7 +5,94 @@ module long_m
 
 	implicit none
 
+	! Shard selector for splitting the long/AOC suite across parallel
+	! processes in CI (see `program long` below for `--shard I/N` parsing).
+	! Defaults run everything in a single process, same as before sharding
+	! was added.
+	integer :: g_shard_i = 0, g_shard_n = 1
+
+	! Global test counter, advanced for every candidate test regardless of
+	! whether this shard runs it, so indices stay stable across shards run in
+	! different processes
+	integer :: g_itest = 0
+
 contains
+
+!===============================================================================
+
+subroutine chk(path, expected, npass, nfail)
+
+	! Run one long/AOC test if it belongs to this shard (round-robin by
+	! global test index) and tally pass/fail.  Path is relative to the repo
+	! root; chdir_ = .true. lets the syntran program's relative input.txt
+	! reads resolve inside its own day directory
+
+	implicit none
+
+	character(len = *), intent(in) :: path, expected
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	logical :: ok
+
+	g_itest = g_itest + 1
+	if (mod(g_itest - 1, g_shard_n) /= g_shard_i) return
+
+	ok = interpret_file(path, quiet = .true., chdir_ = .true.) == expected
+
+	if (ok) then
+		npass = npass + 1
+	else
+		call console_color(fg_bright_red)
+		write(*, '(a,i0,a)') '     Error: test ', g_itest, ' failed: '//path
+		call console_color_reset()
+		nfail = nfail + 1
+	end if
+
+end subroutine chk
+
+!===============================================================================
+
+subroutine parse_shard(str_, i, n)
+
+	! Parse a "I/N" shard spec like "0/4" into i (0-based shard index) and n
+	! (total shard count).  Exits the process with a nonzero status on any
+	! malformed input
+
+	implicit none
+
+	character(len = *), intent(in) :: str_
+	integer, intent(out) :: i, n
+
+	!********
+
+	integer :: islash, ios
+
+	islash = index(str_, '/')
+	if (islash < 2 .or. islash == len(str_)) then
+		write(*,*) 'Error: malformed --shard arg "'//str_//'", expected "I/N"'
+		call exit(1)
+	end if
+
+	read(str_(1: islash - 1), *, iostat = ios) i
+	if (ios /= 0) then
+		write(*,*) 'Error: malformed --shard index in "'//str_//'"'
+		call exit(1)
+	end if
+
+	read(str_(islash + 1:), *, iostat = ios) n
+	if (ios /= 0) then
+		write(*,*) 'Error: malformed --shard count in "'//str_//'"'
+		call exit(1)
+	end if
+
+	if (n < 1 .or. i < 0 .or. i >= n) then
+		write(*,*) 'Error: --shard I/N must satisfy 0 <= I < N and N >= 1, got "'//str_//'"'
+		call exit(1)
+	end if
+
+end subroutine parse_shard
 
 !===============================================================================
 
@@ -23,25 +110,11 @@ subroutine unit_test_aoc_2017(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2017/'
 
-	character(len = :), allocatable :: cwd
-
-	logical, parameter :: quiet = .true.
-	logical, allocatable :: tests(:)
-
 	write(*,*) 'Unit testing '//label//' ...'
 
 	! This one-off is included because it's the first AOC problem where I've used recursion
-	tests = &
-		[   &
-			interpret_file(path//"6/main.syntran" , quiet = .true., chdir_ = .true.) == '6681:2392', &
-			interpret_file(path//"12/main.syntran", quiet = .true., chdir_ = .true.) == '141:171', &
-			.false.  & ! so I don't have to bother w/ trailing commas
-		]
-
-	! Trim dummy false element
-	tests = tests(1: size(tests) - 1)
-
-	call unit_test_coda(tests, label, npass, nfail)
+	call chk(path//"6/main.syntran" , '6681:2392', npass, nfail)
+	call chk(path//"12/main.syntran", '141:171',   npass, nfail)
 
 end subroutine unit_test_aoc_2017
 
@@ -61,23 +134,9 @@ subroutine unit_test_aoc_2019(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2019/'
 
-	character(len = :), allocatable :: cwd
-
-	logical, parameter :: quiet = .true.
-	logical, allocatable :: tests(:)
-
 	write(*,*) 'Unit testing '//label//' ...'
 
-	tests = &
-		[   &
-			interpret_file(path//"20/main.syntran", quiet = .true., chdir_ = .true.) == '514:6208', &
-			.false.  & ! so I don't have to bother w/ trailing commas
-		]
-
-	! Trim dummy false element
-	tests = tests(1: size(tests) - 1)
-
-	call unit_test_coda(tests, label, npass, nfail)
+	call chk(path//"20/main.syntran", '514:6208', npass, nfail)
 
 end subroutine unit_test_aoc_2019
 
@@ -97,48 +156,34 @@ subroutine unit_test_aoc_2023(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2023/'
 
-	character(len = :), allocatable :: cwd
-
-	logical, parameter :: quiet = .true.
-	logical, allocatable :: tests(:)
-
 	write(*,*) 'Unit testing '//label//' ...'
 
-	tests = &
-		[   &
-			interpret_file(path//"01/main.syntran", quiet = .true., chdir_ = .true.) == '107443', &
-			interpret_file(path//"02/main.syntran", quiet = .true., chdir_ = .true.) == '76485', &
-			interpret_file(path//"02/main-struct.syntran", quiet = .true., chdir_ = .true.) == '76485', &
-			interpret_file(path//"03/main.syntran", quiet = .true., chdir_ = .true.) == '88145909', &
-			interpret_file(path//"04/main.syntran", quiet = .true., chdir_ = .true.) == '6311320', &
-			interpret_file(path//"05/main.syntran", quiet = .true., chdir_ = .true.) == '261668924', &
-			interpret_file(path//"06/main.syntran", quiet = .true., chdir_ = .true.) == '34675170', &
-			interpret_file(path//"07/main.syntran", quiet = .true., chdir_ = .true.) == '499106636', &
-			interpret_file(path//"08/main.syntran", quiet = .true., chdir_ = .true.) == '13289612829906', &
-			interpret_file(path//"09/main.syntran", quiet = .true., chdir_ = .true.) == '1819127106', &
-			interpret_file(path//"10/main.syntran", quiet = .true., chdir_ = .true.) == '7220', &
-			interpret_file(path//"11/main.syntran", quiet = .true., chdir_ = .true.) == '827019473638', &
-			interpret_file(path//"12/main.syntran", quiet = .true., chdir_ = .true.) == '21', &
-			interpret_file(path//"13/main.syntran", quiet = .true., chdir_ = .true.) == '57259', &
-			interpret_file(path//"14/main.syntran", quiet = .true., chdir_ = .true.) == '191157', &
-			interpret_file(path//"15/main.syntran", quiet = .true., chdir_ = .true.) == '768500', &
-			interpret_file(path//"16/main.syntran", quiet = .true., chdir_ = .true.) == '14553', &
-			interpret_file(path//"17/main.syntran", quiet = .true., chdir_ = .true.) == '196', &
-			interpret_file(path//"18/main.syntran", quiet = .true., chdir_ = .true.) == '111131797001390', &
-			interpret_file(path//"19/main.syntran", quiet = .true., chdir_ = .true.) == '125317462035060', &
-			interpret_file(path//"20/main.syntran", quiet = .true., chdir_ = .true.) == '818723272', &
-			interpret_file(path//"21/main.syntran", quiet = .true., chdir_ = .true.) == '3770', &
-			interpret_file(path//"22/main.syntran", quiet = .true., chdir_ = .true.) == '66981', &
-			interpret_file(path//"23/main.syntran", quiet = .true., chdir_ = .true.) == '248', &
-			interpret_file(path//"24/main.syntran", quiet = .true., chdir_ = .true.) == '25261', &
-			interpret_file(path//"25/main.syntran", quiet = .true., chdir_ = .true.) == '555856', &
-			.false.  & ! so I don't have to bother w/ trailing commas
-		]
-
-	! Trim dummy false element
-	tests = tests(1: size(tests) - 1)
-
-	call unit_test_coda(tests, label, npass, nfail)
+	call chk(path//"01/main.syntran",        '107443',             npass, nfail)
+	call chk(path//"02/main.syntran",        '76485',              npass, nfail)
+	call chk(path//"02/main-struct.syntran", '76485',              npass, nfail)
+	call chk(path//"03/main.syntran",        '88145909',           npass, nfail)
+	call chk(path//"04/main.syntran",        '6311320',            npass, nfail)
+	call chk(path//"05/main.syntran",        '261668924',          npass, nfail)
+	call chk(path//"06/main.syntran",        '34675170',           npass, nfail)
+	call chk(path//"07/main.syntran",        '499106636',          npass, nfail)
+	call chk(path//"08/main.syntran",        '13289612829906',     npass, nfail)
+	call chk(path//"09/main.syntran",        '1819127106',         npass, nfail)
+	call chk(path//"10/main.syntran",        '7220',                npass, nfail)
+	call chk(path//"11/main.syntran",        '827019473638',       npass, nfail)
+	call chk(path//"12/main.syntran",        '21',                  npass, nfail)
+	call chk(path//"13/main.syntran",        '57259',               npass, nfail)
+	call chk(path//"14/main.syntran",        '191157',              npass, nfail)
+	call chk(path//"15/main.syntran",        '768500',              npass, nfail)
+	call chk(path//"16/main.syntran",        '14553',               npass, nfail)
+	call chk(path//"17/main.syntran",        '196',                 npass, nfail)
+	call chk(path//"18/main.syntran",        '111131797001390',    npass, nfail)
+	call chk(path//"19/main.syntran",        '125317462035060',    npass, nfail)
+	call chk(path//"20/main.syntran",        '818723272',           npass, nfail)
+	call chk(path//"21/main.syntran",        '3770',                npass, nfail)
+	call chk(path//"22/main.syntran",        '66981',               npass, nfail)
+	call chk(path//"23/main.syntran",        '248',                 npass, nfail)
+	call chk(path//"24/main.syntran",        '25261',               npass, nfail)
+	call chk(path//"25/main.syntran",        '555856',              npass, nfail)
 
 end subroutine unit_test_aoc_2023
 
@@ -158,47 +203,33 @@ subroutine unit_test_aoc_2024(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/2024/'
 
-	character(len = :), allocatable :: cwd
-
-	logical, parameter :: quiet = .true.
-	logical, allocatable :: tests(:)
-
 	write(*,*) 'Unit testing '//label//' ...'
 
-	tests = &
-		[   &
-			interpret_file(path//"1/main.syntran" , quiet = .true., chdir_ = .true.) == '32625824', &
-			interpret_file(path//"2/main.syntran" , quiet = .true., chdir_ = .true.) == '920', &
-			interpret_file(path//"3/main.syntran" , quiet = .true., chdir_ = .true.) == '266050255', &
-			interpret_file(path//"4/main.syntran" , quiet = .true., chdir_ = .true.) == '4596', &
-			interpret_file(path//"5/main.syntran" , quiet = .true., chdir_ = .true.) == '10050', &
-			interpret_file(path//"6/main.syntran" , quiet = .true., chdir_ = .true.) == '47', & !'7180', &
-			interpret_file(path//"7/main.syntran" , quiet = .true., chdir_ = .true.) == '15136', & !'42686972627683', &
-			interpret_file(path//"8/main.syntran" , quiet = .true., chdir_ = .true.) == '1731', &
-			interpret_file(path//"9/main.syntran" , quiet = .true., chdir_ = .true.) == '12764730558978', &
-			interpret_file(path//"10/main.syntran", quiet = .true., chdir_ = .true.) == '1493', &
-			interpret_file(path//"11/main.syntran", quiet = .true., chdir_ = .true.) == '218279375892027', &
-			interpret_file(path//"12/main.syntran", quiet = .true., chdir_ = .true.) == '2202472', &
-			interpret_file(path//"13/main.syntran", quiet = .true., chdir_ = .true.) == '93866170426408', &
-			interpret_file(path//"14/main.syntran", quiet = .true., chdir_ = .true.) == '232253028', &
-			interpret_file(path//"15/main.syntran", quiet = .true., chdir_ = .true.) == '19113', &
-			interpret_file(path//"16/main.syntran", quiet = .true., chdir_ = .true.) == '7081', &
-			interpret_file(path//"17/main.syntran", quiet = .true., chdir_ = .true.) == '1,6,7,4,3,0,5,0,6:216148338630253', &
-			interpret_file(path//"18/main.syntran", quiet = .true., chdir_ = .true.) == '374:30,12', &
-			interpret_file(path//"19/main.syntran", quiet = .true., chdir_ = .true.) == '22', &
-			interpret_file(path//"20/main.syntran", quiet = .true., chdir_ = .true.) == '1521', &
-			interpret_file(path//"21/main.syntran", quiet = .true., chdir_ = .true.) == '170279148797334', &
-			interpret_file(path//"22/main.syntran", quiet = .true., chdir_ = .true.) == '37327646', &
-			interpret_file(path//"23/main.syntran", quiet = .true., chdir_ = .true.) == '893:cw,dy,ef,iw,ji,jv,ka,ob,qv,ry,ua,wt,xz', &
-			interpret_file(path//"24/main.syntran", quiet = .true., chdir_ = .true.) == '60714423975686:', &
-			interpret_file(path//"25/main.syntran", quiet = .true., chdir_ = .true.) == '3356', &
-			.false.  & ! so I don't have to bother w/ trailing commas
-		]
-
-	! Trim dummy false element
-	tests = tests(1: size(tests) - 1)
-
-	call unit_test_coda(tests, label, npass, nfail)
+	call chk(path//"1/main.syntran" , '32625824',        npass, nfail)
+	call chk(path//"2/main.syntran" , '920',              npass, nfail)
+	call chk(path//"3/main.syntran" , '266050255',        npass, nfail)
+	call chk(path//"4/main.syntran" , '4596',             npass, nfail)
+	call chk(path//"5/main.syntran" , '10050',            npass, nfail)
+	call chk(path//"6/main.syntran" , '47',                npass, nfail) !'7180'
+	call chk(path//"7/main.syntran" , '15136',             npass, nfail) !'42686972627683'
+	call chk(path//"8/main.syntran" , '1731',              npass, nfail)
+	call chk(path//"9/main.syntran" , '12764730558978',    npass, nfail)
+	call chk(path//"10/main.syntran", '1493',              npass, nfail)
+	call chk(path//"11/main.syntran", '218279375892027',   npass, nfail)
+	call chk(path//"12/main.syntran", '2202472',           npass, nfail)
+	call chk(path//"13/main.syntran", '93866170426408',    npass, nfail)
+	call chk(path//"14/main.syntran", '232253028',         npass, nfail)
+	call chk(path//"15/main.syntran", '19113',             npass, nfail)
+	call chk(path//"16/main.syntran", '7081',              npass, nfail)
+	call chk(path//"17/main.syntran", '1,6,7,4,3,0,5,0,6:216148338630253', npass, nfail)
+	call chk(path//"18/main.syntran", '374:30,12',         npass, nfail)
+	call chk(path//"19/main.syntran", '22',                npass, nfail)
+	call chk(path//"20/main.syntran", '1521',              npass, nfail)
+	call chk(path//"21/main.syntran", '170279148797334',   npass, nfail)
+	call chk(path//"22/main.syntran", '37327646',          npass, nfail)
+	call chk(path//"23/main.syntran", '893:cw,dy,ef,iw,ji,jv,ka,ob,qv,ry,ua,wt,xz', npass, nfail)
+	call chk(path//"24/main.syntran", '60714423975686:',   npass, nfail)
+	call chk(path//"25/main.syntran", '3356',              npass, nfail)
 
 end subroutine unit_test_aoc_2024
 
@@ -218,23 +249,9 @@ subroutine unit_test_misc(npass, nfail)
 	character(len = *), parameter :: &
 		path = 'src/tests/long/aoc/'
 
-	character(len = :), allocatable :: cwd
-
-	logical, parameter :: quiet = .true.
-	logical, allocatable :: tests(:)
-
 	write(*,*) 'Unit testing '//label//' ...'
 
-	tests = &
-		[   &
-			interpret_file(path//"poople_test.syntran" , quiet = .true., chdir_ = .true.) == 'true', &
-			.false.  & ! so I don't have to bother w/ trailing commas
-		]
-
-	! Trim dummy false element
-	tests = tests(1: size(tests) - 1)
-
-	call unit_test_coda(tests, label, npass, nfail)
+	call chk(path//"poople_test.syntran", 'true', npass, nfail)
 
 end subroutine unit_test_misc
 
@@ -252,6 +269,9 @@ subroutine unit_tests_long(iostat)
 
 	write(*,*) repeat('=', 60)
 	write(*,*) 'Running long syntran unit tests ...'
+	if (g_shard_n > 1) then
+		write(*, '(a,i0,a,i0,a)') ' Running shard ', g_shard_i, ' of ', g_shard_n, ' ...'
+	end if
 	write(*,*)
 
 	npass = 0
@@ -277,15 +297,54 @@ end module long_m
 
 program long
 
-	! Run with `fpm test long`
+	! Run with `fpm test long`, or pass `--shard I/N` (0-based I, e.g.
+	! `--shard 0/4`) to run only every Nth test starting at I, splitting the
+	! suite across N parallel processes for faster CI wall-time.  Omitting
+	! the flag runs the full suite in one process, as before sharding existed.
 
 	use syntran__app_m
 	use long_m
 	implicit none
 
 	integer :: io
+	integer :: nargs, iarg, arglen
+	character(len = :), allocatable :: arg
 
 	call set_ansi_colors(.true.)
+
+	nargs = command_argument_count()
+	iarg = 1
+	do while (iarg <= nargs)
+
+		call get_command_argument(iarg, length = arglen)
+		allocate(character(len = arglen) :: arg)
+		call get_command_argument(iarg, arg)
+
+		if (arg == '--shard') then
+
+			if (iarg == nargs) then
+				write(*,*) 'Error: --shard requires an I/N argument'
+				call exit(1)
+			end if
+
+			iarg = iarg + 1
+			deallocate(arg)
+			call get_command_argument(iarg, length = arglen)
+			allocate(character(len = arglen) :: arg)
+			call get_command_argument(iarg, arg)
+
+			call parse_shard(arg, g_shard_i, g_shard_n)
+
+		else
+			write(*,*) 'Error: unrecognized arg "'//arg//'"'
+			call exit(1)
+		end if
+
+		deallocate(arg)
+		iarg = iarg + 1
+
+	end do
+
 	call unit_tests_long(io)
 	call exit(io)
 

--- a/src/tests/long.f90
+++ b/src/tests/long.f90
@@ -338,6 +338,13 @@ program long
 		call exit(0)
 	end if
 
+	if (g_target >= 0 .and. g_target >= g_itest) then
+		write(*, '(a,i0,a,i0)') &
+			'Error: --test index ', g_target, ' is out of range, expected 0 to ', &
+			g_itest - 1
+		call exit(1)
+	end if
+
 	call exit(io)
 
 end program long


### PR DESCRIPTION
## Summary

Various CI/CD improvements, mainly targeting the Intel (ifx/ifort) build, which was the CI bottleneck:

- **Parallelize the long/AOC test suite across processes.** `long` gains `--count` (report the number of tests without running them) and `--test I` (run only test `I`, 0-based). CI now queries `--count` once, then dispatches one `--test I` process per index through `xargs -P $(nproc)`, so idle cores keep picking up the next test instead of sitting on a fixed static shard once their slice finishes.
- **Move the optimized Intel release build from fpm to cmake.** fpm always links with the default `ar`/`ld`, so it can't drive Intel's `-ipo`; cmake now builds an `-Ofast` Intel release directly (see `CMakeLists.txt`), building the core lib once and reusing it for both the `test` and `long` executables. Also drops `-qmkl` (nothing in this codebase calls into BLAS/LAPACK, and CI's Intel install doesn't ship the MKL libs anyway).
- **Extract the gfortran-only `ifport` shim** out of `app.f90` into its own `src/ifport_shim.f90`, so cmake can exclude it from Intel builds (whose real `ifport` module needs no local stub) while fpm, which has no per-compiler source exclusion, still compiles it safely behind its `__GFORTRAN__` guard.
- **Windows packaging** now reuses the already-built, already-tested static fpm release binary instead of rebuilding via cmake.
- **macOS CI** now runs the long/AOC test suite (previously gfortran-only on Linux and Windows).
- Misc cleanup: dropped a since-ineffective `-ipo` link flag and comments describing `-xHost`/`-ipo`/`xiar`/`xild` machinery that a prior commit on this branch already removed at compile time; added a guard so `long --test I` with an out-of-range `I` fails loudly instead of silently running nothing.

## Test plan

- [x] `fpm test test --profile debug` — 2751/2751 passed
- [x] `bash ./build.sh release && ./build/Release/test` — cmake (gfortran) release build passes
- [x] `./build/Release/long` (full suite, no args) — 55/55 passed
- [x] `./build/Release/long --count` / `--test <last>` / `--test <count>` — reports 55, runs the last test normally, and the out-of-range guard fires correctly
- [x] Intel (ifx/ifort) CI job — not buildable locally, relies on the CI run