### PR TITLE
Feature/enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1524,6 +1524,17 @@ enum Card
 }
 ```
 
+The explicit value may be negative, e.g. `Below = -1`, and auto-increment
+continues from it normally:
+```rust
+enum Temp
+{
+    Below = -1,  // -1
+    Freezing,    //  0
+    Above,       //  1
+}
+```
+
 Each enum is a distinct type: two enums are never interchangeable, even if
 they happen to declare the same variant names.  Comparing or passing a
 mismatched enum type is a compile-time error, just like any other type

--- a/README.md
+++ b/README.md
@@ -1457,6 +1457,90 @@ println(e[0].d.c[0].b.a[0]._);
 // 42
 ```
 
+## Enums
+
+Enums declare a named type with a fixed set of integer-valued variants:
+```rust
+enum Suit
+{
+    Hearts,
+    Diamonds,
+    Clubs,
+    Spades,
+}
+```
+
+Just like struct members, variants are delimited by a comma `,` and the
+trailing comma after the last variant is optional.  There is no semicolon
+after the closing `}`.
+
+Variants are accessed with dot syntax on the enum's type name, not on an
+instance:
+```rust
+let s = Suit.Clubs;
+```
+
+By default, variants are assigned consecutive integer values starting at `0`
+in declaration order (`Hearts` is `0`, `Diamonds` is `1`, etc.).  A variant can
+pin an explicit value with `= <intlit>`; later variants without an explicit
+value continue counting up from there:
+```rust
+enum Card
+{
+    Two,        // 0
+    Three,      // 1
+    Jack = 10,  // 10
+    Queen,      // 11
+    King,       // 12
+}
+```
+
+Each enum is a distinct type: two enums are never interchangeable, even if
+they happen to declare the same variant names.  Comparing or passing a
+mismatched enum type is a compile-time error, just like any other type
+mismatch:
+```rust
+enum Dir{North, South}
+enum Signal{North, South}
+
+let d = Dir.North;
+// d == Signal.North;  // error: mismatched types
+```
+
+Enum values only support equality comparison, `==` and `!=`.  To use a
+variant as an integer -- e.g. for ordering, arithmetic, or array indexing --
+convert it explicitly with `i32()`:
+```rust
+let a = [10, 20, 30, 40];
+println(a[i32(Suit.Clubs)]);
+// 30
+```
+
+Printing an enum value shows its qualified name, `EnumType.Variant`:
+```rust
+println(Suit.Diamonds);
+// Suit.Diamonds
+```
+
+Enums can be used anywhere a type is expected: as function parameters and
+return types, and as struct members:
+```rust
+struct Player
+{
+    name: str,
+    suit: Suit,
+}
+
+fn describe(s: Suit): str
+{
+    return str(s);
+}
+
+let p = Player{name = "Alice", suit = Suit.Spades};
+println(describe(p.suit));
+// Suit.Spades
+```
+
 ## Samples
 
 Many syntran samples are provided in this repository and elsewhere:

--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,35 @@ println(p.x);  // 3
 println(p.y);  // 4
 ```
 
+### Exported enums
+
+Enums defined in a module are exported the same way, and can be accessed
+either unqualified (via a glob import) or qualified with the module name:
+
+```rust
+// suit_mod.syntran
+
+enum Suit
+{
+    Hearts,
+    Diamonds,
+    Clubs,
+    Spades,
+}
+```
+
+```rust
+// unqualified (glob import)
+use suit_mod::*;
+println(Suit.Clubs);  // Suit.Clubs
+```
+
+```rust
+// qualified
+use suit_mod;
+println(suit_mod::Suit.Spades);  // suit_mod::Suit.Spades
+```
+
 ### Valid module names
 
 Module names follow the same rules as identifiers: they may contain letters,
@@ -1516,6 +1545,17 @@ println(a[i32(Suit.Clubs)]);
 // 30
 ```
 
+The reverse cast, from an integer ordinal back to an enum variant, uses the
+enum's type name as a call: `EnumName(ordinal)`.  It's an error if no variant
+has that value -- at parse time (`E96`) for a constant literal argument, or
+at runtime (`R32`) otherwise:
+```rust
+println(Suit(2));
+// Suit.Clubs
+
+// Suit(99);  // error: no variant with value 99 in enum `Suit`
+```
+
 Printing an enum value shows its qualified name, `EnumType.Variant`:
 ```rust
 println(Suit.Diamonds);
@@ -1539,6 +1579,16 @@ fn describe(s: Suit): str
 let p = Player{name = "Alice", suit = Suit.Spades};
 println(describe(p.suit));
 // Suit.Spades
+```
+
+Arrays of enums work like arrays of any other type, including indexing,
+assignment, `[value; n]` uniform arrays, and iterating a literal array with
+`for`:
+```rust
+let hand = [Suit.Hearts, Suit.Clubs, Suit.Spades];
+hand[0] = Suit.Diamonds;
+println(hand);
+// [Suit.Diamonds, Suit.Clubs, Suit.Spades]
 ```
 
 ## Samples

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -587,6 +587,12 @@ Two variants in the same enum share a backing value, and at least one of them go
 
 [Example](../src/tests/test-src/errors/E95-duplicate-enum-value.syntran)
 
+### E96 -- enum-cast-range
+
+A reverse cast `EnumName(ordinal)` was given a constant int literal `ordinal` that doesn't match any of the enum's variant values.  A non-constant ordinal that turns out to be out of range at runtime is R32 instead.
+
+[Example](../src/tests/test-src/errors/E96-enum-cast-range.syntran)
+
 ## Internal errors
 
 ### I1 -- eval-unary-type
@@ -927,6 +933,10 @@ An array slice subscript's step (`a[::s]`) evaluated to 0.
 ### R31 -- close-fail
 
 `close()` failed to close an open file (see the accompanying `iostat`).
+
+### R32 -- enum-cast-range
+
+A reverse cast `EnumName(ordinal)` was given an ordinal (not a constant literal, so not caught at parse time as E96) that doesn't match any of the enum's variant values.
 
 ## Warnings
 

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -563,6 +563,24 @@ A function call that returns void (no return value) was passed as an argument to
 
 [Example](../src/tests/test-src/errors/E91-void-arg.syntran)
 
+### E92 -- redeclare-enum
+
+An enum was declared twice.
+
+[Example](../src/tests/test-src/errors/E92-redeclare-enum.syntran)
+
+### E93 -- redeclare-variant
+
+A variant was declared twice in the same enum.
+
+[Example](../src/tests/test-src/errors/E93-redeclare-variant.syntran)
+
+### E94 -- unknown-variant
+
+A dot expression (`EnumName.Variant`) referenced a variant name that doesn't exist on the enum.  May include a "did you mean" suggestion.
+
+[Example](../src/tests/test-src/errors/E94-unknown-variant.syntran)
+
 ## Internal errors
 
 ### I1 -- eval-unary-type

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -581,6 +581,12 @@ A dot expression (`EnumName.Variant`) referenced a variant name that doesn't exi
 
 [Example](../src/tests/test-src/errors/E94-unknown-variant.syntran)
 
+### E95 -- duplicate-enum-value
+
+Two variants in the same enum share a backing value, and at least one of them got it from auto-increment rather than an explicit `= <intlit>`.  Explicit-explicit aliases (e.g. two variants both written as `= 10`) are allowed; any collision involving an auto-incremented value is always accidental and is a hard error.
+
+[Example](../src/tests/test-src/errors/E95-duplicate-enum-value.syntran)
+
 ## Internal errors
 
 ### I1 -- eval-unary-type

--- a/src/bool.f90
+++ b/src/bool.f90
@@ -120,6 +120,12 @@ subroutine is_eq_value_t(left, right, res, op_text)
 	case        (magic * str_type + str_type)
 		res%sca%bool = is_str_eq(left%str%s, right%str%s)
 
+	case        (magic * enum_type + enum_type)
+		! Cross-enum-type comparisons are already rejected at parse time
+		! (parse_expr.f90's enum_cookie check), so both operands are
+		! guaranteed to be the same enum here -- just compare ordinals
+		res%sca%bool = left%sca%i32 == right%sca%i32
+
 	case        (magic * array_type + i32_type)
 
 		!print *, 'left%type       = ', kind_name(left%type)

--- a/src/bytecode.f90
+++ b/src/bytecode.f90
@@ -320,6 +320,14 @@ module syntran__bytecode_m
 	! Stack after:  [result]
 	integer, parameter :: OP_CALL_PTR = 1240
 
+	! Enum reverse cast, e.g. `Suit(2)`: a = node_pool_idx (enum_cast_expr
+	! node, carrying node%right for the ordinal sub-expr and node%val%struct(:)
+	! with one baked enum value_t per variant to match against). Mirrors
+	! OP_NEW_ARRAY's delegation to eval_array_expr.
+	! Stack before: []
+	! Stack after:  [result]
+	integer, parameter :: OP_ENUM_CAST = 1241
+
 	!**** M6: intrinsic function ids (match order in eval_fn_call_intr / declare_intr_fns)
 
 	! Math

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -236,6 +236,15 @@ recursive subroutine compile_node(prog, cs, node)
 		const_idx = add_const(prog, node%val)
 		call emit(prog, OP_LOAD_CONST, a = const_idx)
 
+	! ---- enum variant access ----------------------------------------------------
+	! An enum variant, e.g. `Dir.North`: like fn_ref_expr, node%val was fully
+	! baked at parse time (parse_enum_access) and carries allocatable
+	! components (enum_name/enum_variant/enum_cookie), so it goes through the
+	! const pool rather than the scalar-immediate literal_expr cases above
+	case (enum_access_expr)
+		const_idx = add_const(prog, node%val)
+		call emit(prog, OP_LOAD_CONST, a = const_idx)
+
 	! ---- variable reads --------------------------------------------------------
 	case (name_expr)
 		if (allocated(node%lsubscripts)) then
@@ -725,6 +734,7 @@ recursive subroutine compile_node(prog, cs, node)
 		do i = 1, size(node%members)
 			if (node%members(i)%kind == fn_declaration    ) cycle
 			if (node%members(i)%kind == struct_declaration) cycle
+			if (node%members(i)%kind == enum_declaration   ) cycle
 			if (.not. first) call emit(prog, OP_POP)
 			first = .false.
 			call compile_node(prog, cs, node%members(i))
@@ -911,6 +921,7 @@ recursive subroutine compile_node(prog, cs, node)
 			do i = 1, size(node%member%members)
 				if (node%member%members(i)%kind == fn_declaration    ) cycle
 				if (node%member%members(i)%kind == struct_declaration) cycle
+				if (node%member%members(i)%kind == enum_declaration   ) cycle
 				call compile_node(prog, cs, node%member%members(i))
 				call emit(prog, OP_POP)
 			end do

--- a/src/compile_ctrl.f90
+++ b/src/compile_ctrl.f90
@@ -868,6 +868,14 @@ recursive subroutine compile_node(prog, cs, node)
 
 		end select
 
+	! ---- enum reverse cast -----------------------------------------------------
+	! `EnumName(ordinal)`: node%right (the ordinal sub-expr) and node%val%struct(:)
+	! (baked variants to match against) are both carried via the node pool, so a
+	! single generic opcode delegates to eval_enum_cast_expr, mirroring OP_NEW_ARRAY.
+	case (enum_cast_expr)
+		idx = add_node(prog, node)
+		call emit(prog, OP_ENUM_CAST, a = idx)
+
 	! ---- struct instance construction -----------------------------------------
 	! M5: Compile each member-initialiser expression in order, then emit
 	! OP_MAKE_STRUCT.  The node is stored in the pool so the VM can recover

--- a/src/consts.f90
+++ b/src/consts.f90
@@ -37,6 +37,7 @@ module syntran__consts_m
 	! Token and syntax node kinds enum.  Is there a better way to do this that
 	! allows re-ordering enums?  Currently it would break kind_name()
 	integer, parameter ::          &
+			enum_cast_expr        = 132, &
 			enum_access_expr      = 131, &
 			enum_type             = 130, &
 			enum_declaration      = 129, &
@@ -461,6 +462,7 @@ function kind_name(kind)
 			"enum_declaration     ", & ! 129
 			"enum_type            ", & ! 130
 			"enum_access_expr     ", & ! 131
+			"enum_cast_expr       ", & ! 132
 			"unknown              "  & ! inf (trailing comma hack)
 		]
 			! FIXME: update kind_tokens array too

--- a/src/consts.f90
+++ b/src/consts.f90
@@ -37,6 +37,10 @@ module syntran__consts_m
 	! Token and syntax node kinds enum.  Is there a better way to do this that
 	! allows re-ordering enums?  Currently it would break kind_name()
 	integer, parameter ::          &
+			enum_access_expr      = 131, &
+			enum_type             = 130, &
+			enum_declaration      = 129, &
+			enum_keyword          = 128, &
 			fn_call_ptr_expr      = 127, &
 			fn_ref_expr           = 126, &
 			fn_type               = 125, &
@@ -453,6 +457,10 @@ function kind_name(kind)
 			"fn_type              ", & ! 125
 			"fn_ref_expr          ", & ! 126
 			"fn_call_ptr_expr     ", & ! 127
+			"enum_keyword         ", & ! 128
+			"enum_declaration     ", & ! 129
+			"enum_type            ", & ! 130
+			"enum_access_expr     ", & ! 131
 			"unknown              "  & ! inf (trailing comma hack)
 		]
 			! FIXME: update kind_tokens array too

--- a/src/core.f90
+++ b/src/core.f90
@@ -31,6 +31,17 @@ module syntran__core_m
 		syntran_patch =  0
 
 	! TODO:
+	!  - maybe cover README codeblocks in ci
+	!    * add markup in markdown (html) comments denoting begin/end of each
+	!      block. could also have asserts of expected results in comments. then
+	!      a ci script could extract blocks, pre-process, and verify results
+	!  - cover utils/run-samples.sh in ci
+	!    * need a blocklist probably to avoid running interactive samples like
+	!      betweenle et al
+	!  - enum improvements:
+	!    * arrays of enums
+	!    * exported enums across modules
+	!    * reverse cast from i32 to enum
 	!  - fn pointer (callback) improvements:
 	!    * A function pointer (`fn(...)`-typed value) cannot be taken to an
 	!      intrinsic function, a struct method, or a user-defined function with
@@ -44,13 +55,9 @@ module syntran__core_m
 	!      is the can of worms opened by callbacks
 	!      + structs of fns work, arrays do not
 	!    * closures and anonymous (lambda) fns?
-	!  - cleanup misc files from top level of repo folder
-	!    * keep 1 or 2 Dockerfiles, move others
-	!    * move most *.sh scripts
 	!  - switch/match/case. needs to work with strings. would be nice to work
 	!    with arrays. basic switch/case is fine but also consider "pattern
 	!    matching" or whatever rust has
-	!  - enums
 	!  - something like python's "if name == main" feature. it could be nice to
 	!    run a module like a program, e.g. to unit test itself, but ignore when
 	!    imported

--- a/src/core.f90
+++ b/src/core.f90
@@ -38,10 +38,6 @@ module syntran__core_m
 	!  - cover utils/run-samples.sh in ci
 	!    * need a blocklist probably to avoid running interactive samples like
 	!      betweenle et al
-	!  - enum improvements:
-	!    * arrays of enums
-	!    * exported enums across modules
-	!    * reverse cast from i32 to enum
 	!  - fn pointer (callback) improvements:
 	!    * A function pointer (`fn(...)`-typed value) cannot be taken to an
 	!      intrinsic function, a struct method, or a user-defined function with

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -110,6 +110,7 @@ module syntran__errors_m
 		EC_REDECLARE_ENUM = "E92", &
 		EC_REDECLARE_VARIANT = "E93", &
 		EC_UNKNOWN_VARIANT = "E94", &
+		EC_DUPLICATE_ENUM_VALUE = "E95", &
 		IC_EVAL_UNARY_TYPE = "I1", &
 		IC_EVAL_BINARY_TYPES = "I2", &
 		IC_EVAL_LEN_ARRAY = "I3", &
@@ -378,6 +379,7 @@ function get_all_error_codes() result(codes)
 	call codes%push(EC_REDECLARE_ENUM)
 	call codes%push(EC_REDECLARE_VARIANT)
 	call codes%push(EC_UNKNOWN_VARIANT)
+	call codes%push(EC_DUPLICATE_ENUM_VALUE)
 	call codes%push(IC_EVAL_UNARY_TYPE)
 	call codes%push(IC_EVAL_BINARY_TYPES)
 	call codes%push(IC_EVAL_LEN_ARRAY)
@@ -925,6 +927,28 @@ function err_redeclare_variant(context, span, variant) result(err)
 		//underline(context, span)//" variant already declared"//color_reset
 
 end function err_redeclare_variant
+
+!===============================================================================
+
+function err_duplicate_enum_value(context, span, variant, other, value) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: variant, other
+	integer, intent(in) :: value
+
+	err = err_pre(EC_DUPLICATE_ENUM_VALUE) &
+		//'variant `'//variant//'` reuses value '//str(value) &
+		//', already assigned to `'//other//'`' &
+		//underline(context, span)//" duplicate enum value" &
+		//color_reset &
+		//line_feed &
+		//fg_bright_green//"help"//color_reset &
+		//": only explicitly-valued variants may share a value; " &
+		//"assign `"//variant//"` an explicit value to alias `"//other//"`"
+
+end function err_duplicate_enum_value
 
 !===============================================================================
 

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -111,6 +111,7 @@ module syntran__errors_m
 		EC_REDECLARE_VARIANT = "E93", &
 		EC_UNKNOWN_VARIANT = "E94", &
 		EC_DUPLICATE_ENUM_VALUE = "E95", &
+		EC_ENUM_CAST_RANGE = "E96", &
 		IC_EVAL_UNARY_TYPE = "I1", &
 		IC_EVAL_BINARY_TYPES = "I2", &
 		IC_EVAL_LEN_ARRAY = "I3", &
@@ -182,6 +183,7 @@ module syntran__errors_m
 		RC_GETENV_UNSET = "R29", &
 		RC_WRITELN_FAIL = "R30", &
 		RC_CLOSE_FAIL   = "R31", &
+		RC_ENUM_CAST_RANGE = "R32", &
 		WC_MISSING_RETURN = "W1"
 
 	! A text span indicates which characters to underline in a faulty line of
@@ -380,6 +382,7 @@ function get_all_error_codes() result(codes)
 	call codes%push(EC_REDECLARE_VARIANT)
 	call codes%push(EC_UNKNOWN_VARIANT)
 	call codes%push(EC_DUPLICATE_ENUM_VALUE)
+	call codes%push(EC_ENUM_CAST_RANGE)
 	call codes%push(IC_EVAL_UNARY_TYPE)
 	call codes%push(IC_EVAL_BINARY_TYPES)
 	call codes%push(IC_EVAL_LEN_ARRAY)
@@ -450,6 +453,7 @@ function get_all_error_codes() result(codes)
 	call codes%push(RC_CLOSE_STANDARD)
 	call codes%push(RC_WRITELN_FAIL)
 	call codes%push(RC_CLOSE_FAIL)
+	call codes%push(RC_ENUM_CAST_RANGE)
 	call codes%push(WC_MISSING_RETURN)
 end function get_all_error_codes
 
@@ -975,6 +979,23 @@ function err_unknown_variant(context, span, variant, enum, suggest) result(err)
 	end if
 
 end function err_unknown_variant
+
+!===============================================================================
+
+function err_enum_cast_range(context, span, enum, value) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: enum
+	integer, intent(in) :: value
+
+	err = err_pre(EC_ENUM_CAST_RANGE) &
+		//'no variant with value '//str(value)//' in enum `'//enum//'`' &
+		//underline(context, span) &
+		//" out-of-range enum cast"//color_reset
+
+end function err_enum_cast_range
 
 !===============================================================================
 

--- a/src/errors.f90
+++ b/src/errors.f90
@@ -107,6 +107,9 @@ module syntran__errors_m
 		EC_FN_PTR_ARRAY = "E89", &
 		EC_FN_PTR_STRUCT_MEMBER = "E90", &
 		EC_VOID_ARG = "E91", &
+		EC_REDECLARE_ENUM = "E92", &
+		EC_REDECLARE_VARIANT = "E93", &
+		EC_UNKNOWN_VARIANT = "E94", &
 		IC_EVAL_UNARY_TYPE = "I1", &
 		IC_EVAL_BINARY_TYPES = "I2", &
 		IC_EVAL_LEN_ARRAY = "I3", &
@@ -372,6 +375,9 @@ function get_all_error_codes() result(codes)
 	call codes%push(EC_FN_PTR_ARRAY)
 	call codes%push(EC_FN_PTR_STRUCT_MEMBER)
 	call codes%push(EC_VOID_ARG)
+	call codes%push(EC_REDECLARE_ENUM)
+	call codes%push(EC_REDECLARE_VARIANT)
+	call codes%push(EC_UNKNOWN_VARIANT)
 	call codes%push(IC_EVAL_UNARY_TYPE)
 	call codes%push(IC_EVAL_BINARY_TYPES)
 	call codes%push(IC_EVAL_LEN_ARRAY)
@@ -891,6 +897,60 @@ function err_redeclare_struct(context, span, struct) result(err)
 		//underline(context, span)//" struct already declared"//color_reset
 
 end function err_redeclare_struct
+
+!===============================================================================
+
+function err_redeclare_enum(context, span, enum) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: enum
+	err = err_pre(EC_REDECLARE_ENUM) &
+		//'enum `'//enum//'` has already been declared' &
+		//underline(context, span)//" enum already declared"//color_reset
+
+end function err_redeclare_enum
+
+!===============================================================================
+
+function err_redeclare_variant(context, span, variant) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: variant
+	err = err_pre(EC_REDECLARE_VARIANT) &
+		//'variant `'//variant//'` has already been declared in this enum' &
+		//underline(context, span)//" variant already declared"//color_reset
+
+end function err_redeclare_variant
+
+!===============================================================================
+
+function err_unknown_variant(context, span, variant, enum, suggest) result(err)
+	type(text_context_t) :: context
+	type(text_span_t), intent(in) :: span
+	character(len = :), allocatable :: err
+
+	character(len = *), intent(in) :: variant, enum
+	character(len = *), intent(in), optional :: suggest
+
+	err = err_pre(EC_UNKNOWN_VARIANT) &
+		//'variant `'//variant//'` does not exist in enum `'//enum//'`' &
+		//underline(context, span) &
+		//" unknown variant"//color_reset
+
+	if (present(suggest)) then
+		if (len(suggest) > 0) then
+			err = err//line_feed &
+				//fg_bright_green//"help"//color_reset &
+				//": did you mean `" &
+				//fg_bright_green//suggest//color_reset//"`?"
+		end if
+	end if
+
+end function err_unknown_variant
 
 !===============================================================================
 

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -346,6 +346,12 @@ module syntran__eval_m
 			type(value_t), intent(out) :: res
 		end subroutine
 
+		recursive module subroutine eval_enum_cast_expr(node, state, res)
+			type(syntax_node_t), intent(in) :: node
+			type(state_t), intent(inout) :: state
+			type(value_t), intent(out) :: res
+		end subroutine
+
 	end interface
 
 !===============================================================================
@@ -444,6 +450,12 @@ recursive subroutine syntax_eval(node, state, res)
 		! fully baked at parse time (parse_enum_access), so there's nothing
 		! left to resolve at runtime
 		res = node%val
+
+	case (enum_cast_expr)
+		! Reverse cast, e.g. `Dir(2)`: node%right is the ordinal expression,
+		! and node%val%struct(:) holds one fully-baked enum value_t per
+		! variant (set at parse time by parse_enum_cast) to match against
+		call eval_enum_cast_expr(node, state, res)
 
 	case (array_expr)
 		call eval_array_expr(node, state, res)

--- a/src/eval.f90
+++ b/src/eval.f90
@@ -439,6 +439,12 @@ recursive subroutine syntax_eval(node, state, res)
 	case (literal_expr)
 		res = node%val  ! this handles ints, bools, etc.
 
+	case (enum_access_expr)
+		! An enum variant, e.g. `Dir.North`: like literal_expr, node%val was
+		! fully baked at parse time (parse_enum_access), so there's nothing
+		! left to resolve at runtime
+		res = node%val
+
 	case (array_expr)
 		call eval_array_expr(node, state, res)
 

--- a/src/eval_array.f90
+++ b/src/eval_array.f90
@@ -70,7 +70,7 @@ recursive module subroutine set_val(node, var, state, val, index_)
 		else
 			i8 = sub_eval(node, var, state)
 		end if
-		if (var%array%type /= struct_type) then
+		if (.not. any(var%array%type == [struct_type, enum_type])) then
 			call set_array_val(var%array, i8, val)
 			return
 		end if
@@ -116,7 +116,7 @@ recursive module subroutine set_val(node, var, state, val, index_)
 		return
 	end if
 
-	if (var%struct(id)%array%type /= struct_type) then
+	if (.not. any(var%struct(id)%array%type == [struct_type, enum_type])) then
 		call set_array_val(var%struct(id)%array, i8, val)
 		return
 	end if
@@ -211,16 +211,21 @@ recursive module subroutine get_val(node, var, state, res, index_)
 			i8 = sub_eval(node, var, state)
 		end if
 
-		if (var%array%type /= struct_type) then
+		if (.not. any(var%array%type == [struct_type, enum_type])) then
 			!print *, "get_array_val 2"
 			call get_array_val(var%array, i8, res)
 			return
 		end if
 
 		res = var%struct(i8+1)
-		res%type = struct_type
-		res%struct_name = var%struct_name
-		if (allocated(var%struct_cookie)) res%struct_cookie = var%struct_cookie
+		if (var%array%type == struct_type) then
+			res%type = struct_type
+			res%struct_name = var%struct_name
+			if (allocated(var%struct_cookie)) res%struct_cookie = var%struct_cookie
+		end if
+		! For enum_type, each stored element is already a fully baked enum
+		! value_t (type/enum_name/enum_variant/enum_cookie all set), so no
+		! extra tagging is needed here
 		return
 
 	end if
@@ -266,7 +271,7 @@ recursive module subroutine get_val(node, var, state, res, index_)
 		return
 	end if
 
-	if (var%struct(id)%array%type /= struct_type) then
+	if (.not. any(var%struct(id)%array%type == [struct_type, enum_type])) then
 		!print *, "get_array_val 3"
 		call get_array_val(var%struct(id)%array, i8, res)
 		return
@@ -342,7 +347,7 @@ module subroutine allocate_array(val, cap)
 	case (str_type)
 		allocate(val%array%str( cap ))
 
-	case (struct_type)
+	case (struct_type, enum_type)
 		allocate(val%struct( cap ))
 
 	case default
@@ -1547,6 +1552,10 @@ module subroutine apply_subscripts_to_val(node, val, state, res)
 			res%type       = struct_type
 			res%struct_name = val%struct_name
 			if (allocated(val%struct_cookie)) res%struct_cookie = val%struct_cookie
+		else if (val%array%type == enum_type) then
+			! Each stored element is already a fully baked enum value_t, so
+			! no extra tagging is needed here (c.f. get_val above)
+			res = val%struct(i8+1)
 		else
 			call get_array_val(val%array, i8, res)
 		end if

--- a/src/eval_control.f90
+++ b/src/eval_control.f90
@@ -1300,6 +1300,9 @@ recursive module subroutine eval_enum_cast_expr(node, state, res)
 
 	ord = arg%to_i32()
 
+	! Linear scan, not an array/hash lookup: variant values are arbitrary i32
+	! (explicit, sparse, negative, or aliased), so no direct-index table
+	! exists in general, and enums are small enough that this is cheap
 	do i = 1, size(node%val%struct)
 		if (node%val%struct(i)%sca%i32 == ord) then
 			res = node%val%struct(i)

--- a/src/eval_control.f90
+++ b/src/eval_control.f90
@@ -1077,6 +1077,20 @@ recursive module subroutine eval_array_expr(node, state, res)
 			res%struct_name = lbound_%struct_name
 			if (allocated(lbound_%struct_cookie)) res%struct_cookie = lbound_%struct_cookie
 
+		case (enum_type)
+
+			! Unlike struct_type, an enum variant has no nested allocatable
+			! members of its own, so a plain value_copy() per element is
+			! enough (no need to deep-copy a struct(:) sub-array)
+			do i8 = 1, res%array%len_
+				call value_copy(res%struct(i8), lbound_)
+			end do
+
+			! Arrays are homogeneous, so every element shares one enum_name
+			! for efficiency
+			res%enum_name = lbound_%enum_name
+			if (allocated(lbound_%enum_cookie)) res%enum_cookie = lbound_%enum_cookie
+
 		case default
 			write(*,*) err_eval_len_array(kind_name(res%array%type))
 			call internal_error()
@@ -1203,7 +1217,7 @@ recursive module subroutine eval_array_expr(node, state, res)
 			if (state%rt_halt) return
 			!print *, 'elem['//str(i)//'] = ', elem%str()
 
-			if (res%array%type == struct_type) then
+			if (any(res%array%type == [struct_type, enum_type])) then
 				res%struct(i) = elem
 
 			else if (elem%type == array_type) then
@@ -1226,7 +1240,7 @@ recursive module subroutine eval_array_expr(node, state, res)
 			call res%array%trim()
 		end if
 
-		if (res%array%type == struct_type) then
+		if (any(res%array%type == [struct_type, enum_type])) then
 			res%array%len_ = size(node%elems)
 		end if
 
@@ -1242,6 +1256,12 @@ recursive module subroutine eval_array_expr(node, state, res)
 		if (allocated(node%val%struct_cookie)) then
 			res%struct_cookie = node%val%struct_cookie
 		end if
+		if (allocated(node%val%enum_name)) then
+			res%enum_name = node%val%enum_name
+		end if
+		if (allocated(node%val%enum_cookie)) then
+			res%enum_cookie = node%val%enum_cookie
+		end if
 
 		!print *, "struct_name = ", res%struct_name
 
@@ -1251,6 +1271,46 @@ recursive module subroutine eval_array_expr(node, state, res)
 	end if
 
 end subroutine eval_array_expr
+
+!===============================================================================
+
+recursive module subroutine eval_enum_cast_expr(node, state, res)
+
+	! Evaluate `EnumName(ordinal)`.  node%val%struct(:) holds one fully-baked
+	! enum value_t per variant (set at parse time by parse_enum_cast()), so
+	! this just evaluates the ordinal expression and scans that baked list
+	! for a match -- no runtime enum registry is needed.  R32 if none matches
+
+	type(syntax_node_t), intent(in) :: node
+
+	type(state_t), intent(inout) :: state
+
+	type(value_t), intent(out) :: res
+
+	!********
+
+	type(value_t) :: arg
+
+	integer(kind = 4) :: ord
+
+	integer :: i
+
+	call syntax_eval(node%right, state, arg)
+	if (state%rt_halt) return
+
+	ord = arg%to_i32()
+
+	do i = 1, size(node%val%struct)
+		if (node%val%struct(i)%sca%i32 == ord) then
+			res = node%val%struct(i)
+			return
+		end if
+	end do
+
+	call rt_throw(state, err_rt(RC_ENUM_CAST_RANGE, &
+		"no variant with value "//str(ord)//" in enum `"//node%val%enum_name//"`"))
+
+end subroutine eval_enum_cast_expr
 
 !===============================================================================
 

--- a/src/eval_control.f90
+++ b/src/eval_control.f90
@@ -724,9 +724,10 @@ module subroutine eval_translation_unit(node, state, res)
 	! members only change the (vars) state or define fns
 	do i = 1, size(node%members)
 
-		! Only eval statements, not fn or struct declarations
+		! Only eval statements, not fn, struct, or enum declarations
 		if (node%members(i)%kind == fn_declaration    ) cycle
 		if (node%members(i)%kind == struct_declaration) cycle
+		if (node%members(i)%kind == enum_declaration   ) cycle
 
 		call syntax_eval(node%members(i), state, res)
 

--- a/src/math.f90
+++ b/src/math.f90
@@ -109,6 +109,9 @@ subroutine assign_value_t(left, right, op_text)
 		case (struct_type)
 			left = right
 
+		case (enum_type)
+			left = right
+
 		case default
 			write(*,*) err_eval_binary_types(op_text)
 			call internal_error()

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -109,6 +109,7 @@ module syntran__parse_m
 				parse_struct_instance, &
 				parse_enum_declaration, &
 				parse_enum_access, &
+				parse_enum_cast, &
 				parse_for_statement, &
 				parse_if_statement, &
 				parse_return_statement, &
@@ -190,10 +191,17 @@ module syntran__parse_m
 			type(syntax_node_t), intent(out) :: decl
 		end subroutine parse_enum_declaration
 
-		module subroutine parse_enum_access(parser, expr)
+		module subroutine parse_enum_access(parser, expr, enum_name)
 			class(parser_t), target :: parser
 			type(syntax_node_t), intent(out) :: expr
+			character(len = *), intent(in), optional :: enum_name
 		end subroutine parse_enum_access
+
+		module subroutine parse_enum_cast(parser, expr, enum_name)
+			class(parser_t), target :: parser
+			type(syntax_node_t), intent(out) :: expr
+			character(len = *), intent(in), optional :: enum_name
+		end subroutine parse_enum_cast
 
 		module subroutine check_call_arg(parser, arg, call_is_ref_i, arg_span, &
 				fn_name, i_0based, param_val, param_name, param_is_ref, param_is_const_ref, &

--- a/src/parse.f90
+++ b/src/parse.f90
@@ -42,9 +42,13 @@ module syntran__parse_m
 		type(string_vector_t) :: fn_names
 		type(string_vector_t) :: var_names    ! track module-level variable names
 		type(string_vector_t) :: struct_names ! track module-level struct names
+		type(string_vector_t) :: enum_names   ! track module-level enum names
 
 		type(structs_t) :: structs
 		integer :: num_structs = 0
+
+		type(enums_t) :: enums
+		integer :: num_enums = 0
 
 		! Set this to (the current) fn's return type.  Check that each return
 		! statement matches while parsing.  This is redundant since the fn
@@ -103,6 +107,8 @@ module syntran__parse_m
 				parse_qualified_expr, &
 				parse_struct_declaration, &
 				parse_struct_instance, &
+				parse_enum_declaration, &
+				parse_enum_access, &
 				parse_for_statement, &
 				parse_if_statement, &
 				parse_return_statement, &
@@ -178,6 +184,16 @@ module syntran__parse_m
 			type(syntax_node_t), intent(out) :: inst
 			character(len = *), intent(in), optional :: struct_name
 		end subroutine parse_struct_instance
+
+		module subroutine parse_enum_declaration(parser, decl)
+			class(parser_t) :: parser
+			type(syntax_node_t), intent(out) :: decl
+		end subroutine parse_enum_declaration
+
+		module subroutine parse_enum_access(parser, expr)
+			class(parser_t), target :: parser
+			type(syntax_node_t), intent(out) :: expr
+		end subroutine parse_enum_access
 
 		module subroutine check_call_arg(parser, arg, call_is_ref_i, arg_span, &
 				fn_name, i_0based, param_val, param_name, param_is_ref, param_is_const_ref, &

--- a/src/parse_array.f90
+++ b/src/parse_array.f90
@@ -33,6 +33,8 @@ recursive module subroutine parse_array_expr(parser, expr)
 
 	integer :: span_beg, span_end, pos0, lb_beg, lb_end, ub_beg, ub_end, rank_, i
 
+	logical :: enum_mismatch
+
 	type(syntax_node_t)  :: lbound_, step, ubound_, len_, elem
 	type(syntax_node_vector_t) :: elems, size_
 	type(syntax_token_t) :: lbracket, rbracket, colon, semicolon, comma, dummy
@@ -135,6 +137,10 @@ recursive module subroutine parse_array_expr(parser, expr)
 		expr%val%type        = array_type
 		if (allocated(lbound_%val%struct_name)) then
 			expr%val%struct_name = lbound_%val%struct_name
+		else if (allocated(lbound_%val%enum_name)) then
+			expr%val%enum_name = lbound_%val%enum_name
+			if (allocated(lbound_%val%enum_cookie)) &
+				expr%val%enum_cookie = lbound_%val%enum_cookie
 		end if
 
 		if (lbound_%val%type == array_type) then
@@ -427,6 +433,21 @@ recursive module subroutine parse_array_expr(parser, expr)
 			span = new_span(span_beg, span_end - span_beg + 1)
 			call parser%diagnostics%push(err_het_array( &
 				parser%context(), span, parser%text(span_beg, span_end)))
+		else if (elem%val%type == enum_type) then
+			! Matching `type == enum_type` isn't enough -- two different
+			! enums (e.g. Suit vs Card) must not be mixed in one array
+			! literal.  Mirrors the cross-enum operand check for binary ops
+			if (allocated(elem%val%enum_cookie) .and. &
+				allocated(lbound_%val%enum_cookie)) then
+				enum_mismatch = elem%val%enum_cookie /= lbound_%val%enum_cookie
+			else
+				enum_mismatch = elem%val%enum_name /= lbound_%val%enum_name
+			end if
+			if (enum_mismatch) then
+				span = new_span(span_beg, span_end - span_beg + 1)
+				call parser%diagnostics%push(err_het_array( &
+					parser%context(), span, parser%text(span_beg, span_end)))
+			end if
 		end if
 
 		if (elem%val%type == array_type) then
@@ -494,6 +515,10 @@ recursive module subroutine parse_array_expr(parser, expr)
 	expr%val%type        = array_type
 	if (allocated(lbound_%val%struct_name)) then
 		expr%val%struct_name = lbound_%val%struct_name
+	else if (allocated(lbound_%val%enum_name)) then
+		expr%val%enum_name = lbound_%val%enum_name
+		if (allocated(lbound_%val%enum_cookie)) &
+			expr%val%enum_cookie = lbound_%val%enum_cookie
 	end if
 
 	expr%val%array%type = lbound_%val%type

--- a/src/parse_control.f90
+++ b/src/parse_control.f90
@@ -144,6 +144,7 @@ module subroutine parse_use_statement(parser, statement)
 	character(len = :), allocatable :: module_name, import_name, module_path
 	character(len = :), allocatable :: mod_filename, mod_text, src_dir, fn_name
 	character(len = :), allocatable :: insert_name, var_name, struct_name
+	character(len = :), allocatable :: enum_name
 	character(len = :), allocatable :: alias_name
 	type(syntax_token_t) :: use_token, mod_identifier, double_colon, &
 		name_identifier, semi, star, dummy, as_identifier, alias_identifier
@@ -154,7 +155,8 @@ module subroutine parse_use_statement(parser, statement)
 	type(fn_t), pointer :: fn
 	type(value_t) :: var_val
 	type(struct_t), pointer :: struct_val
-	integer :: i, io, iostat, mod_unit_, id_index, struct_slot, fn_slot
+	type(enum_t), pointer :: enum_val
+	integer :: i, io, iostat, mod_unit_, id_index, struct_slot, fn_slot, enum_slot
 	logical :: qualified_import, is_const_var
 	character(len = :), allocatable :: qualified_prefix
 
@@ -428,21 +430,25 @@ module subroutine parse_use_statement(parser, statement)
 	! Do not touch mod_parser%num_vars here; it is inherited from parser below.
 	call declare_intr_vars(mod_parser%vars)
 
-	! Share variable, function, AND struct numbering with parent parser. Module
-	! variables, functions, and structs will get indices continuing from parent's
-	! count, avoiding the need for remapping. This is similar to how #include works.
+	! Share variable, function, struct, AND enum numbering with parent parser.
+	! Module variables, functions, structs, and enums will get indices
+	! continuing from parent's count, avoiding the need for remapping. This is
+	! similar to how #include works.
 	mod_parser%num_vars = parser%num_vars
 	mod_parser%num_fns = parser%num_fns
 	mod_parser%num_structs = parser%num_structs
+	mod_parser%num_enums = parser%num_enums
 
 	! Parse the module
 	mod_parser%is_module = .true.
 	call mod_parser%parse_unit(mod_unit)
 
-	! Update parent's variable, function, and struct counts to include module definitions
+	! Update parent's variable, function, struct, and enum counts to include
+	! module definitions
 	parser%num_vars = mod_parser%num_vars
 	parser%num_fns = mod_parser%num_fns
 	parser%num_structs = mod_parser%num_structs
+	parser%num_enums = mod_parser%num_enums
 
 	! Check for parsing errors in the module (only in first pass)
 	if (parser%ipass == 0 .and. mod_parser%diagnostics%len_ > 0) then
@@ -555,6 +561,30 @@ module subroutine parse_use_statement(parser, statement)
 		if (parser%ipass == 0) call parser%struct_names%push(insert_name)
 	end do
 
+	! Copy parsed module enums to current parser.
+	do i = 1, mod_parser%enum_names%len_
+		enum_name = mod_parser%enum_names%v(i)%s
+
+		! Look up the enum in the module parser
+		enum_slot = mod_parser%enums%find(enum_name)
+		if (enum_slot == 0) cycle
+		enum_val => mod_parser%enums%get(enum_slot)
+		id_index  = mod_parser%enums%id_at(enum_slot)
+
+		! Determine insert name (qualified or unqualified)
+		if (qualified_import) then
+			insert_name = qualified_prefix // "::" // enum_name
+		else
+			insert_name = enum_name
+		end if
+
+		! Insert into current parser with the SAME id_index from module parser.
+		! This is critical: since we shared num_enums before parsing, indices
+		! already match - no remapping needed (same pattern as structs).
+		call parser%enums%insert(insert_name, enum_val, id_index, io)
+		if (parser%ipass == 0) call parser%enum_names%push(insert_name)
+	end do
+
 	! Store the module's translation unit for later evaluation. This ensures
 	! that module-level statements (like `let a = [0: 10];`) are evaluated,
 	! not just parsed.
@@ -592,7 +622,7 @@ end subroutine qualify_fn_struct_names
 
 subroutine qualify_value_struct_name(val, prefix)
 
-	! Update struct_name in a value_t to use qualified name
+	! Update struct_name/enum_name in a value_t to use qualified name
 
 	type(value_t), intent(inout) :: val
 	character(len = *), intent(in) :: prefix
@@ -601,12 +631,20 @@ subroutine qualify_value_struct_name(val, prefix)
 		if (allocated(val%struct_name)) then
 			val%struct_name = prefix // "::" // val%struct_name
 		end if
+	else if (val%type == enum_type) then
+		if (allocated(val%enum_name)) then
+			val%enum_name = prefix // "::" // val%enum_name
+		end if
 	else if (val%type == array_type) then
 		! Handle arrays of structs
 		if (allocated(val%array)) then
 			if (val%array%type == struct_type) then
 				if (allocated(val%struct_name)) then
 					val%struct_name = prefix // "::" // val%struct_name
+				end if
+			else if (val%array%type == enum_type) then
+				if (allocated(val%enum_name)) then
+					val%enum_name = prefix // "::" // val%enum_name
 				end if
 			end if
 		end if
@@ -746,6 +784,13 @@ recursive module subroutine parse_for_statement(parser, statement)
 		! Array iterator type could be i32 or i64, and lbound type might not
 		! match ubound type!
 		dummy%type = array%val%array%type
+		if (dummy%type == enum_type) then
+			! Propagate the enum identity so uses of the loop var (e.g. `s ==
+			! Suit.Clubs` inside the body) don't misfire the cross-enum
+			! mismatch check, which requires enum_name/enum_cookie to be set
+			if (allocated(array%val%enum_name)) dummy%enum_name = array%val%enum_name
+			if (allocated(array%val%enum_cookie)) dummy%enum_cookie = array%val%enum_cookie
+		end if
 		if (parser%is_loc) then
 			call parser%locs%insert(identifier%text, dummy, statement%id_index)
 		else

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -215,6 +215,18 @@ recursive module subroutine parse_expr_statement(parser, expr)
 			call parser%match(identifier_token, identifier)
 		end do
 
+		! `mod::EnumName.Variant` can never be an assignment target (enum
+		! variants aren't assignable), same rationale as the unqualified
+		! EnumName.Variant check below.  Rewind and let parse_expr dispatch to
+		! parse_qualified_expr -> parse_enum_access instead of misreading this
+		! as an undeclared qualified variable
+		if (parser%current_kind() == dot_token .and. &
+			parser%enums%exists(expr%module_prefix // "::" // identifier%text)) then
+			parser%pos = pos0
+			call parser%parse_expr(expr=expr)
+			return
+		end if
+
 		! Look up the qualified variable
 		expr%identifier = identifier
 		is_const_var = .false.
@@ -743,6 +755,12 @@ recursive module subroutine parse_primary_expr(parser, expr)
 			if (parser%peek_kind(1) == double_colon_token) then
 				! Qualified name like `std::println()` or `mod::fn()`
 				call parser%parse_qualified_expr(expr)
+			else if (parser%peek_kind(1) == lparen_token .and. &
+					parser%enums%exists(parser%current_text())) then
+				! Reverse cast, e.g. `Suit(2)`.  Checked against the enums
+				! dict so a same-named fn is never shadowed by this -- enum
+				! type names and fn names live in separate namespaces
+				call parser%parse_enum_cast(expr)
 			else if (parser%peek_kind(1) == lparen_token) then
 				call parser%parse_fn_call(fn_call=expr)
 				if (parser%current_kind() == lbracket_token) then

--- a/src/parse_expr.f90
+++ b/src/parse_expr.f90
@@ -311,6 +311,22 @@ recursive module subroutine parse_expr_statement(parser, expr)
 		end if
 	end if
 
+	if (parser%peek_kind(0) == identifier_token .and. &
+	    parser%peek_kind(1) == dot_token .and. &
+	    parser%enums%exists(parser%current_text())) then
+
+		! `EnumName.Variant` can never be an assignment target (enum variants
+		! aren't assignable), so route straight to the general expression
+		! parser (parse_primary_expr -> parse_enum_access handles it from
+		! here).  This skips the speculative assignment-parse logic below,
+		! which would otherwise treat the leading identifier as an undeclared
+		! struct-instance variable and error out before ever checking whether
+		! this is actually an assignment
+		call parser%parse_expr(expr=expr)
+		return
+
+	end if
+
 	if (parser%peek_kind(0) == identifier_token) then
 
 		! There may or may not be a subscript expression after an identifier, so
@@ -499,6 +515,15 @@ recursive module subroutine parse_expr_statement(parser, expr)
 				! args, instead of a bunch of int args as-is
 				is_op_allowed = .false.
 			end if
+		else if (ltype == enum_type .and. is_op_allowed) then
+			! Mirrors the struct_type cookie check above, for the same reason
+			if (allocated(expr%val%enum_cookie) .and. &
+				allocated(expr%right%val%enum_cookie)) then
+				if (expr%val%enum_cookie /= expr%right%val%enum_cookie) &
+					is_op_allowed = .false.
+			else if (expr%val%enum_name /= expr%right%val%enum_name) then
+				is_op_allowed = .false.
+			end if
 		end if
 
 		! This check could be moved inside of is_binary_op_allowed, but we would
@@ -555,6 +580,8 @@ recursive module subroutine parse_expr(parser, parent_prec, expr)
 	integer :: parent_precl, prec, ltype, rtype, larrtype, rarrtype, &
 		lrank, rrank
 
+	logical :: is_op_allowed
+
 	type(syntax_node_t) :: right, bin_tmp
 	type(syntax_token_t) :: op
 	type(text_span_t) :: span
@@ -610,7 +637,21 @@ recursive module subroutine parse_expr(parser, parent_prec, expr)
 		!print *, 'ltype = ', kind_name(ltype)
 		!print *, 'rtype = ', kind_name(rtype)
 
-		if (.not. is_binary_op_allowed(ltype, op%kind, rtype, larrtype, rarrtype)) then
+		is_op_allowed = is_binary_op_allowed(ltype, op%kind, rtype, larrtype, rarrtype)
+		if (ltype == enum_type .and. is_op_allowed) then
+			! Mirrors the enum_cookie check in parse_expr_statement, for
+			! comparisons (e.g. `==`) that don't go through that
+			! assignment-only path
+			if (allocated(expr%left%val%enum_cookie) .and. &
+				allocated(expr%right%val%enum_cookie)) then
+				if (expr%left%val%enum_cookie /= expr%right%val%enum_cookie) &
+					is_op_allowed = .false.
+			else if (expr%left%val%enum_name /= expr%right%val%enum_name) then
+				is_op_allowed = .false.
+			end if
+		end if
+
+		if (.not. is_op_allowed) then
 
 			!print *, 'bin not allowed in parse_expr'
 
@@ -754,6 +795,15 @@ recursive module subroutine parse_primary_expr(parser, expr)
 					! Same as default case below
 					call parser%parse_name_expr(expr)
 				end if
+
+			else if (parser%peek_kind(1) == dot_token .and. &
+					parser%enums%exists(parser%current_text())) then
+				! Enum variant access, e.g. `Dir.North`.  Checked against the
+				! enums dict so a same-named local variable followed by `.`
+				! (a struct-instance dot, handled elsewhere) is never
+				! shadowed by this -- enum type names and variable names
+				! live in separate namespaces, so no ambiguity here
+				call parser%parse_enum_access(expr)
 
 			else
 				call parser%parse_name_expr(expr)

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -902,7 +902,7 @@ module subroutine parse_struct_declaration(parser, decl)
 	call parser%match(identifier_token, identifier)
 	!print *, "parsing struct ", identifier%text
 
-	itype = lookup_type(identifier%text, parser%structs)
+	itype = lookup_type(identifier%text, parser%structs, parser%enums)
 	!print *, "itype = ", itype, kind_name(itype)
 	if (itype /= unknown_type .and. itype /= struct_type) then
 		! Redeclared structs are caught below
@@ -1112,6 +1112,256 @@ module subroutine parse_struct_declaration(parser, decl)
 	!print *, "done parsing struct"
 
 end subroutine parse_struct_declaration
+
+!===============================================================================
+
+module subroutine parse_enum_declaration(parser, decl)
+
+	class(parser_t) :: parser
+	type(syntax_node_t), intent(out) :: decl
+
+	!********
+
+	integer :: itype, i, j, io, pos0
+	integer :: next_value, this_value
+
+	logical :: overwrite
+
+	type(enum_t) :: enum
+
+	type(syntax_token_t) :: identifier, comma, lbrace, rbrace, dummy, &
+		equals, name, enum_kw, intlit
+
+	type(text_span_t) :: span
+
+	type(string_vector_t) :: names
+	type(integer_vector_t) :: values, pos_mems
+
+	! Enums use this syntax:
+	!
+	!     // declaration
+	!     enum Card
+	!     {
+	!     	Two,        // 0
+	!     	Three,      // 1
+	!     	Jack = 10,  // 10
+	!     	Queen,      // 11
+	!     }
+	!
+	!     // access
+	!     let c = Card.Jack;
+	!
+	! Variants are compile-time constants -- unlike struct members there is
+	! no type annotation, just an optional `= <intlit>` to pin the backing
+	! value.  Subsequent variants continue the auto-increment from there
+
+	call parser%match(enum_keyword, enum_kw)
+
+	call parser%match(identifier_token, identifier)
+
+	itype = lookup_type(identifier%text, parser%structs, parser%enums)
+	if (itype /= unknown_type .and. itype /= enum_type) then
+		! Redeclared enums are caught below
+		span = new_span(identifier%pos, len(identifier%text))
+		call parser%diagnostics%push(err_redeclare_primitive( &
+			parser%context(), &
+			span, &
+			identifier%text))
+	end if
+
+	call parser%match(lbrace_token, lbrace)
+
+	names  = new_string_vector()
+	values = new_integer_vector()
+	pos_mems = new_integer_vector()
+
+	next_value = 0
+	do while ( &
+			parser%current_kind() /= rbrace_token .and. &
+			parser%current_kind() /= eof_token)
+
+		pos0 = parser%current_pos()
+
+		call parser%match(identifier_token, name)
+		call pos_mems%push( name%pos )
+
+		this_value = next_value
+		if (parser%current_kind() == equals_token) then
+			call parser%next(equals)
+			call parser%match(i32_token, intlit)
+			this_value = intlit%val%sca%i32
+		end if
+
+		call values%push(this_value)
+		call names%push( name%text )
+		next_value = this_value + 1
+
+		if (parser%current_kind() /= rbrace_token) then
+			! Delimiting commas are required; trailing comma is optional
+			call parser%match(comma_token, comma)
+		end if
+
+		! Break infinite loop
+		if (parser%current_pos() == pos0) call parser%next(dummy)
+
+	end do
+
+	! Sentinel for duplicate-variant span: end of the last variant (or rbrace)
+	call pos_mems%push(parser%current_pos())
+
+	enum%num_vars = 0
+	allocate(enum%variant_names%v( names%len_ ))
+	allocate(enum%variant_values ( names%len_ ))
+
+	! Canonical alias-independent identity, set once at declaration time,
+	! mirroring struct%cookie above
+	enum%cookie = parser%contexts%v(parser%current_unit())%src_file &
+		// "::" // identifier%text
+
+	do i = 1, names%len_
+
+		enum%variant_names%v(i)%s = names%v(i)%s
+		enum%variant_values(i)    = values%v(i)
+		enum%num_vars = enum%num_vars + 1
+
+		do j = 1, i - 1
+			if (enum%variant_names%v(j)%s == names%v(i)%s) then
+				span = new_span(pos_mems%v(i), pos_mems%v(i+1) - pos_mems%v(i))
+				call parser%diagnostics%push(err_redeclare_variant( &
+					parser%context(), &
+					span, &
+					names%v(i)%s))
+				exit
+			end if
+		end do
+
+	end do
+
+	call parser%match(rbrace_token, rbrace)
+
+	! Insert enum into parser dict
+
+	parser%num_enums = parser%num_enums + 1
+	decl%id_index  = parser%num_enums
+
+	overwrite = .false.
+	if (parser%ipass > 0) overwrite = .true.
+
+	call parser%enums%insert( &
+		identifier%text, enum, decl%id_index, io, overwrite = overwrite)
+	if (parser%ipass == 0) call parser%enum_names%push(identifier%text)
+	if (io /= 0) then
+		span = new_span(identifier%pos, len(identifier%text))
+		call parser%diagnostics%push(err_redeclare_enum( &
+			parser%context(), &
+			span, &
+			identifier%text))
+	end if
+
+	decl%kind = enum_declaration
+
+end subroutine parse_enum_declaration
+
+!===============================================================================
+
+module subroutine parse_enum_access(parser, expr)
+
+	! Parse `EnumName.Variant`, called from parse_primary_expr() when the
+	! current identifier is a registered enum name.  Bakes a fully-resolved
+	! enum value_t into expr%val at parse time -- enum values are
+	! compile-time constants, so there is no runtime lookup
+
+	class(parser_t), target :: parser
+	type(syntax_node_t), intent(out) :: expr
+
+	!********
+
+	integer :: enum_id, i, variant_id
+
+	character(len = :), allocatable :: enum_name_text
+
+	type(enum_t), pointer :: enum
+
+	type(syntax_token_t) :: enum_tok, dot, variant_tok
+
+	type(text_span_t) :: span
+
+	call parser%match(identifier_token, enum_tok)
+	enum_name_text = enum_tok%text
+
+	call parser%match(dot_token, dot)
+	call parser%match(identifier_token, variant_tok)
+
+	enum_id = parser%enums%find(enum_name_text)
+	enum => parser%enums%get(enum_id)
+
+	variant_id = 0
+	do i = 1, enum%num_vars
+		if (enum%variant_names%v(i)%s == variant_tok%text) then
+			variant_id = i
+			exit
+		end if
+	end do
+
+	expr%kind = enum_access_expr
+	expr%identifier = variant_tok
+
+	if (variant_id == 0) then
+		span = new_span(variant_tok%pos, len(variant_tok%text))
+		call parser%diagnostics%push(err_unknown_variant( &
+			parser%context(), span, variant_tok%text, enum_name_text, &
+			enum_closest_variant(enum, variant_tok%text)))
+
+		! Error recovery: sanitize to unknown_type so this doesn't cascade
+		! into a fn-ptr-struct-member-style crash downstream
+		expr%val%type = unknown_type
+		return
+	end if
+
+	expr%val%type = enum_type
+	expr%val%sca%i32 = enum%variant_values(variant_id)
+	expr%val%enum_name = enum_name_text
+	expr%val%enum_variant = variant_tok%text
+	expr%val%enum_cookie = enum%cookie
+
+end subroutine parse_enum_access
+
+!===============================================================================
+
+function enum_closest_variant(enum, key) result(closest)
+
+	! Return the closest variant name in `enum` to `key`, or "" when none is
+	! close enough.  Mirrors structs_t%closest()/enums_t%closest(), but scans
+	! an enum_t's variant_names instead of a whole hash table of enum_t's
+
+	type(enum_t), intent(in) :: enum
+	character(len = *), intent(in) :: key
+	character(len = :), allocatable :: closest
+
+	!********
+
+	integer :: i, min_dist, dist, threshold
+	character(len = :), allocatable :: key_low, target_low
+
+	closest  = ""
+	min_dist = huge(min_dist)
+	target_low = to_lower(key)
+
+	do i = 1, enum%num_vars
+		key_low = to_lower(enum%variant_names%v(i)%s)
+		if (key_low == target_low) cycle
+
+		dist = levenshtein(target_low, key_low)
+		if (dist < min_dist) then
+			min_dist = dist
+			closest  = enum%variant_names%v(i)%s
+		end if
+	end do
+
+	threshold = max(2, len(target_low) / 3)
+	if (min_dist > threshold) closest = ""
+
+end function enum_closest_variant
 
 !===============================================================================
 
@@ -1554,7 +1804,7 @@ recursive module subroutine parse_type(parser, type_text, type)
 	integer :: rank, itype, i
 	integer :: pos0, pos1, pos2
 
-	character(len = :), allocatable :: struct_cookie, param_type_text, ret_type_text
+	character(len = :), allocatable :: cookie, suggest, param_type_text, ret_type_text
 
 	type(syntax_token_t) :: colon, ident, comma, lbracket, rbracket, semi, dummy, &
 		double_colon, fn_kw, lparen, rparen
@@ -1662,13 +1912,14 @@ recursive module subroutine parse_type(parser, type_text, type)
 	end if
 	pos2 = parser%current_pos()
 
-	itype = lookup_type(type_text, parser%structs, struct_cookie)
+	itype = lookup_type(type_text, parser%structs, parser%enums, cookie)
 
 	if (itype == unknown_type) then
 		span = new_span(pos1, pos2 - pos1)
+		suggest = parser%structs%closest(type_text)
+		if (len(suggest) == 0) suggest = parser%enums%closest(type_text)
 		call parser%diagnostics%push(err_bad_type( &
-			parser%context(), span, type_text, &
-			parser%structs%closest(type_text)))
+			parser%context(), span, type_text, suggest))
 	end if
 
 	if (rank >= 0) then
@@ -1683,7 +1934,10 @@ recursive module subroutine parse_type(parser, type_text, type)
 
 	if (itype == struct_type) then
 		type%struct_name = type_text
-		type%struct_cookie = struct_cookie
+		type%struct_cookie = cookie
+	else if (itype == enum_type) then
+		type%enum_name = type_text
+		type%enum_cookie = cookie
 	end if
 
 end subroutine parse_type

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -1138,7 +1138,7 @@ module subroutine parse_enum_declaration(parser, decl)
 	!********
 
 	integer :: itype, i, j, k, io, pos0
-	integer :: next_value, this_value, this_explicit
+	integer :: next_value, this_value, this_explicit, sgn
 
 	logical :: overwrite, found_alias
 
@@ -1239,8 +1239,19 @@ module subroutine parse_enum_declaration(parser, decl)
 				! exempt from the duplicate-value check below
 				this_explicit = 2
 			else
+				! Optional leading sign: `-1` (and `+1`) lex as a separate
+				! unary minus/plus token before the i32 literal -- enum
+				! values are plain int literals, not full expressions, so
+				! only a single leading sign is handled here
+				sgn = 1
+				if (parser%current_kind() == minus_token) then
+					call parser%next(dummy)
+					sgn = -1
+				else if (parser%current_kind() == plus_token) then
+					call parser%next(dummy)
+				end if
 				call parser%match(i32_token, intlit)
-				this_value = intlit%val%sca%i32
+				this_value = sgn * intlit%val%sca%i32
 				this_explicit = 1
 			end if
 		end if

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -1122,15 +1122,15 @@ module subroutine parse_enum_declaration(parser, decl)
 
 	!********
 
-	integer :: itype, i, j, io, pos0
+	integer :: itype, i, j, k, io, pos0
 	integer :: next_value, this_value, this_explicit
 
-	logical :: overwrite
+	logical :: overwrite, found_alias
 
 	type(enum_t) :: enum
 
 	type(syntax_token_t) :: identifier, comma, lbrace, rbrace, dummy, &
-		equals, name, enum_kw, intlit
+		equals, name, enum_kw, intlit, alias
 
 	type(text_span_t) :: span
 
@@ -1146,14 +1146,18 @@ module subroutine parse_enum_declaration(parser, decl)
 	!     	Three,      // 1
 	!     	Jack = 10,  // 10
 	!     	Queen,      // 11
+	!     	King = Jack,// 10 (alias)
 	!     }
 	!
 	!     // access
 	!     let c = Card.Jack;
 	!
 	! Variants are compile-time constants -- unlike struct members there is
-	! no type annotation, just an optional `= <intlit>` to pin the backing
-	! value.  Subsequent variants continue the auto-increment from there
+	! no type annotation, just an optional `= <intlit>` or `= <prior variant
+	! name>` to pin the backing value.  A name reference must refer to a
+	! variant already declared above it (like C's enumerator constants) and
+	! makes this variant an intentional alias.  Subsequent variants continue
+	! the auto-increment from there
 
 	call parser%match(enum_keyword, enum_kw)
 
@@ -1190,9 +1194,40 @@ module subroutine parse_enum_declaration(parser, decl)
 		this_explicit = 0
 		if (parser%current_kind() == equals_token) then
 			call parser%next(equals)
-			call parser%match(i32_token, intlit)
-			this_value = intlit%val%sca%i32
-			this_explicit = 1
+
+			if (parser%current_kind() == identifier_token) then
+				! Named alias, e.g. `King = Jack`.  Only variants already
+				! declared above this one are in scope, exactly like C
+				! enumerator constants -- forward references are an error
+				call parser%match(identifier_token, alias)
+
+				found_alias = .false.
+				do k = 1, names%len_
+					if (names%v(k)%s == alias%text) then
+						this_value = values%v(k)
+						found_alias = .true.
+						exit
+					end if
+				end do
+
+				if (.not. found_alias) then
+					span = new_span(alias%pos, len(alias%text))
+					call parser%diagnostics%push(err_unknown_variant( &
+						parser%context(), &
+						span, &
+						alias%text, &
+						identifier%text))
+				end if
+
+				! Whether resolved or not, this is an intentional alias --
+				! not an accidental auto-increment collision -- so it's
+				! exempt from the duplicate-value check below
+				this_explicit = 2
+			else
+				call parser%match(i32_token, intlit)
+				this_value = intlit%val%sca%i32
+				this_explicit = 1
+			end if
 		end if
 
 		call values%push(this_value)
@@ -1239,14 +1274,17 @@ module subroutine parse_enum_declaration(parser, decl)
 			end if
 		end do
 
-		! Duplicate values are only allowed when both variants are pinned
-		! explicitly (an intentional alias, e.g. `King = 10` next to
-		! `Jack = 10`).  Any collision that involves an auto-incremented
-		! value is always accidental, since auto-increment has no way to
-		! express aliasing intent -- so it's a hard error
+		! Duplicate values are only allowed when the collision is
+		! intentional: either a named alias (`King = Jack`, explicits == 2)
+		! on either side, or both variants pinned explicitly to the same
+		! int literal (e.g. `King = 10` next to `Jack = 10`).  Any
+		! collision that involves an auto-incremented value is always
+		! accidental, since auto-increment has no way to express aliasing
+		! intent -- so it's a hard error
 		do j = 1, i - 1
 			if (values%v(j) == values%v(i) .and. &
 					names%v(j)%s /= names%v(i)%s .and. &
+					explicits%v(i) /= 2 .and. explicits%v(j) /= 2 .and. &
 					.not. (explicits%v(i) == 1 .and. explicits%v(j) == 1)) then
 				span = new_span(pos_mems%v(i), pos_mems%v(i+1) - pos_mems%v(i))
 				call parser%diagnostics%push(err_duplicate_enum_value( &

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -537,7 +537,14 @@ recursive module subroutine parse_qualified_expr(parser, expr)
 		fn_name = fn_identifier%text
 	end do
 
-	if (parser%current_kind() == lparen_token) then
+	if (parser%current_kind() == lparen_token .and. &
+			parser%enums%exists(module_name // "::" // fn_name)) then
+		! Qualified reverse cast: mod::Suit(2).  Checked against the enums
+		! dict, mirroring the unqualified dispatch in parse_primary_expr()
+		lookup_name = module_name // "::" // fn_name
+		call parser%parse_enum_cast(expr, lookup_name)
+
+	else if (parser%current_kind() == lparen_token) then
 		! Qualified function call: std::println(...) or math::vectors::fn(...)
 		call parser%parse_fn_call(module_name, fn_identifier, expr)
 		if (parser%current_kind() == lbracket_token) then
@@ -560,6 +567,14 @@ recursive module subroutine parse_qualified_expr(parser, expr)
 				err_undeclare_var(parser%context(), span, fn_name, &
 				parser%vars%closest(fn_name)))
 		end if
+
+	else if (parser%current_kind() == dot_token .and. &
+			parser%enums%exists(module_name // "::" // fn_name)) then
+		! Qualified enum variant access: mod::EnumName.Variant.  Checked
+		! against the enums dict, mirroring the unqualified dispatch in
+		! parse_primary_expr()
+		lookup_name = module_name // "::" // fn_name
+		call parser%parse_enum_access(expr, lookup_name)
 
 	else
 		! Qualified variable access: mod::var
@@ -1326,15 +1341,21 @@ end subroutine parse_enum_declaration
 
 !===============================================================================
 
-module subroutine parse_enum_access(parser, expr)
+module subroutine parse_enum_access(parser, expr, enum_name)
 
 	! Parse `EnumName.Variant`, called from parse_primary_expr() when the
 	! current identifier is a registered enum name.  Bakes a fully-resolved
 	! enum value_t into expr%val at parse time -- enum values are
 	! compile-time constants, so there is no runtime lookup
+	!
+	! When `enum_name` is present, it is the already-parsed, alias-qualified
+	! lookup name (e.g. "mod::Suit") from parse_qualified_expr(), and only the
+	! trailing `.Variant` remains to be consumed here -- mirrors
+	! parse_struct_instance()'s optional `struct_name` argument
 
 	class(parser_t), target :: parser
 	type(syntax_node_t), intent(out) :: expr
+	character(len = *), intent(in), optional :: enum_name
 
 	!********
 
@@ -1348,8 +1369,12 @@ module subroutine parse_enum_access(parser, expr)
 
 	type(text_span_t) :: span
 
-	call parser%match(identifier_token, enum_tok)
-	enum_name_text = enum_tok%text
+	if (present(enum_name)) then
+		enum_name_text = enum_name
+	else
+		call parser%match(identifier_token, enum_tok)
+		enum_name_text = enum_tok%text
+	end if
 
 	call parser%match(dot_token, dot)
 	call parser%match(identifier_token, variant_tok)
@@ -1387,6 +1412,110 @@ module subroutine parse_enum_access(parser, expr)
 	expr%val%enum_cookie = enum%cookie
 
 end subroutine parse_enum_access
+
+!===============================================================================
+
+module subroutine parse_enum_cast(parser, expr, enum_name)
+
+	! Parse `EnumName(ordinal)`, the reverse cast from an integer ordinal back
+	! to an enum variant, e.g. `Suit(2) -> Suit.Clubs`.  Called from
+	! parse_primary_expr() when the current identifier is a registered enum
+	! name followed by `(`
+	!
+	! When `enum_name` is present, it is the already-parsed, alias-qualified
+	! lookup name (e.g. "mod::Suit") from parse_qualified_expr(), and only the
+	! trailing `(ordinal)` remains to be consumed here -- mirrors
+	! parse_enum_access()'s optional `enum_name` argument
+	!
+	! Bakes every one of the enum's variants into expr%val%struct(:) at parse
+	! time -- the same representation used for enum-array elements (c.f.
+	! parse_array_expr) -- so the ordinal->variant lookup at eval time needs
+	! no runtime enum registry; it just scans this baked list.  When the
+	! argument is a constant int literal, the ordinal is checked against the
+	! baked variants right here at parse time (E96); otherwise the check is
+	! deferred to runtime (R32)
+
+	class(parser_t), target :: parser
+	type(syntax_node_t), intent(out) :: expr
+	character(len = *), intent(in), optional :: enum_name
+
+	!********
+
+	integer :: enum_id, i
+	integer :: span_beg, span_end
+
+	character(len = :), allocatable :: enum_name_text
+
+	type(enum_t), pointer :: enum
+
+	type(syntax_node_t) :: arg
+
+	type(syntax_token_t) :: enum_tok, lparen, rparen
+
+	type(text_span_t) :: span
+
+	logical :: found
+
+	if (present(enum_name)) then
+		enum_name_text = enum_name
+	else
+		call parser%match(identifier_token, enum_tok)
+		enum_name_text = enum_tok%text
+	end if
+
+	call parser%match(lparen_token, lparen)
+
+	span_beg = parser%peek_pos(0)
+	call parser%parse_expr(expr=arg)
+	span_end = parser%peek_pos(0) - 1
+
+	call parser%match(rparen_token, rparen)
+
+	enum_id = parser%enums%find(enum_name_text)
+	enum => parser%enums%get(enum_id)
+
+	if (.not. is_int_type(arg%val%type)) then
+		span = new_span(span_beg, span_end - span_beg + 1)
+		call parser%diagnostics%push(err_bad_arg_type( &
+			parser%context(), span, enum_name_text, 1, "ordinal", "i32", &
+			type_name(arg%val)))
+
+	else if (arg%kind == literal_expr .and. arg%val%type == i32_type) then
+		! Parse-time check: a constant i32 literal argument can be validated
+		! right now instead of waiting for a runtime error
+		found = .false.
+		do i = 1, enum%num_vars
+			if (enum%variant_values(i) == arg%val%sca%i32) then
+				found = .true.
+				exit
+			end if
+		end do
+		if (.not. found) then
+			span = new_span(span_beg, span_end - span_beg + 1)
+			call parser%diagnostics%push(err_enum_cast_range( &
+				parser%context(), span, enum_name_text, arg%val%sca%i32))
+		end if
+	end if
+
+	expr%kind = enum_cast_expr
+	if (.not. present(enum_name)) expr%identifier = enum_tok
+	call syntax_node_move(arg, expr%right)
+
+	! Bake every variant into expr%val%struct(:), mirroring how an
+	! enum-array literal tags its elements (c.f. parse_array_expr)
+	expr%val%type = enum_type
+	expr%val%enum_name = enum_name_text
+	expr%val%enum_cookie = enum%cookie
+	allocate(expr%val%struct( enum%num_vars ))
+	do i = 1, enum%num_vars
+		expr%val%struct(i)%type = enum_type
+		expr%val%struct(i)%sca%i32 = enum%variant_values(i)
+		expr%val%struct(i)%enum_name = enum_name_text
+		expr%val%struct(i)%enum_variant = enum%variant_names%v(i)%s
+		expr%val%struct(i)%enum_cookie = enum%cookie
+	end do
+
+end subroutine parse_enum_cast
 
 !===============================================================================
 

--- a/src/parse_fn.f90
+++ b/src/parse_fn.f90
@@ -1123,7 +1123,7 @@ module subroutine parse_enum_declaration(parser, decl)
 	!********
 
 	integer :: itype, i, j, io, pos0
-	integer :: next_value, this_value
+	integer :: next_value, this_value, this_explicit
 
 	logical :: overwrite
 
@@ -1135,7 +1135,7 @@ module subroutine parse_enum_declaration(parser, decl)
 	type(text_span_t) :: span
 
 	type(string_vector_t) :: names
-	type(integer_vector_t) :: values, pos_mems
+	type(integer_vector_t) :: values, pos_mems, explicits
 
 	! Enums use this syntax:
 	!
@@ -1174,6 +1174,7 @@ module subroutine parse_enum_declaration(parser, decl)
 	names  = new_string_vector()
 	values = new_integer_vector()
 	pos_mems = new_integer_vector()
+	explicits = new_integer_vector()
 
 	next_value = 0
 	do while ( &
@@ -1186,14 +1187,17 @@ module subroutine parse_enum_declaration(parser, decl)
 		call pos_mems%push( name%pos )
 
 		this_value = next_value
+		this_explicit = 0
 		if (parser%current_kind() == equals_token) then
 			call parser%next(equals)
 			call parser%match(i32_token, intlit)
 			this_value = intlit%val%sca%i32
+			this_explicit = 1
 		end if
 
 		call values%push(this_value)
 		call names%push( name%text )
+		call explicits%push(this_explicit)
 		next_value = this_value + 1
 
 		if (parser%current_kind() /= rbrace_token) then
@@ -1231,6 +1235,26 @@ module subroutine parse_enum_declaration(parser, decl)
 					parser%context(), &
 					span, &
 					names%v(i)%s))
+				exit
+			end if
+		end do
+
+		! Duplicate values are only allowed when both variants are pinned
+		! explicitly (an intentional alias, e.g. `King = 10` next to
+		! `Jack = 10`).  Any collision that involves an auto-incremented
+		! value is always accidental, since auto-increment has no way to
+		! express aliasing intent -- so it's a hard error
+		do j = 1, i - 1
+			if (values%v(j) == values%v(i) .and. &
+					names%v(j)%s /= names%v(i)%s .and. &
+					.not. (explicits%v(i) == 1 .and. explicits%v(j) == 1)) then
+				span = new_span(pos_mems%v(i), pos_mems%v(i+1) - pos_mems%v(i))
+				call parser%diagnostics%push(err_duplicate_enum_value( &
+					parser%context(), &
+					span, &
+					names%v(i)%s, &
+					names%v(j)%s, &
+					values%v(i)))
 				exit
 			end if
 		end do

--- a/src/parse_misc.f90
+++ b/src/parse_misc.f90
@@ -357,7 +357,7 @@ module subroutine parse_unit(parser, unit)
 	type(syntax_node_t)  :: stmt_tmp
 	type(syntax_token_t) :: dummy
 
-	integer :: i, pos0, num_vars0, num_fns0, num_structs0
+	integer :: i, pos0, num_vars0, num_fns0, num_structs0, num_enums0
 
 	!print *, 'starting parse_unit()'
 
@@ -382,9 +382,11 @@ module subroutine parse_unit(parser, unit)
 	num_vars0 = parser%num_vars  ! not necessarily 0 for the REPL
 	num_fns0 = parser%num_fns    ! includes intrinsic fns
 	num_structs0 = parser%num_structs
+	num_enums0 = parser%num_enums
 	parser%fn_names = new_string_vector()
 	parser%var_names = new_string_vector()
 	parser%struct_names = new_string_vector()
+	parser%enum_names = new_string_vector()
 
 	do while (parser%current_kind() /= eof_token)
 
@@ -400,6 +402,9 @@ module subroutine parse_unit(parser, unit)
 			call members%push_move(stmt_tmp)
 		case (struct_keyword)
 			call parser%parse_struct_declaration(stmt_tmp)
+			call members%push_move(stmt_tmp)
+		case (enum_keyword)
+			call parser%parse_enum_declaration(stmt_tmp)
 			call members%push_move(stmt_tmp)
 		case default
 			call parser%parse_statement(stmt_tmp)
@@ -434,6 +439,7 @@ module subroutine parse_unit(parser, unit)
 		parser%num_vars = num_vars0
 		parser%num_fns = num_fns0
 		parser%num_structs = num_structs0
+		parser%num_enums = num_enums0
 
 		! TODO: Double check struct resetting.  Does anything else need to be reset?
 
@@ -463,6 +469,9 @@ module subroutine parse_unit(parser, unit)
 				call members%push_move(stmt_tmp)
 			case (struct_keyword)
 				call parser%parse_struct_declaration(stmt_tmp)
+				call members%push_move(stmt_tmp)
+			case (enum_keyword)
+				call parser%parse_enum_declaration(stmt_tmp)
 				call members%push_move(stmt_tmp)
 			case default
 				call parser%parse_statement(stmt_tmp)

--- a/src/tests/test-src/enum/test-01.syntran
+++ b/src/tests/test-src/enum/test-01.syntran
@@ -1,0 +1,44 @@
+enum Suit
+{
+	Hearts,
+	Diamonds,
+	Clubs,
+	Spades,
+}
+
+enum Card
+{
+	Two,
+	Three,
+	Jack = 10,
+	Queen,
+	King,
+}
+
+let s = Suit.Clubs;
+let ok1 = i32(s) == 2;
+
+let c = Card.Queen;
+let ok2 = i32(c) == 11;
+
+let ok3 = Suit.Hearts == Suit.Hearts;
+let ok4 = Suit.Hearts != Suit.Spades;
+
+let deck = [10, 20, 30, 40];
+let ok5 = deck[i32(Suit.Clubs)] == 30;
+
+fn describe(x: Suit): str
+{
+	return str(x);
+}
+let ok6 = describe(Suit.Diamonds) == "Suit.Diamonds";
+
+struct Player
+{
+	name: str,
+	suit: Suit,
+}
+let p = Player{name = "Alice", suit = Suit.Spades};
+let ok7 = p.suit == Suit.Spades;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6 and ok7;

--- a/src/tests/test-src/enum/test-02.syntran
+++ b/src/tests/test-src/enum/test-02.syntran
@@ -1,0 +1,33 @@
+// Auto-increment continues from an explicit value across multiple enums
+// declared in the same file, and enums can be used as fn params/returns
+// without any struct in the mix
+
+enum Direction
+{
+	North,
+	East,
+	South,
+	West,
+}
+
+fn turn_right(d: Direction): Direction
+{
+	if d == Direction.North { return Direction.East; }
+	if d == Direction.East  { return Direction.South; }
+	if d == Direction.South { return Direction.West; }
+	return Direction.North;
+}
+
+let d0 = Direction.North;
+let d1 = turn_right(d0);
+let d2 = turn_right(d1);
+let d3 = turn_right(d2);
+let d4 = turn_right(d3);
+
+let ok1 = d1 == Direction.East;
+let ok2 = d2 == Direction.South;
+let ok3 = d3 == Direction.West;
+let ok4 = d4 == Direction.North;
+let ok5 = i32(Direction.West) == 3;
+
+return ok1 and ok2 and ok3 and ok4 and ok5;

--- a/src/tests/test-src/enum/test-03.syntran
+++ b/src/tests/test-src/enum/test-03.syntran
@@ -1,0 +1,32 @@
+// Named aliases: a variant can pin its value to a previously-declared
+// variant by bare name, e.g. `King = Jack`, instead of an int literal.
+// Auto-increment resumes from the aliased value, and aliased variants
+// compare equal to the variant they reference
+
+enum Card
+{
+	Two,
+	Three,
+	Jack,
+	Queen,
+	King = Jack,
+}
+
+let ok1 = Card.King == Card.Jack;
+let ok2 = i32(Card.King) == i32(Card.Jack);
+let ok3 = i32(Card.King) == 2;
+
+// Alias to an explicitly-pinned variant, and auto-increment continuing
+// after an alias (not after the value it would have taken without one)
+enum Suit
+{
+	Hearts,
+	Diamonds = 10,
+	Clubs = Diamonds,
+	Spades,
+}
+
+let ok4 = i32(Suit.Clubs) == 10;
+let ok5 = i32(Suit.Spades) == 11;
+
+return ok1 and ok2 and ok3 and ok4 and ok5;

--- a/src/tests/test-src/enum/test-04.syntran
+++ b/src/tests/test-src/enum/test-04.syntran
@@ -1,0 +1,57 @@
+// Arrays of enums: literal arrays, indexing, assignment, str() formatting,
+// the uniform [x; n] form, enums as struct-array members, fn params/returns
+// of enum arrays, and iterating a literal enum array with a for loop
+
+enum Suit
+{
+	Hearts,
+	Diamonds,
+	Clubs,
+	Spades,
+}
+
+let hand = [Suit.Hearts, Suit.Clubs, Suit.Spades];
+let ok1 = hand[1] == Suit.Clubs;
+
+hand[0] = Suit.Diamonds;
+let ok2 = hand[0] == Suit.Diamonds;
+
+let ok3 = str(hand) == "[Suit.Diamonds, Suit.Clubs, Suit.Spades]";
+
+// Uniform [x; n] form
+let deck = [Suit.Hearts; 3];
+let ok4 = deck[0] == Suit.Hearts and deck[1] == Suit.Hearts and deck[2] == Suit.Hearts;
+
+// Enum array as a struct member
+struct Player
+{
+	name: str,
+	cards: [Suit; :],
+}
+let p = Player{name = "Alice", cards = [Suit.Hearts, Suit.Spades]};
+let ok5 = p.cards[1] == Suit.Spades;
+p.cards[0] = Suit.Clubs;
+let ok6 = p.cards[0] == Suit.Clubs;
+
+// Enum array as fn param/return
+fn describe_hand(h: [Suit; :]): str
+{
+	return str(h);
+}
+let ok7 = describe_hand(hand) == "[Suit.Diamonds, Suit.Clubs, Suit.Spades]";
+
+fn make_hand(): [Suit; :]
+{
+	return [Suit.Clubs, Suit.Hearts];
+}
+let ok8 = make_hand()[0] == Suit.Clubs;
+
+// Iterate a literal enum array with a for loop
+let count = 0;
+for s in [Suit.Hearts, Suit.Clubs, Suit.Spades]
+{
+	if s == Suit.Clubs { count = count + 1; }
+}
+let ok9 = count == 1;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6 and ok7 and ok8 and ok9;

--- a/src/tests/test-src/enum/test-05.syntran
+++ b/src/tests/test-src/enum/test-05.syntran
@@ -1,0 +1,46 @@
+// Reverse cast from i32 to enum: `Suit(2) -> Suit.Clubs`
+
+enum Suit
+{
+	Hearts,
+	Diamonds,
+	Clubs,
+	Spades,
+}
+
+let ok1 = Suit(2) == Suit.Clubs;
+let ok2 = Suit(0) == Suit.Hearts;
+
+// Round trip through the forward cast
+let ok3 = Suit(i32(Suit.Spades)) == Suit.Spades;
+
+// str() of a cast result
+let ok4 = str(Suit(1)) == "Suit.Diamonds";
+
+// Cast with a non-literal (runtime-only) argument
+let x = 3;
+let ok5 = Suit(x) == Suit.Spades;
+
+// Cast inside an array literal
+let hand = [Suit(0), Suit(2)];
+let ok6 = hand[1] == Suit.Clubs;
+
+// Cast as a fn call argument
+fn describe(s: Suit): str
+{
+	return str(s);
+}
+let ok7 = describe(Suit(3)) == "Suit.Spades";
+
+// Explicit-value enum: cast picks the right variant by value, not position
+enum Card
+{
+	Two,
+	Three,
+	Jack = 10,
+	Queen,
+	King,
+}
+let ok8 = Card(11) == Card.Queen;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6 and ok7 and ok8;

--- a/src/tests/test-src/enum/test-06.syntran
+++ b/src/tests/test-src/enum/test-06.syntran
@@ -1,0 +1,48 @@
+// Negative explicit enum values: `A = -1`, auto-increment continuing from a
+// negative value, equality/aliasing on negative values, arrays, and the
+// reverse cast with a negative ordinal
+
+enum Temp
+{
+	Below = -1,
+	Freezing,
+	Above,
+}
+
+let ok1 = i32(Temp.Below) == -1;
+let ok2 = i32(Temp.Freezing) == 0;
+let ok3 = i32(Temp.Above) == 1;
+
+// Auto-increment resumes from a negative value across multiple variants
+enum E
+{
+	A = -5,
+	B,
+	C,
+}
+let ok4 = i32(E.C) == -3;
+
+// Two variants explicitly pinned to the same negative value are an
+// intentional alias, not a duplicate-value error
+enum F
+{
+	X = -1,
+	Y = -1,
+}
+let ok5 = F.X == F.Y;
+
+// str() formats by variant name, independent of the backing value
+let ok6 = str(Temp.Below) == "Temp.Below";
+
+// Array of enums with negative values
+let temps = [Temp.Below, Temp.Freezing, Temp.Above];
+let ok7 = i32(temps[0]) == -1;
+
+// Reverse cast with a negative ordinal (runtime path, since a negated
+// literal isn't a constant literal_expr at parse time)
+let ok8 = Temp(-1) == Temp.Below;
+
+let x = -1;
+let ok9 = Temp(x) == Temp.Below;
+
+return ok1 and ok2 and ok3 and ok4 and ok5 and ok6 and ok7 and ok8 and ok9;

--- a/src/tests/test-src/enum/test-07.syntran
+++ b/src/tests/test-src/enum/test-07.syntran
@@ -1,0 +1,84 @@
+// Regression test for reused-slot / bulk-free teardown of enum values.
+//
+// value_destroy() (value.f90) is responsible for explicitly freeing every
+// allocatable component of a value_t before gfortran's implicit deep
+// deallocation of a nested value_t (or value_t array) has to run -- the
+// implicit path is unreliable and has historically crashed on Windows.  A
+// past bug left enum_name/enum_variant/enum_cookie out of that teardown, so
+// this exercises the two hot paths that rely on it: the VM's reused
+// call-frame locals slots (value_reset), and repeated construction/discard of
+// enum arrays and structs holding an enum member (value_array_destroy).
+
+enum Suit
+{
+	Hearts,
+	Diamonds,
+	Clubs,
+	Spades,
+}
+
+struct Card
+{
+	suit: Suit,
+	rank: i32,
+}
+
+fn make_card(s: Suit, r: i32): Card
+{
+	// Local enum + struct-with-enum values are created and discarded every
+	// call, forcing the VM to reset the same locals slots many times
+	let c = Card{suit = s, rank = r};
+	return c;
+}
+
+fn suit_name(s: Suit): str
+{
+	// Local var slot reused across calls, always holding an enum value
+	let local_s = s;
+	return str(local_s);
+}
+
+let suits = [Suit.Hearts, Suit.Diamonds, Suit.Clubs, Suit.Spades];
+
+let count = 0;
+for i in [0: 200]
+{
+	// Rebuild an enum array and a struct-with-enum-member every iteration,
+	// re-using the same loop-local variable slots each time
+	let hand = [suits[i % 4], suits[(i + 1) % 4], suits[(i + 2) % 4]];
+	let c = make_card(suits[i % 4], i);
+
+	if c.suit == hand[0]
+		count = count + 1;
+}
+let ok1 = count == 200;
+
+// Alternate the same local variable slot between an enum value and a
+// non-enum (i32) value across iterations, to exercise the stale-slot type
+// transition in value_reset()
+let total = 0;
+for i in [0: 100]
+{
+	if i % 2 == 0
+	{
+		let x = suits[i % 4];
+		total = total + i32(x);
+	}
+	else
+	{
+		let x = i;
+		total = total + x;
+	}
+}
+let ok2 = total > 0;
+
+// Repeated str() calls on enum values force repeated bake/discard of
+// enum_variant-bearing temporaries
+let names = "";
+for i in [0: 4]
+{
+	names = names + suit_name(suits[i]);
+}
+let ok3 = names == "Suit.HeartsSuit.DiamondsSuit.ClubsSuit.Spades";
+
+return ok1 and ok2 and ok3;

--- a/src/tests/test-src/errors/E92-redeclare-enum.syntran
+++ b/src/tests/test-src/errors/E92-redeclare-enum.syntran
@@ -1,0 +1,14 @@
+// E92: redeclare-enum
+// An enum was declared twice
+
+enum Dir
+{
+	North,
+	South,
+}
+
+enum Dir
+{
+	East,
+	West,
+}

--- a/src/tests/test-src/errors/E93-redeclare-variant.syntran
+++ b/src/tests/test-src/errors/E93-redeclare-variant.syntran
@@ -1,0 +1,8 @@
+// E93: redeclare-variant
+// A variant was declared twice in the same enum
+
+enum Dir
+{
+	North,
+	North,
+}

--- a/src/tests/test-src/errors/E94-unknown-variant.syntran
+++ b/src/tests/test-src/errors/E94-unknown-variant.syntran
@@ -1,0 +1,10 @@
+// E94: unknown-variant
+// A dot expression referenced a variant name that doesn't exist on the enum
+
+enum Dir
+{
+	North,
+	South,
+}
+
+let d = Dir.Nrth;

--- a/src/tests/test-src/errors/E95-duplicate-enum-value.syntran
+++ b/src/tests/test-src/errors/E95-duplicate-enum-value.syntran
@@ -1,0 +1,15 @@
+// E95: duplicate-enum-value
+// Two variants share a backing value, and at least one of them got that
+// value from auto-increment rather than an explicit `= <intlit>`.
+//
+// `King = 10` explicitly aliases `Jack = 10` -- that's allowed, no error.
+// `Ace` auto-increments to 11, silently colliding with `Queen = 11` -- that
+// collision is always accidental, so it's a hard error.
+
+enum Card
+{
+	Jack = 10,
+	Queen,
+	King = 10,
+	Ace,
+}

--- a/src/tests/test-src/errors/E96-enum-cast-range.syntran
+++ b/src/tests/test-src/errors/E96-enum-cast-range.syntran
@@ -1,0 +1,11 @@
+// E96: enum-cast-range
+// A reverse cast EnumName(ordinal) with a constant int literal argument
+// that doesn't match any variant's backing value
+
+enum Dir
+{
+	North,
+	South,
+}
+
+let d = Dir(99);

--- a/src/tests/test-src/modules/enum_mod.syntran
+++ b/src/tests/test-src/modules/enum_mod.syntran
@@ -1,0 +1,19 @@
+// Module that exports an enum definition
+
+enum Suit
+{
+	Hearts,
+	Diamonds,
+	Clubs,
+	Spades,
+}
+
+fn is_red(s: Suit): bool
+{
+	return s == Suit.Hearts or s == Suit.Diamonds;
+}
+
+fn full_deck(): [Suit; :]
+{
+	return [Suit.Hearts, Suit.Diamonds, Suit.Clubs, Suit.Spades];
+}

--- a/src/tests/test-src/modules/test-enum-mod-qualified.syntran
+++ b/src/tests/test-src/modules/test-enum-mod-qualified.syntran
@@ -1,0 +1,19 @@
+// Test qualified enum export from module (mod::EnumName.Variant and
+// mod::EnumName(ordinal) syntax), including qualified fn calls returning/
+// taking the enum and enum arrays
+
+use enum_mod;
+
+let s1 = enum_mod::Suit.Hearts;
+let ok1 = enum_mod::is_red(s1);
+
+let s2 = enum_mod::Suit(2);
+let ok2 = s2 == enum_mod::Suit.Clubs and not enum_mod::is_red(s2);
+
+let deck = enum_mod::full_deck();
+let ok3 = deck[3] == enum_mod::Suit.Spades;
+
+let hand = [enum_mod::Suit.Hearts, enum_mod::Suit(2)];
+let ok4 = hand[1] == enum_mod::Suit.Clubs;
+
+return ok1 and ok2 and ok3 and ok4;

--- a/src/tests/test-src/modules/test-enum-mod.syntran
+++ b/src/tests/test-src/modules/test-enum-mod.syntran
@@ -1,0 +1,18 @@
+// Test unqualified enum export from module: values, arrays, fn params/
+// returns, and the reverse cast, all via the imported (unqualified) name
+
+use enum_mod::*;
+
+let s1 = Suit.Hearts;
+let ok1 = is_red(s1);
+
+let s2 = Suit(2);
+let ok2 = s2 == Suit.Clubs and not is_red(s2);
+
+let deck = full_deck();
+let ok3 = deck[3] == Suit.Spades;
+
+let hand = [Suit.Hearts, Suit(2)];
+let ok4 = hand[1] == Suit.Clubs;
+
+return ok1 and ok2 and ok3 and ok4;

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -5408,6 +5408,34 @@ subroutine unit_test_enum(npass, nfail)
 				//'let x = 99; Suit(x);', bytecode = .false.), &
 				RC_ENUM_CAST_RANGE), &
 
+			! Explicit negative values, and auto-increment resuming from a
+			! negative value
+			eval( 'enum E{A=-1,B}' &
+				//'i32(E.A);', quiet) == '-1', &
+			eval( 'enum E{A=-1,B}' &
+				//'i32(E.B);', quiet) == '0', &
+			eval( 'enum E{A=-5,B,C}' &
+				//'i32(E.C);', quiet) == '-3', &
+
+			! Two variants both pinned explicitly to the same negative
+			! value are an intentional alias, not a duplicate-value error
+			.not. diag_has_code(get_diags( &
+				'enum E{A=-1,B=-1} E.A;'), &
+				EC_DUPLICATE_ENUM_VALUE), &
+			eval( 'enum E{A=-1,B=-1}' &
+				//'E.A == E.B;', quiet) == 'true', &
+
+			! str() formats by variant name regardless of a negative
+			! backing value
+			eval( 'enum E{A=-1,B}' &
+				//'str(E.A);', quiet) == 'E.A', &
+
+			! Reverse cast round-trips through a negative ordinal (runtime
+			! R32 path, since a negated literal isn't a literal_expr at
+			! parse time)
+			eval( 'enum E{A=-1,B}' &
+				//'E(-1) == E.A;', quiet) == 'true', &
+
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 
@@ -5445,6 +5473,7 @@ subroutine unit_test_enum_long(npass, nfail)
 			interpret_file(path//'test-03.syntran', quiet) == 'true', &
 			interpret_file(path//'test-04.syntran', quiet) == 'true', &
 			interpret_file(path//'test-05.syntran', quiet) == 'true', &
+			interpret_file(path//'test-06.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -5262,6 +5262,123 @@ end subroutine unit_test_methods
 
 !===============================================================================
 
+subroutine unit_test_enum(npass, nfail)
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'enums'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			! Auto-increment from 0
+			eval( 'enum Dir{North,South,East,West}' &                    ! 1
+				//'i32(Dir.North);', quiet) == '0', &
+			eval( 'enum Dir{North,South,East,West}' &                    ! 2
+				//'i32(Dir.West);', quiet) == '3', &
+
+			! Explicit value + continuation
+			eval( 'enum Card{Two,Three,Jack=10,Queen,King}' &            ! 3
+				//'i32(Card.Jack);', quiet) == '10', &
+			eval( 'enum Card{Two,Three,Jack=10,Queen,King}' &            ! 4
+				//'i32(Card.Queen);', quiet) == '11', &
+			eval( 'enum Card{Two,Three,Jack=10,Queen,King}' &            ! 5
+				//'i32(Card.King);', quiet) == '12', &
+
+			! Printing (qualified name)
+			eval( 'enum Dir{North,South}' &                              ! 6
+				//'Dir.North;', quiet) == 'Dir.North', &
+			eval( 'enum Dir{North,South}' &                              ! 7
+				//'str(Dir.South);', quiet) == 'Dir.South', &
+
+			! Equality/inequality
+			eval( 'enum Dir{North,South}' &                              ! 8
+				//'Dir.North == Dir.North;', quiet) == 'true', &
+			eval( 'enum Dir{North,South}' &                              ! 9
+				//'Dir.North == Dir.South;', quiet) == 'false', &
+			eval( 'enum Dir{North,South}' &                              ! 10
+				//'Dir.North != Dir.South;', quiet) == 'true', &
+
+			! Array indexing via i32() cast
+			eval( 'enum Suit{Hearts,Diamonds,Clubs,Spades}' &            ! 11
+				//'let a = [10,20,30,40];' &
+				//'a[i32(Suit.Clubs)];', quiet) == '30', &
+
+			! let-bound variable retains type across statements
+			eval( 'enum Dir{North,South}' &                              ! 12
+				//'let d = Dir.North;' &
+				//'d == Dir.North;', quiet) == 'true', &
+
+			! fn param/return
+			eval( 'enum Dir{North,South}' &                              ! 13
+				//'fn other(d: Dir): Dir {' &
+				//'    if d == Dir.North { return Dir.South; }' &
+				//'    return Dir.North;' &
+				//'}' &
+				//'other(Dir.North) == Dir.South;', quiet) == 'true', &
+
+			! Two different enums are not interchangeable
+			diag_has_code(get_diags( &
+				'enum Dir{N,S} enum Sig{N,S} Dir.N == Sig.N;'), &
+				EC_BINARY_TYPES), &
+			diag_has_code(get_diags( &
+				'enum Dir{N,S} enum Sig{N,S} fn f(x: Dir): void {} f(Sig.N);'), &
+				EC_BAD_ARG_TYPE), &
+
+			.false.  & ! so I don't have to bother w/ trailing commas
+		]
+
+	! Trim dummy false element
+	tests = tests(1: size(tests) - 1)
+
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_enum
+
+!===============================================================================
+
+subroutine unit_test_enum_long(npass, nfail)
+
+	implicit none
+
+	integer, intent(inout) :: npass, nfail
+
+	!********
+
+	character(len = *), parameter :: label = 'enum scripts'
+
+	! Path to syntran test files from root of repo
+	character(len = *), parameter :: path = 'src/tests/test-src/enum/'
+
+	logical, parameter :: quiet = .true.
+	logical, allocatable :: tests(:)
+
+	write(*,*) 'Unit testing '//label//' ...'
+
+	tests = &
+		[   &
+			interpret_file(path//'test-01.syntran', quiet) == 'true', &
+			interpret_file(path//'test-02.syntran', quiet) == 'true', &
+			.false.  & ! so I don't have to bother w/ trailing commas
+		]
+
+	! Trim dummy false element
+	tests = tests(1: size(tests) - 1)
+
+	call unit_test_coda(tests, label, npass, nfail)
+
+end subroutine unit_test_enum_long
+
+!===============================================================================
+
 subroutine unit_test_bitwise_2(npass, nfail)
 
 	implicit none
@@ -6207,6 +6324,34 @@ subroutine unit_test_error_codes(npass, nfail)
 				'fn g(x: i32): i32 { return x; } fn f() { let y = 1; } g(f());'), &
 				EC_VOID_ARG), &
 
+			! E92: an enum was declared twice
+			diag_has_code(get_diags( &
+				'enum Dir{North,South} enum Dir{East,West}'), &
+				EC_REDECLARE_ENUM), &
+			diag_count_code(get_diags( &
+				'enum Dir{North,South} enum Dir{East,West}'), &
+				EC_REDECLARE_ENUM) == 1, &
+
+			! E93: a variant was declared twice in the same enum
+			diag_has_code(get_diags( &
+				'enum Dir{North,North}'), &
+				EC_REDECLARE_VARIANT), &
+			diag_count_code(get_diags( &
+				'enum Dir{North,North}'), &
+				EC_REDECLARE_VARIANT) == 1, &
+
+			! E94: a dot expression referenced a variant that doesn't exist
+			diag_has_code(get_diags( &
+				'enum Dir{North,South} let d = Dir.Nrth;'), &
+				EC_UNKNOWN_VARIANT), &
+			diag_count_code(get_diags( &
+				'enum Dir{North,South} let d = Dir.Nrth;'), &
+				EC_UNKNOWN_VARIANT) == 1, &
+			! positive: a valid variant is unaffected
+			.not. diag_has_code(get_diags( &
+				'enum Dir{North,South} let d = Dir.North;'), &
+				EC_UNKNOWN_VARIANT), &
+
 			! 4. direct constructor / prefix-helper spot checks.  RC_MATMUL_DIM
 			! is no longer spot-checked here since it's tested end-to-end (under
 			! both backends) in unit_test_runtime_errors() below
@@ -6637,7 +6782,19 @@ subroutine unit_test_error_locations(npass, nfail)
 			diag_loc_ok(get_diags_file(P//'E91-void-arg.syntran'), &
 				EC_VOID_ARG, P//'E91-void-arg.syntran', 9, 9, 3), &
 			diag_count_code(get_diags_file(P//'E91-void-arg.syntran'), &
-				EC_VOID_ARG) == 1 &
+				EC_VOID_ARG) == 1, &
+			diag_loc_ok(get_diags_file(P//'E92-redeclare-enum.syntran'), &
+				EC_REDECLARE_ENUM, P//'E92-redeclare-enum.syntran', 10, 6, 3), &
+			diag_count_code(get_diags_file(P//'E92-redeclare-enum.syntran'), &
+				EC_REDECLARE_ENUM) == 1, &
+			diag_loc_ok(get_diags_file(P//'E93-redeclare-variant.syntran'), &
+				EC_REDECLARE_VARIANT, P//'E93-redeclare-variant.syntran', 7, 2, 6), &
+			diag_count_code(get_diags_file(P//'E93-redeclare-variant.syntran'), &
+				EC_REDECLARE_VARIANT) == 1, &
+			diag_loc_ok(get_diags_file(P//'E94-unknown-variant.syntran'), &
+				EC_UNKNOWN_VARIANT, P//'E94-unknown-variant.syntran', 10, 13, 4), &
+			diag_count_code(get_diags_file(P//'E94-unknown-variant.syntran'), &
+				EC_UNKNOWN_VARIANT) == 1 &
 		]
 
 	call unit_test_coda(tests, label, npass, nfail)
@@ -6849,6 +7006,8 @@ subroutine unit_tests(iostat)
 	call unit_test_struct_str (npass, nfail)
 	call unit_test_struct_long(npass, nfail)
 	call unit_test_methods    (npass, nfail)
+	call unit_test_enum       (npass, nfail)
+	call unit_test_enum_long  (npass, nfail)
 	call unit_test_f64_mix    (npass, nfail)
 	call unit_test_literals   (npass, nfail)
 	call unit_test_bitwise    (npass, nfail)

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -5474,6 +5474,7 @@ subroutine unit_test_enum_long(npass, nfail)
 			interpret_file(path//'test-04.syntran', quiet) == 'true', &
 			interpret_file(path//'test-05.syntran', quiet) == 'true', &
 			interpret_file(path//'test-06.syntran', quiet) == 'true', &
+			interpret_file(path//'test-07.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -5342,6 +5342,38 @@ subroutine unit_test_enum(npass, nfail)
 			eval( 'enum Card{Jack=10,King=10}' &
 				//'Card.King == Card.Jack;', quiet) == 'true', &
 
+			! Named alias, `King = Jack`, referencing a prior auto-
+			! incremented variant.  Also not a duplicate-value error
+			.not. diag_has_code(get_diags( &
+				'enum Card{Two,Three,Jack,Queen,King=Jack} Card.King;'), &
+				EC_DUPLICATE_ENUM_VALUE), &
+			eval( 'enum Card{Two,Three,Jack,Queen,King=Jack}' &
+				//'Card.King == Card.Jack;', quiet) == 'true', &
+			eval( 'enum Card{Two,Three,Jack,Queen,King=Jack}' &
+				//'i32(Card.King);', quiet) == '2', &
+
+			! Auto-increment resumes from an aliased value, not from
+			! where it would have been without the alias
+			eval( 'enum E{A,B=10,C=A,D}' &
+				//'i32(E.C);', quiet) == '0', &
+			eval( 'enum E{A,B=10,C=A,D}' &
+				//'i32(E.D);', quiet) == '1', &
+
+			! Named alias to an explicitly-pinned variant
+			eval( 'enum E{A=5,B=A}' &
+				//'i32(E.B);', quiet) == '5', &
+
+			! Forward reference (alias to a variant declared below it) is
+			! an unknown-variant error, not resolved
+			diag_has_code(get_diags( &
+				'enum E{A=B,B} i32(E.A);'), &
+				EC_UNKNOWN_VARIANT), &
+
+			! Alias to a name that doesn't exist in the enum at all
+			diag_has_code(get_diags( &
+				'enum E{A,B=Zz} i32(E.B);'), &
+				EC_UNKNOWN_VARIANT), &
+
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 
@@ -5376,6 +5408,7 @@ subroutine unit_test_enum_long(npass, nfail)
 		[   &
 			interpret_file(path//'test-01.syntran', quiet) == 'true', &
 			interpret_file(path//'test-02.syntran', quiet) == 'true', &
+			interpret_file(path//'test-03.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -5374,6 +5374,40 @@ subroutine unit_test_enum(npass, nfail)
 				'enum E{A,B=Zz} i32(E.B);'), &
 				EC_UNKNOWN_VARIANT), &
 
+			! Reverse cast from i32 to enum
+			eval( 'enum Suit{Hearts,Diamonds,Clubs,Spades}' &
+				//'Suit(2) == Suit.Clubs;', quiet) == 'true', &
+			eval( 'enum Suit{Hearts,Diamonds,Clubs,Spades}' &
+				//'Suit(i32(Suit.Spades)) == Suit.Spades;', quiet) == 'true', &
+			eval( 'enum Suit{Hearts,Diamonds,Clubs,Spades}' &
+				//'str(Suit(1));', quiet) == 'Suit.Diamonds', &
+
+			! Reverse cast picks the variant by explicit value, not position
+			eval( 'enum Card{Two,Three,Jack=10,Queen,King}' &
+				//'Card(11) == Card.Queen;', quiet) == 'true', &
+
+			! Reverse cast with a non-i32 argument is a parse-time type error
+			diag_has_code(get_diags( &
+				'enum Suit{Hearts,Clubs} Suit("x");'), &
+				EC_BAD_ARG_TYPE), &
+
+			! Reverse cast with an out-of-range constant literal is a
+			! parse-time error (E96)
+			diag_has_code(get_diags( &
+				'enum Suit{Hearts,Diamonds,Clubs,Spades} Suit(99);'), &
+				EC_ENUM_CAST_RANGE), &
+
+			! Reverse cast with an out-of-range non-literal ordinal is a
+			! runtime error (R32), on both backends
+			diag_has_code(get_diags( &
+				'enum Suit{Hearts,Diamonds,Clubs,Spades}' &
+				//'let x = 99; Suit(x);', bytecode = .true.), &
+				RC_ENUM_CAST_RANGE), &
+			diag_has_code(get_diags( &
+				'enum Suit{Hearts,Diamonds,Clubs,Spades}' &
+				//'let x = 99; Suit(x);', bytecode = .false.), &
+				RC_ENUM_CAST_RANGE), &
+
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 
@@ -5409,6 +5443,8 @@ subroutine unit_test_enum_long(npass, nfail)
 			interpret_file(path//'test-01.syntran', quiet) == 'true', &
 			interpret_file(path//'test-02.syntran', quiet) == 'true', &
 			interpret_file(path//'test-03.syntran', quiet) == 'true', &
+			interpret_file(path//'test-04.syntran', quiet) == 'true', &
+			interpret_file(path//'test-05.syntran', quiet) == 'true', &
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 
@@ -5577,6 +5613,8 @@ subroutine unit_test_modules(npass, nfail)
 			interpret_file(path//'test-struct-collision.syntran', quiet) == 'true', &
 			interpret_file(path//'test-struct-collision-rev.syntran', quiet) == 'true', &
 			interpret_file(path//'test-struct-transitive.syntran', quiet) == 'true', &
+			interpret_file(path//'test-enum-mod.syntran', quiet) == 'true', &
+			interpret_file(path//'test-enum-mod-qualified.syntran', quiet) == 'true', &
 			interpret_file(path//'test-circular.syntran', quiet) == '', &
 			interpret_file(path//'test-duplicate-import.syntran', quiet) == '', &
 			interpret_file(path//'test-duplicate-alias.syntran', quiet) == '', &
@@ -6410,6 +6448,19 @@ subroutine unit_test_error_codes(npass, nfail)
 				'enum Card{Jack=10,King=10}'), &
 				EC_DUPLICATE_ENUM_VALUE), &
 
+			! E96: reverse cast EnumName(ordinal) with a constant literal
+			! ordinal that doesn't match any variant
+			diag_has_code(get_diags( &
+				'enum Dir{North,South} Dir(99);'), &
+				EC_ENUM_CAST_RANGE), &
+			diag_count_code(get_diags( &
+				'enum Dir{North,South} Dir(99);'), &
+				EC_ENUM_CAST_RANGE) == 1, &
+			! positive: a valid ordinal is unaffected
+			.not. diag_has_code(get_diags( &
+				'enum Dir{North,South} Dir(1);'), &
+				EC_ENUM_CAST_RANGE), &
+
 			! 4. direct constructor / prefix-helper spot checks.  RC_MATMUL_DIM
 			! is no longer spot-checked here since it's tested end-to-end (under
 			! both backends) in unit_test_runtime_errors() below
@@ -6856,7 +6907,11 @@ subroutine unit_test_error_locations(npass, nfail)
 			diag_loc_ok(get_diags_file(P//'E95-duplicate-enum-value.syntran'), &
 				EC_DUPLICATE_ENUM_VALUE, P//'E95-duplicate-enum-value.syntran', 14, 2, 4), &
 			diag_count_code(get_diags_file(P//'E95-duplicate-enum-value.syntran'), &
-				EC_DUPLICATE_ENUM_VALUE) == 1 &
+				EC_DUPLICATE_ENUM_VALUE) == 1, &
+			diag_loc_ok(get_diags_file(P//'E96-enum-cast-range.syntran'), &
+				EC_ENUM_CAST_RANGE, P//'E96-enum-cast-range.syntran', 11, 13, 2), &
+			diag_count_code(get_diags_file(P//'E96-enum-cast-range.syntran'), &
+				EC_ENUM_CAST_RANGE) == 1 &
 		]
 
 	call unit_test_coda(tests, label, npass, nfail)

--- a/src/tests/test.f90
+++ b/src/tests/test.f90
@@ -5333,6 +5333,15 @@ subroutine unit_test_enum(npass, nfail)
 				'enum Dir{N,S} enum Sig{N,S} fn f(x: Dir): void {} f(Sig.N);'), &
 				EC_BAD_ARG_TYPE), &
 
+			! Two variants that are both pinned explicitly to the same
+			! value are an intentional alias (not a duplicate-value
+			! error), and compare equal at runtime
+			.not. diag_has_code(get_diags( &
+				'enum Card{Jack=10,King=10} Card.King == Card.Jack;'), &
+				EC_DUPLICATE_ENUM_VALUE), &
+			eval( 'enum Card{Jack=10,King=10}' &
+				//'Card.King == Card.Jack;', quiet) == 'true', &
+
 			.false.  & ! so I don't have to bother w/ trailing commas
 		]
 
@@ -6352,6 +6361,22 @@ subroutine unit_test_error_codes(npass, nfail)
 				'enum Dir{North,South} let d = Dir.North;'), &
 				EC_UNKNOWN_VARIANT), &
 
+			! E95: duplicate enum values are a hard error unless both
+			! variants sharing the value are pinned explicitly (an
+			! intentional alias) -- any collision involving an
+			! auto-incremented value is always accidental
+			diag_has_code(get_diags( &
+				'enum Card{Jack=10,Queen,King=10,Ace}'), &
+				EC_DUPLICATE_ENUM_VALUE), &
+			diag_count_code(get_diags( &
+				'enum Card{Jack=10,Queen,King=10,Ace}'), &
+				EC_DUPLICATE_ENUM_VALUE) == 1, &
+			! positive: two variants both pinned explicitly to the same
+			! value is an intentional alias, not an error
+			.not. diag_has_code(get_diags( &
+				'enum Card{Jack=10,King=10}'), &
+				EC_DUPLICATE_ENUM_VALUE), &
+
 			! 4. direct constructor / prefix-helper spot checks.  RC_MATMUL_DIM
 			! is no longer spot-checked here since it's tested end-to-end (under
 			! both backends) in unit_test_runtime_errors() below
@@ -6794,7 +6819,11 @@ subroutine unit_test_error_locations(npass, nfail)
 			diag_loc_ok(get_diags_file(P//'E94-unknown-variant.syntran'), &
 				EC_UNKNOWN_VARIANT, P//'E94-unknown-variant.syntran', 10, 13, 4), &
 			diag_count_code(get_diags_file(P//'E94-unknown-variant.syntran'), &
-				EC_UNKNOWN_VARIANT) == 1 &
+				EC_UNKNOWN_VARIANT) == 1, &
+			diag_loc_ok(get_diags_file(P//'E95-duplicate-enum-value.syntran'), &
+				EC_DUPLICATE_ENUM_VALUE, P//'E95-duplicate-enum-value.syntran', 14, 2, 4), &
+			diag_count_code(get_diags_file(P//'E95-duplicate-enum-value.syntran'), &
+				EC_DUPLICATE_ENUM_VALUE) == 1 &
 		]
 
 	call unit_test_coda(tests, label, npass, nfail)

--- a/src/types.f90
+++ b/src/types.f90
@@ -327,6 +327,65 @@ module syntran__types_m
 
 	!********
 
+	type enum_t
+		! User-defined enumeration: a named integer constant ("variant") per
+		! entry.  Variants are compile-time constants, so unlike struct_t
+		! there is no vars_t of member types -- just parallel arrays of
+		! variant names and their backing i32 values
+
+		type(string_vector_t) :: variant_names
+		integer, allocatable :: variant_values(:)  ! parallel to variant_names
+		integer :: num_vars = 0
+
+		! Canonical, alias-independent identity: "<defining src file>::<local
+		! enum name>", set once at declaration time. c.f. value_t%enum_cookie
+		character(len = :), allocatable :: cookie
+
+		contains
+			! This is also required unfortunately
+#ifndef SYNTRAN_INTEL
+			procedure, pass(dst) :: copy => enum_copy
+			generic, public :: assignment(=) => copy
+#endif
+
+	end type enum_t
+
+	!********
+
+	type enum_entry_t
+		! One slot of the enums_t hash table.  An unallocated `key` marks an
+		! empty (never-used) slot
+
+		character(len = :), allocatable :: key
+		type(enum_t), allocatable :: val
+		integer :: id_index = 0
+
+	end type enum_entry_t
+
+	!********
+
+	type enums_t
+
+		! Open-addressing hash table (FNV-1a + linear probing), mirroring
+		! structs_t, mapping enum name -> enum_t
+
+		type(enum_entry_t), allocatable :: table(:)
+		integer :: capacity = 0, count = 0
+		real :: load_factor_threshold = 0.75
+
+		contains
+			procedure :: &
+				insert  => enum_insert, &
+				find    => enum_find, &
+				get     => enum_get, &
+				id_at   => enum_id_at, &
+				exists  => enum_exists, &
+				closest => enum_closest
+
+	end type enums_t
+
+	!********
+
 	type syntax_token_vector_t
 		type(syntax_token_t), allocatable :: v(:)
 		integer :: len_, cap
@@ -372,6 +431,11 @@ module syntran__types_m
 			class(struct_t), intent(inout) :: dst
 			class(struct_t), intent(in)    :: src
 		end subroutine struct_copy
+
+		recursive module subroutine enum_copy(dst, src)
+			class(enum_t), intent(inout) :: dst
+			class(enum_t), intent(in)    :: src
+		end subroutine enum_copy
 
 		recursive module subroutine fn_copy(dst, src)
 			class(fn_t), intent(inout) :: dst
@@ -551,6 +615,47 @@ module syntran__types_m
 			character(len = :), allocatable :: closest
 		end function struct_closest
 
+		module subroutine enum_insert(dict, key, val, id_index, iostat, overwrite)
+			class(enums_t) :: dict
+			character(len = *), intent(in) :: key
+			type(enum_t), intent(in) :: val
+			integer, intent(inout) :: id_index
+			integer, intent(out), optional :: iostat
+			logical, intent(in), optional :: overwrite
+		end subroutine enum_insert
+
+		module function enum_find(dict, key) result(slot)
+			! Returns the table slot for `key`, or 0 if not present.  Mirrors
+			! struct_find() -- see its comment for slot validity caveats
+			class(enums_t), intent(in) :: dict
+			character(len = *), intent(in) :: key
+			integer :: slot
+		end function enum_find
+
+		module function enum_get(dict, slot) result(val)
+			class(enums_t), intent(in), target :: dict
+			integer, intent(in) :: slot
+			type(enum_t), pointer :: val
+		end function enum_get
+
+		module function enum_id_at(dict, slot) result(id_index)
+			class(enums_t), intent(in) :: dict
+			integer, intent(in) :: slot
+			integer :: id_index
+		end function enum_id_at
+
+		module function enum_exists(dict, key) result(exists)
+			class(enums_t), intent(in) :: dict
+			character(len = *), intent(in) :: key
+			logical :: exists
+		end function enum_exists
+
+		module function enum_closest(dict, key) result(closest)
+			class(enums_t), intent(in) :: dict
+			character(len = *), intent(in) :: key
+			character(len = :), allocatable :: closest
+		end function enum_closest
+
 		!***************************************
 		! types_ops.f90 procedures
 		!***************************************
@@ -566,9 +671,10 @@ module syntran__types_m
 			integer, optional, intent(in) :: ou
 		end subroutine log_diagnostics
 
-		module integer function lookup_type(name, structs, cookie) result(type)
+		module integer function lookup_type(name, structs, enums, cookie) result(type)
 			character(len = *), intent(in) :: name
 			type(structs_t), intent(in), target :: structs
+			type(enums_t), intent(in), target :: enums
 			character(len = :), allocatable, intent(out), optional :: cookie
 		end function lookup_type
 

--- a/src/types.f90
+++ b/src/types.f90
@@ -8,6 +8,7 @@ module syntran__types_m
 	implicit none
 
 	integer, parameter :: &
+		TYPE_ARRAY_ENUM_MISMATCH = 6, &
 		TYPE_ARRAY_STRUCT_MISMATCH = 5, &
 		TYPE_RANK_MISMATCH = 4, &
 		TYPE_ARRAY_MISMATCH = 3, &

--- a/src/types_copy.f90
+++ b/src/types_copy.f90
@@ -111,6 +111,32 @@ end subroutine struct_copy
 
 !===============================================================================
 
+recursive module subroutine enum_copy(dst, src)
+
+	! Deep copy.  This overwrites dst with src
+
+	class(enum_t), intent(inout) :: dst
+	class(enum_t), intent(in)    :: src
+
+	dst%variant_names = src%variant_names
+	dst%num_vars      = src%num_vars
+
+	if (allocated(src%variant_values)) then
+		dst%variant_values = src%variant_values
+	else if (allocated(dst%variant_values)) then
+		deallocate(dst%variant_values)
+	end if
+
+	if (allocated(src%cookie)) then
+		dst%cookie = src%cookie
+	else if (allocated(dst%cookie)) then
+		deallocate(dst%cookie)
+	end if
+
+end subroutine enum_copy
+
+!===============================================================================
+
 recursive module subroutine fn_copy(dst, src)
 
 	! Deep copy.  This overwrites dst with src

--- a/src/types_dict.f90
+++ b/src/types_dict.f90
@@ -879,6 +879,242 @@ end function struct_closest
 
 !===============================================================================
 
+subroutine enum_grow(dict)
+
+	! Double dict%table's capacity (or allocate an initial table) and rehash
+	! all existing entries into it.  Mirrors struct_grow()
+
+	class(enums_t) :: dict
+
+	!********
+
+	type(enum_entry_t), allocatable :: old_table(:)
+	integer :: old_capacity, i, new_capacity
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	old_capacity = dict%capacity
+	new_capacity = max(2 * old_capacity, 8)
+
+	if (old_capacity > 0) call move_alloc(dict%table, old_table)
+
+	dict%capacity = new_capacity
+	allocate(dict%table(new_capacity))
+	! dict%count is unchanged -- rehashing doesn't add or remove entries
+
+	do i = 1, old_capacity
+		if (.not. allocated(old_table(i)%key)) cycle
+
+		hash_val = fnv_1a(old_table(i)%key)
+		hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+		do probe = 0, dict%capacity - 1
+			idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+			if (.not. allocated(dict%table(idx)%key)) then
+				call move_alloc(old_table(i)%key, dict%table(idx)%key)
+				call move_alloc(old_table(i)%val, dict%table(idx)%val)
+				dict%table(idx)%id_index = old_table(i)%id_index
+				exit
+			end if
+		end do
+	end do
+
+end subroutine enum_grow
+
+!===============================================================================
+
+module function enum_find(dict, key) result(slot)
+
+	! Returns the table slot for `key`, or 0 if not present.  Mirrors
+	! struct_find() -- see its comment for slot validity caveats
+
+	class(enums_t), intent(in) :: dict
+	character(len = *), intent(in) :: key
+
+	integer :: slot
+
+	!********
+
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx
+
+	slot = 0
+
+	if (dict%capacity <= 0) return
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot => key not present
+			return
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			slot = idx
+			return
+		end if
+	end do
+
+end function enum_find
+
+!===============================================================================
+
+module function enum_get(dict, slot) result(val)
+
+	class(enums_t), intent(in), target :: dict
+	integer, intent(in) :: slot
+
+	type(enum_t), pointer :: val
+
+	val => dict%table(slot)%val
+
+end function enum_get
+
+!===============================================================================
+
+module function enum_id_at(dict, slot) result(id_index)
+
+	class(enums_t), intent(in) :: dict
+	integer, intent(in) :: slot
+
+	integer :: id_index
+
+	id_index = dict%table(slot)%id_index
+
+end function enum_id_at
+
+!===============================================================================
+
+module function enum_exists(dict, key) result(exists)
+
+	! Check if a key exists, without going through get() like other callers do
+
+	class(enums_t), intent(in) :: dict
+	character(len = *), intent(in) :: key
+	logical :: exists
+
+	exists = enum_find(dict, key) > 0
+
+end function enum_exists
+
+!===============================================================================
+
+module subroutine enum_insert(dict, key, val, id_index, iostat, overwrite)
+
+	class(enums_t) :: dict
+	character(len = *), intent(in) :: key
+	type(enum_t), intent(in) :: val
+	integer, intent(inout) :: id_index
+
+	integer, intent(out), optional :: iostat
+	logical, intent(in), optional :: overwrite
+
+	!********
+
+	integer(int64) :: hash_val
+	integer :: hash_idx, probe, idx, io
+	logical :: overwritel
+
+	id_index = id_index + 1
+
+	! Note that this is different than the fn insert default.  Re-declared
+	! enums are caught in the caller (in parse_enum_declaration())
+	overwritel = .true.
+	if (present(overwrite)) overwritel = overwrite
+
+	io = exit_success
+
+	! Two separate `if`s rather than one `.or.` expression -- see the
+	! identical comment in fn_insert() above for why
+	if (dict%capacity <= 0) then
+		call enum_grow(dict)
+	else if (real(dict%count) / real(dict%capacity) >= dict%load_factor_threshold) then
+		call enum_grow(dict)
+	end if
+
+	hash_val = fnv_1a(key)
+	hash_idx = int(modulo(hash_val, int(dict%capacity, int64)) + 1)
+
+	do probe = 0, dict%capacity - 1
+		idx = modulo(hash_idx + probe - 1, dict%capacity) + 1
+
+		if (.not. allocated(dict%table(idx)%key)) then
+			! Empty slot - insert new entry.  enum_t has a defined
+			! assignment(=) (enum_copy), which -- unlike intrinsic
+			! assignment -- does not auto-allocate an unallocated allocatable
+			! target, so val must be explicitly allocated first
+			dict%table(idx)%key = key
+			if (.not. allocated(dict%table(idx)%val)) allocate(dict%table(idx)%val)
+			dict%table(idx)%val = val
+			dict%table(idx)%id_index = id_index
+			dict%count = dict%count + 1
+			exit
+		else if (is_str_eq(dict%table(idx)%key, key)) then
+			! Key already inserted
+			if (.not. overwritel) then
+				io = exit_failure
+				exit
+			end if
+			if (.not. allocated(dict%table(idx)%val)) allocate(dict%table(idx)%val)
+			dict%table(idx)%val = val
+			dict%table(idx)%id_index = id_index
+			exit
+		end if
+	end do
+
+	if (present(iostat)) iostat = io
+
+end subroutine enum_insert
+
+!===============================================================================
+
+module function enum_closest(dict, key) result(closest)
+
+	! Return the closest declared enum name to `key`, or "" when none is
+	! close enough.  Mirrors struct_closest()
+
+	class(enums_t), intent(in) :: dict
+	character(len = *), intent(in) :: key
+	character(len = :), allocatable :: closest
+
+	!********
+
+	integer :: i, min_dist, min_qdist, threshold, dist, qdist
+	character(len = :), allocatable :: target_low, target_unqual_low, &
+		key_, key_low, key_unqual
+
+	closest           = ""
+	min_dist          = huge(min_dist)
+	min_qdist         = huge(min_qdist)
+	target_low        = to_lower(key)
+	target_unqual_low = to_lower(unqualified_name(key))
+
+	do i = 1, dict%capacity
+		if (.not. allocated(dict%table(i)%key)) cycle
+
+		key_ = dict%table(i)%key
+		key_low = to_lower(key_)
+		if (key_low == target_low) cycle
+
+		key_unqual = unqualified_name(key_)
+		dist  = levenshtein(target_unqual_low, to_lower(key_unqual))
+		qdist = levenshtein(target_low, key_low)
+		if (dist < min_dist .or. (dist == min_dist .and. qdist < min_qdist)) then
+			min_dist  = dist
+			min_qdist = qdist
+			closest   = key_
+		end if
+	end do
+
+	threshold = max(2, len(target_unqual_low) / 3)
+	if (min_dist > threshold) closest = ""
+
+end function enum_closest
+
+!===============================================================================
+
 ! ternary_closest() was here.  var_dict_t is now a flat hash table, so
 ! var_closest() below scans dict%dicts(i)%table(:) directly, mirroring
 ! fn_closest()'s scan of fns_t's single table

--- a/src/types_ops.f90
+++ b/src/types_ops.f90
@@ -160,18 +160,20 @@ end subroutine log_diagnostics
 
 !===============================================================================
 
-module integer function lookup_type(name, structs, cookie) result(type)
+module integer function lookup_type(name, structs, enums, cookie) result(type)
 
 	character(len = *), intent(in) :: name
 
 	type(structs_t), intent(in), target :: structs
+	type(enums_t), intent(in), target :: enums
 
 	character(len = :), allocatable, intent(out), optional :: cookie
 
 	!********
 
-	integer :: struct_id
+	integer :: struct_id, enum_id
 	type(struct_t), pointer :: struct_ptr
+	type(enum_t), pointer :: enum_ptr
 
 	! Immo also has an "any" type.  Should I allow that?
 
@@ -195,7 +197,8 @@ module integer function lookup_type(name, structs, cookie) result(type)
 		case default
 
 			if (present(cookie)) then
-				! Cookie is requested, so we need the actual struct_t pointer
+				! Cookie is requested, so we need the actual struct_t/enum_t
+				! pointer
 				struct_id = structs%find(name)
 
 				if (struct_id > 0) then
@@ -204,13 +207,22 @@ module integer function lookup_type(name, structs, cookie) result(type)
 					cookie = struct_ptr%cookie
 					!print *, "struct num vars = ", struct_ptr%num_vars
 				else
-					type = unknown_type
+					enum_id = enums%find(name)
+					if (enum_id > 0) then
+						type = enum_type
+						enum_ptr => enums%get(enum_id)
+						cookie = enum_ptr%cookie
+					else
+						type = unknown_type
+					end if
 				end if
 			else
 				! Cheap existence check, without copying/pointing to the
-				! struct_t like search() does
+				! struct_t/enum_t like search() does
 				if (structs%exists(name)) then
 					type = struct_type
+				else if (enums%exists(name)) then
+					type = enum_type
 				else
 					type = unknown_type
 				end if
@@ -269,6 +281,9 @@ module integer function get_keyword_kind(text) result(kind)
 		case ("struct")
 			kind = struct_keyword
 
+		case ("enum")
+			kind = enum_keyword
+
 		case ("include")
 			kind = include_keyword
 
@@ -324,7 +339,7 @@ module logical function is_identifier_or_keyword(kind)
 	is_identifier_or_keyword = kind == identifier_token .or. any(kind == [ &
 		true_keyword, false_keyword, not_keyword, and_keyword, or_keyword, &
 		let_keyword, if_keyword, else_keyword, for_keyword, in_keyword, &
-		while_keyword, fn_keyword, struct_keyword, include_keyword, &
+		while_keyword, fn_keyword, struct_keyword, enum_keyword, include_keyword, &
 		return_keyword, break_keyword, continue_keyword, use_keyword &
 	])
 
@@ -964,6 +979,14 @@ recursive module integer function types_match(a, b) result(io)
 		end if
 	end if
 
+	if (a%type == enum_type) then
+		if (enum_kind_mismatch(a, b)) then
+			! Both are enums but different kinds of enums
+			io = TYPE_MISMATCH
+			return
+		end if
+	end if
+
 	if (a%type == array_type) then
 
 		if (.not. (a%array%type == any_type .or. a%array%type == b%array%type)) then
@@ -1043,6 +1066,24 @@ logical function struct_kind_mismatch(a, b) result(mismatch)
 	end if
 
 end function struct_kind_mismatch
+
+!===============================================================================
+
+logical function enum_kind_mismatch(a, b) result(mismatch)
+
+	! Check whether two enum values are different kinds of enums.  Mirrors
+	! struct_kind_mismatch() -- prefer the alias-independent enum_cookie,
+	! falling back to enum_name if either side lacks a cookie
+
+	type(value_t), intent(in) :: a, b
+
+	if (allocated(a%enum_cookie) .and. allocated(b%enum_cookie)) then
+		mismatch = a%enum_cookie /= b%enum_cookie
+	else
+		mismatch = a%enum_name /= b%enum_name
+	end if
+
+end function enum_kind_mismatch
 
 !===============================================================================
 

--- a/src/types_ops.f90
+++ b/src/types_ops.f90
@@ -1009,6 +1009,14 @@ recursive module integer function types_match(a, b) result(io)
 			end if
 		end if
 
+		if (a%array%type == enum_type) then
+			if (enum_kind_mismatch(a, b)) then
+				! Both are arrays of enums but different kinds of enums
+				io = TYPE_ARRAY_ENUM_MISMATCH
+				return
+			end if
+		end if
+
 	end if
 
 	if (a%type == fn_type) then

--- a/src/value.f90
+++ b/src/value.f90
@@ -335,7 +335,8 @@ subroutine value_reset(val)
 		! deallocation of that doesn't reliably free every level (same bug
 		! already fixed piecewise in value_copy()/array_copy() and
 		! eval_fn_call()'s locs teardown). value_destroy() clears every
-		! level explicitly, including str/file_/struct_name/struct_cookie
+		! level explicitly, including str/file_/struct_name/struct_cookie/
+		! enum_name/enum_variant/enum_cookie
 		call value_destroy(val)
 		val%type = unknown_type
 	end select
@@ -718,6 +719,9 @@ recursive subroutine value_destroy(val)
 	if (allocated(val%file_)) deallocate(val%file_)
 	if (allocated(val%struct_name)) deallocate(val%struct_name)
 	if (allocated(val%struct_cookie)) deallocate(val%struct_cookie)
+	if (allocated(val%enum_name)) deallocate(val%enum_name)
+	if (allocated(val%enum_variant)) deallocate(val%enum_variant)
+	if (allocated(val%enum_cookie)) deallocate(val%enum_cookie)
 
 	if (allocated(val%array)) then
 		call array_destroy(val%array)

--- a/src/value.f90
+++ b/src/value.f90
@@ -133,6 +133,22 @@ module syntran__value_m
 		! import path
 		character(len = :), allocatable :: struct_cookie
 
+		! Enum type name, e.g. "Dir", used when value%type == enum_type.
+		! Mirrors struct_name's role for type-descriptor rendering (fn param/
+		! return types, etc.)
+		character(len = :), allocatable :: enum_name
+
+		! Enum variant name, e.g. "North", for an actual enum value (as
+		! opposed to a bare enum type descriptor, which leaves this
+		! unallocated).  Printed as "<enum_name>.<enum_variant>".  The
+		! backing i32 ordinal is stored in sca%i32
+		character(len = :), allocatable :: enum_variant
+
+		! Canonical, alias-independent enum identity: "<defining src
+		! file>::<local enum name>".  Used for type matching, mirroring
+		! struct_cookie above
+		character(len = :), allocatable :: enum_cookie
+
 		! Fn pointer signature, used when value%type == fn_type.  fn_params(i)
 		! and fn_ret carry only the *type* of each param/return (like fn_t%params
 		! /fn_t%type in types.f90), not runtime values -- used for type-checking
@@ -363,6 +379,12 @@ recursive subroutine value_move(src, dst)
 		if (allocated(src%struct_cookie)) call move_alloc(src%struct_cookie, dst%struct_cookie)
 		call move_alloc(src%struct, dst%struct)
 
+	case (enum_type)
+		dst%sca = src%sca   ! the backing i32 ordinal rides along here
+		call move_alloc(src%enum_name, dst%enum_name)
+		if (allocated(src%enum_variant)) call move_alloc(src%enum_variant, dst%enum_variant)
+		if (allocated(src%enum_cookie)) call move_alloc(src%enum_cookie, dst%enum_cookie)
+
 	case (str_type)
 		call move_alloc(src%str, dst%str)
 
@@ -571,6 +593,24 @@ recursive subroutine value_copy(dst, src)
 		dst%struct_cookie = src%struct_cookie
 	else if (allocated(dst%struct_cookie)) then
 		deallocate(dst%struct_cookie)
+	end if
+
+	if (allocated(src%enum_name)) then
+		dst%enum_name = src%enum_name
+	else if (allocated(dst%enum_name)) then
+		deallocate(dst%enum_name)
+	end if
+
+	if (allocated(src%enum_variant)) then
+		dst%enum_variant = src%enum_variant
+	else if (allocated(dst%enum_variant)) then
+		deallocate(dst%enum_variant)
+	end if
+
+	if (allocated(src%enum_cookie)) then
+		dst%enum_cookie = src%enum_cookie
+	else if (allocated(dst%enum_cookie)) then
+		deallocate(dst%enum_cookie)
 	end if
 
 	if (allocated(src%array)) then
@@ -986,6 +1026,10 @@ function value_to_i32(val) result(ans)
 		case (i64_type)
 			ans = int(val%sca%i64, 4)
 
+		case (enum_type)
+			! The backing ordinal, e.g. i32(Card.Queen) -> 11
+			ans = val%sca%i32
+
 		case (str_type)
 
 			if (allocated(val%str) .and. len(val%str%s) == 1) then
@@ -1229,6 +1273,9 @@ recursive function value_to_str(val) result(ans)
 			call str_vec%push("}")
 			ans = str_vec%trim()
 
+		case (enum_type)
+			ans = val%enum_name//"."//val%enum_variant
+
 		case (array_type)
 
 			! This whole case could be an array_to_str() fn
@@ -1464,6 +1511,8 @@ recursive function value_type_name(a) result(str_)
 
 	if (a%type == struct_type) then
 		str_ = a%struct_name
+	else if (a%type == enum_type) then
+		str_ = a%enum_name
 	else if (a%type == array_type) then
 
 		if (a%array%type == struct_type) then

--- a/src/value.f90
+++ b/src/value.f90
@@ -373,6 +373,9 @@ recursive subroutine value_move(src, dst)
 		if (allocated(src%struct)) call move_alloc(src%struct, dst%struct)
 		if (allocated(src%struct_name)) call move_alloc(src%struct_name, dst%struct_name)
 		if (allocated(src%struct_cookie)) call move_alloc(src%struct_cookie, dst%struct_cookie)
+		! Enum arrays likewise use struct(:) for elements and enum_name for type tag.
+		if (allocated(src%enum_name)) call move_alloc(src%enum_name, dst%enum_name)
+		if (allocated(src%enum_cookie)) call move_alloc(src%enum_cookie, dst%enum_cookie)
 
 	case (struct_type)
 		call move_alloc(src%struct_name, dst%struct_name)
@@ -384,6 +387,9 @@ recursive subroutine value_move(src, dst)
 		call move_alloc(src%enum_name, dst%enum_name)
 		if (allocated(src%enum_variant)) call move_alloc(src%enum_variant, dst%enum_variant)
 		if (allocated(src%enum_cookie)) call move_alloc(src%enum_cookie, dst%enum_cookie)
+		! An enum_cast_expr node's %val is enum_type but also carries a baked
+		! struct(:) of candidate variants (c.f. parse_enum_cast); move it too
+		if (allocated(src%struct)) call move_alloc(src%struct, dst%struct)
 
 	case (str_type)
 		call move_alloc(src%str, dst%str)
@@ -1435,8 +1441,8 @@ recursive function value_to_str(val) result(ans)
 
 				end do
 
-			else if (val%array%type == struct_type) then
-	
+			else if (any(val%array%type == [struct_type, enum_type])) then
+
 				n = size(val%struct)
 				do i8 = 1, n
 					! Just recurse instead of nesting a loop
@@ -1517,6 +1523,8 @@ recursive function value_type_name(a) result(str_)
 
 		if (a%array%type == struct_type) then
 			array_name = a%struct_name
+		else if (a%array%type == enum_type) then
+			array_name = a%enum_name
 		else
 			array_name = value_type_name_primitive(a%array%type)
 		end if

--- a/src/vm_exec.f90
+++ b/src/vm_exec.f90
@@ -1419,6 +1419,15 @@ module subroutine vm_run(prog, state, res)
 			call eval_array_expr(prog%nodes(instr%a), state, val)
 			call vm_push_move(stack, val)
 
+		! --- enum reverse cast, e.g. `Suit(2)` -------------------------------------
+		! Delegates to eval_enum_cast_expr, which matches the runtime ordinal
+		! against the node's baked variant list and can rt_throw (R32) if none
+		! match, so check rt_halt before pushing a possibly-unset result.
+		case (OP_ENUM_CAST)
+			call eval_enum_cast_expr(prog%nodes(instr%a), state, val)
+			if (state%rt_halt) exit
+			call vm_push_move(stack, val)
+
 		! --- M8: slice/complex LHS assignment ------------------------------------
 		! Handles slice-range LHS (a[1:3] = x) and subscript-less compound
 		! assignments by delegating to eval_assignment_expr.


### PR DESCRIPTION
Adds C-style integer enums to syntran.

## Feature

```rust
enum Suit { Hearts, Diamonds, Clubs, Spades }

let s = Suit.Clubs;      // variants accessed on the type, not an instance
println(s);              // Suit.Clubs
```

- **Auto-incrementing values.** Variants count up from `0` in declaration
  order. A variant can pin an explicit value with `= <intlit>` (negatives
  allowed, e.g. `Below = -1`); later variants continue counting from there.
- **Named aliases.** An initializer can reference a prior variant by bare
  name (`King = Jack`), matching C/C++/C#/TypeScript.
- **Distinct types.** Each enum is its own type; mismatched enums are a
  parse-time type error. Only `==`/`!=` are supported.
- **Casts.** `i32(Suit.Clubs)` gets the backing integer for ordering or array
  indexing; `Suit(ordinal)` reverse-casts an integer back to a variant.
- **Composability.** Works as fn params/returns, struct members, and arrays
  of enums (indexing, assignment, `[value; n]`, `for` over literals).
- **Modules.** Enums are exported across module boundaries like structs, via
  glob (`use m::*;`) or qualified (`m::Enum.Variant`) access.
- **Printing.** Enum values print as their qualified name, `EnumType.Variant`.

Both the bytecode VM and the AST tree-walker are covered.

## Error codes

- `E92` redeclare-enum
- `E93` redeclare-variant
- `E94` unknown-variant
- `E95` duplicate-enum-value — collisions involving an auto-incremented value
  (explicit-only duplicates are allowed as intentional aliases)
- `E96` enum-cast-range — constant out-of-range reverse cast (runtime `R32`
  otherwise)

## Notable fixes along the way

- `assign_value_t` had no `enum_type` case (`arr[i] = EnumVal` crashed).
- `value_move` dropped `%struct` for enums, losing the reverse cast's baked
  variant list when its node was moved.
- `value_destroy()` didn't tear down the new `enum_name`/`enum_variant`/
  `enum_cookie` components, leaking on hot reset paths (VM local-slot reuse,
  `value_t(:)` pool free) — likely the cause of the recent uptick in Windows
  crashes.

## Tests & docs

- New enum test suite (`test-src/enum/test-01..07`) and module tests.
- Reproduction files and coverage for `E92`–`E96`.
- README "Enums"/"Exported enums" sections and `doc/errors.md` entries.